### PR TITLE
Do not convert the properties of untrusted data to camelCase

### DIFF
--- a/packages/auth0-acul-js/interfaces/models/untrusted-data.ts
+++ b/packages/auth0-acul-js/interfaces/models/untrusted-data.ts
@@ -13,10 +13,10 @@ export interface UntrustedDataContext {
 
 export interface UntrustedDataMembers {
   submittedFormData: { [key: string]: any } | null;
-  authParams: {
-    loginHint: string | undefined;
-    screenHint: string | undefined;
-    uiLocales: string | undefined;
-    ext: { [key: string]: string } | undefined;
+  authorizationParams: {
+    login_hint?: string;
+    screen_hint?: string;
+    ui_locales?: string;
+    [key: `ext-${string}`]: string;
   } | null;
 }

--- a/packages/auth0-acul-js/src/models/untrusted-data.ts
+++ b/packages/auth0-acul-js/src/models/untrusted-data.ts
@@ -2,11 +2,11 @@ import type { UntrustedDataContext, UntrustedDataMembers } from '../../interface
 
 export class UntrustedData implements UntrustedDataMembers {
   submittedFormData: UntrustedDataMembers['submittedFormData'];
-  authParams: UntrustedDataMembers['authParams'];
+  authorizationParams: UntrustedDataMembers['authorizationParams'];
 
   constructor(untrustedData: UntrustedDataContext | undefined) {
     this.submittedFormData = UntrustedData.getSubmittedFormData(untrustedData);
-    this.authParams = UntrustedData.getAuthParams(untrustedData);
+    this.authorizationParams = UntrustedData.getAuthorizationParams(untrustedData);
   }
 
   static getSubmittedFormData(untrustedData: UntrustedDataContext | undefined): UntrustedDataMembers['submittedFormData'] {
@@ -14,14 +14,14 @@ export class UntrustedData implements UntrustedDataMembers {
     return untrustedData?.submitted_form_data ?? null;
   }
 
-  static getAuthParams(untrustedData: UntrustedDataContext | undefined): UntrustedDataMembers['authParams'] {
+  static getAuthorizationParams(untrustedData: UntrustedDataContext | undefined): UntrustedDataMembers['authorizationParams'] {
     if (!untrustedData?.authorization_params) return null;
 
     return {
-      loginHint: untrustedData?.authorization_params?.login_hint,
-      screenHint: untrustedData?.authorization_params?.screen_hint,
-      uiLocales: untrustedData?.authorization_params?.ui_locales,
-      ext: untrustedData?.authorization_params,
+      login_hint: untrustedData?.authorization_params?.login_hint,
+      screen_hint: untrustedData?.authorization_params?.screen_hint,
+      ui_locales: untrustedData?.authorization_params?.ui_locales,
+      ...untrustedData?.authorization_params,
     };
   }
 }


### PR DESCRIPTION
Renamed `authParams` to `authorizationParams`, as these represent the parameters sent in the authorization request. 

Restored the original casing for query string parameters such as `login_hint`, `screen_hint`, etc., as they must remain in their current form.