### PR TITLE
Analytics support via additional proerty to submit handlers

### DIFF
--- a/packages/auth0-acul-js/interfaces/utils/form-handler.ts
+++ b/packages/auth0-acul-js/interfaces/utils/form-handler.ts
@@ -2,9 +2,16 @@ export interface FormOptions {
   state: string;
   useBrowserCapabilities?: boolean;
   route?: string;
+  analytics?: AnalyticsOptions;
+  [key: string]: string | number | boolean | null | undefined | AnalyticsOptions;
 }
 
 export interface PostPayloadOptions {
   state: string;
   [key: string]: string | number | boolean | null | undefined;
+}
+
+export interface AnalyticsOptions {
+  screenName?: string;
+  methodName?: string;
 }

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -155,7 +155,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && npm run lint && npm run test && npm run docs && rollup -c rollup.config.js --bundleConfigAsCjs",
+    "build": "npm run clean && npm run lint:fix && npm run test && npm run docs && rollup -c rollup.config.js --bundleConfigAsCjs",
     "test": "jest --verbose tests/unit/**/* --coverage",
     "test:e2e": "cypress open",
     "docs": "typedoc --options typedoc.json",

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -1,6 +1,6 @@
 import { BaseContext } from '../../models/base-context';
 import { Errors } from '../../utils/errors';
-import { FormHandler } from '../../utils/form-handler';
+import { FormHandler, getAnalyticsData } from '../../utils/form-handler';
 import { getPasskeyCredentials } from '../../utils/passkeys';
 
 import { ScreenOverride } from './screen-override';
@@ -50,6 +50,7 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = {
       state: this.transaction.state,
+      analytics: getAnalyticsData(this.screen.name, 'login'),
     };
 
     await new FormHandler(options).submitData<LoginOptions>(payload);

--- a/packages/auth0-acul-js/src/utils/form-handler.ts
+++ b/packages/auth0-acul-js/src/utils/form-handler.ts
@@ -1,4 +1,4 @@
-import type { FormOptions, PostPayloadOptions } from '../../interfaces/utils/form-handler';
+import type { FormOptions, PostPayloadOptions, AnalyticsOptions } from '../../interfaces/utils/form-handler';
 
 export class FormHandler {
   options: FormOptions;
@@ -32,6 +32,30 @@ export class FormHandler {
       $form.appendChild(input);
     });
 
+    this.addAnalyticsField($form);
+
     return $form;
   }
+
+  private addAnalyticsField(form: HTMLFormElement): HTMLFormElement {
+    const input = document.createElement('input');
+    const analyticsPayload: AnalyticsOptions = {
+      screenName: this.options?.analytics?.screenName,
+      methodName: this.options?.analytics?.methodName,
+    };
+    input.type = 'hidden';
+    input.name = 'x-acul-js-sdk-analytics';
+    input.value = JSON.stringify(analyticsPayload);
+    form.appendChild(input);
+
+    return form;
+  }
+}
+
+export function getAnalyticsData(screenName?: string, methodName?: string): AnalyticsOptions {
+  const options: AnalyticsOptions = {
+    screenName,
+    methodName,
+  };
+  return options;
 }

--- a/packages/auth0-acul-js/tests/unit/utils/form-handler.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/form-handler.test.ts
@@ -32,7 +32,7 @@ describe('FormHandler', () => {
   
     // Check that all inputs are correctly created
     const inputs = form.querySelectorAll('input');
-    expect(inputs.length).toBe(3);
+    expect(inputs.length).toBe(4);
     expect(inputs[0].name).toBe('key1');
     expect(inputs[0].value).toBe('value1');
     expect(inputs[1].name).toBe('key2');
@@ -49,7 +49,7 @@ describe('FormHandler', () => {
     expect(form.action).toBe(`${ currentLocation }submit`);
 
     const inputs = form.querySelectorAll('input');
-    expect(inputs.length).toBe(1);
+    expect(inputs.length).toBe(2);
     expect(inputs[0].name).toBe('state');
     expect(inputs[0].value).toBe('testState');
   });
@@ -73,7 +73,7 @@ describe('FormHandler', () => {
     const form = formHandler['buildForm'](payload);
 
     const inputs = form.querySelectorAll('input');
-    expect(inputs.length).toBe(3);
+    expect(inputs.length).toBe(4);
     expect(inputs[0].name).toBe('key1');
     expect(inputs[0].value).toBe(''); // null should be converted to an empty string
     expect(inputs[1].name).toBe('key2');


### PR DESCRIPTION
## Summary

This PR adds support for analytics tracking within the form submission process. It introduces a new property in the form post and updates the submit handlers to include analytics-related properties.

## Changes

- **Added analytics support**: Integrated analytics tracking into the form submission process.
- **Updated submit handlers**: Modified existing submit handlers to include analytics-related properties for better tracking.
- **New property added to form post**: Introduced a new property `x-acul-js-sdk-analytics` to the form post to track analytics data.

## Impact

This update will enable better monitoring and tracking of form submissions via analytics. It should be seamless for end-users, but will help in collecting more detailed usage data.

## Testing

- Ensure that the form submission now includes the `x-acul-js-sdk-analytics` property.
- Verify that analytics data is correctly captured when the form is submitted.
