### PR TITLE
feat: Throw an error when the user imports and uses wrong screen

### DIFF
--- a/packages/auth0-acul-js/.eslintrc.json
+++ b/packages/auth0-acul-js/.eslintrc.json
@@ -20,7 +20,7 @@
     "eqeqeq": ["error", "always"],
     "curly": "off",
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": ["error"],
+    "@typescript-eslint/no-unused-vars": "error",
     "no-var": "error",
     "prettier/prettier": [
       "error", {

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -155,7 +155,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && npm run lint:fix && npm run test && npm run docs && rollup -c rollup.config.js --bundleConfigAsCjs",
+    "build": "npm run clean && npm run lint && npm run test && npm run docs && rollup -c rollup.config.js --bundleConfigAsCjs",
     "test": "jest --verbose tests/unit/**/* --coverage",
     "test:e2e": "cypress open",
     "docs": "typedoc --options typedoc.json",

--- a/packages/auth0-acul-js/src/models/base-context.ts
+++ b/packages/auth0-acul-js/src/models/base-context.ts
@@ -25,6 +25,7 @@ export class BaseContext implements BaseMembers {
   untrustedData: UntrustedDataMembers;
 
   private static context: UniversalLoginContext | null = null;
+  static screenIdentifier: string = '';
 
   constructor() {
     if (!BaseContext.context) {
@@ -33,9 +34,16 @@ export class BaseContext implements BaseMembers {
     }
 
     const context = BaseContext.context;
+    const screenIdentifier: string = new.target?.screenIdentifier;
 
     if (!context) {
       throw new Error('Universal Login Context is not available on the global window object.');
+    }
+
+    if (screenIdentifier !== context?.screen?.name && screenIdentifier !== '') {
+      throw new Error(
+        `Incorrect import: The current screen name does not match the imported screen class. Imported Screen: ${screenIdentifier}, Current Screen: ${context?.screen?.name}`,
+      );
     }
 
     this.branding = new Branding(context.branding);

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
@@ -14,6 +14,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class EmailIdentifierChallenge extends BaseContext implements EmailIdentifierChallengeMembers {
   screen: ScreenOptions;
+  static screenIdentifier: string = 'email-identifier-challenge';
 
   constructor() {
     super();

--- a/packages/auth0-acul-js/src/screens/interstitial-captcha/index.ts
+++ b/packages/auth0-acul-js/src/screens/interstitial-captcha/index.ts
@@ -5,6 +5,8 @@ import type { InterstitialCaptchaMembers, SubmitCaptchaOptions } from '../../../
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class InterstitialCaptcha extends BaseContext implements InterstitialCaptchaMembers {
+  static screenIdentifier: string = 'interstitial-captcha';
+
   constructor() {
     super();
   }

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -19,6 +19,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class LoginId extends BaseContext implements LoginIdMembers {
+  static screenIdentifier: string = 'login-id';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/src/screens/login-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/index.ts
@@ -15,6 +15,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class LoginPassword extends BaseContext implements LoginPasswordMembers {
+  static screenIdentifier: string = 'login-password';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/src/screens/login-passwordless-email-code/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-passwordless-email-code/index.ts
@@ -16,6 +16,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class LoginPasswordlessEmailCode extends BaseContext implements LoginPasswordlessEmailCodeMembers {
+  static screenIdentifier: string = 'login-passwordless-email-code';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/src/screens/login-passwordless-sms-otp/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-passwordless-sms-otp/index.ts
@@ -16,6 +16,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class LoginPasswordlessSmsOtp extends BaseContext implements LoginPasswordlessSmsOtpMembers {
+  static screenIdentifier: string = 'login-passwordless-sms-otp';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -19,6 +19,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Login screen implementation class
  */
 export default class Login extends BaseContext implements LoginMembers {
+  static screenIdentifier: string = 'login';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/src/screens/mfa-begin-enroll-options/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-begin-enroll-options/index.ts
@@ -9,6 +9,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Handles the selection and enrollment of MFA factors
  */
 export default class MfaBeginEnrollOptions extends BaseContext implements MfaBeginEnrollOptionsMembers {
+  static screenIdentifier: string = 'mfa-begin-enroll-options';
   /**
    * Creates an instance of MFA Begin Enroll Options screen manager
    */

--- a/packages/auth0-acul-js/src/screens/mfa-country-codes/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-country-codes/index.ts
@@ -17,6 +17,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen allows users to select a country code for MFA phone number verification
  */
 export default class MfaCountryCodes extends BaseContext implements MfaCountryCodesMembers {
+  static screenIdentifier: string = 'mfa-country-codes';
   screen: ScreenOptions;
 
   /**

--- a/packages/auth0-acul-js/src/screens/mfa-detect-browser-capabilities/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-detect-browser-capabilities/index.ts
@@ -11,6 +11,8 @@ import type { CustomOptions } from 'interfaces/common';
  * This screen detects browser capabilities for MFA authentication methods
  */
 export default class MfaDetectBrowserCapabilities extends BaseContext implements MfaDetectBrowserCapabilitiesMembers {
+  static screenIdentifier: string = 'mfa-detect-browser-capabilities';
+
   /**
    * Creates an instance of MfaDetectBrowserCapabilities screen manager
    */

--- a/packages/auth0-acul-js/src/screens/mfa-email-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-email-challenge/index.ts
@@ -19,6 +19,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen is shown when a user needs to verify their email during MFA
  */
 export default class MfaEmailChallenge extends BaseContext implements MfaEmailChallengeMembers {
+  static screenIdentifier: string = 'mfa-email-challenge';
   screen: ScreenOptions;
 
   /**

--- a/packages/auth0-acul-js/src/screens/mfa-email-list/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-email-list/index.ts
@@ -14,6 +14,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen allows users to select an enrolled email address for MFA
  */
 export default class MfaEmailList extends BaseContext implements MfaEmailListMembers {
+  static screenIdentifier: string = 'mfa-email-list';
   /**
    * Creates an instance of MfaEmailList screen manager
    */

--- a/packages/auth0-acul-js/src/screens/mfa-enroll-result/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-enroll-result/index.ts
@@ -7,6 +7,8 @@ import type { MfaEnrollResultMembers } from '../../../interfaces/screens/mfa-enr
  * This screen is displayed after successful MFA enrollment to show the result.
  */
 export default class MfaEnrollResult extends BaseContext implements MfaEnrollResultMembers {
+  static screenIdentifier: string = 'mfa-enroll-result';
+
   /**
    * Creates an instance of MfaEnrollResult screen manager.
    */

--- a/packages/auth0-acul-js/src/screens/mfa-login-options/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-login-options/index.ts
@@ -9,6 +9,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen allows users to select which MFA factor they want to use for login
  */
 export default class MfaLoginOptions extends BaseContext implements MfaLoginOptionsMembers {
+  static screenIdentifier: string = 'mfa-login-options';
   /**
    * Creates an instance of MfaLoginOptions screen manager
    */

--- a/packages/auth0-acul-js/src/screens/mfa-push-challenge-push/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-challenge-push/index.ts
@@ -17,6 +17,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen is shown when a push notification has been sent to the user's device
  */
 export default class MfaPushChallengePush extends BaseContext implements MfaPushChallengePushMembers {
+  static screenIdentifier: string = 'mfa-push-challenge-push';
   screen: ScreenOptions;
 
   /**

--- a/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/index.ts
@@ -15,6 +15,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Class implementing the mfa-push-enrollment-qr screen functionality
  */
 export default class MfaPushEnrollmentQr extends BaseContext implements MfaPushEnrollmentQrMembers {
+  static screenIdentifier: string = 'mfa-push-enrollment-qr';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/mfa-push-list/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-list/index.ts
@@ -9,6 +9,8 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Class implementing the mfa-push-list screen functionality
  */
 export default class MfaPushList extends BaseContext implements MfaPushListMembers {
+  static screenIdentifier: string = 'mfa-push-list';
+
   constructor() {
     super();
   }

--- a/packages/auth0-acul-js/src/screens/mfa-push-welcome/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-welcome/index.ts
@@ -11,6 +11,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Implements the mfa-push-welcome screen functionality.
  */
 export default class MfaPushWelcome extends BaseContext implements MfaPushWelcomeMembers {
+  static screenIdentifier: string = 'mfa-push-welcome';
   screen: ScreenOptions;
 
   /**

--- a/packages/auth0-acul-js/src/screens/mfa-sms-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-sms-challenge/index.ts
@@ -17,6 +17,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * @extends BaseContext
  */
 export default class MfaSmsChallenge extends BaseContext implements MfaSmsChallengeMembers {
+  static screenIdentifier: string = 'mfa-sms-challenge';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/mfa-sms-enrollment/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-sms-enrollment/index.ts
@@ -13,6 +13,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Represents the MFA SMS Enrollment screen.
  */
 export default class MfaSmsEnrollment extends BaseContext implements MfaSmsEnrollmentMembers {
+  static screenIdentifier: string = 'mfa-sms-enrollment';
   screen: ScreenMembersOnMfaSmsEnrollment;
 
   /**

--- a/packages/auth0-acul-js/src/screens/mfa-sms-list/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-sms-list/index.ts
@@ -11,6 +11,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * @extends {BaseContext}
  */
 export default class MfaSmsList extends BaseContext implements MfaSmsListMembers {
+  static screenIdentifier: string = 'mfa-sms-list';
   constructor() {
     super();
   }

--- a/packages/auth0-acul-js/src/screens/passkey-enrollment-local/index.ts
+++ b/packages/auth0-acul-js/src/screens/passkey-enrollment-local/index.ts
@@ -14,6 +14,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class PasskeyEnrollmentLocal extends BaseContext implements PasskeyEnrollmentLocalMembers {
+  static screenIdentifier: string = 'passkey-enrollment-local';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/passkey-enrollment/index.ts
+++ b/packages/auth0-acul-js/src/screens/passkey-enrollment/index.ts
@@ -10,6 +10,7 @@ import type { PasskeyEnrollmentMembers, ScreenMembersOnPasskeyEnrollment as Scre
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class PasskeyEnrollment extends BaseContext implements PasskeyEnrollmentMembers {
+  static screenIdentifier: string = 'passkey-enrollment';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -13,6 +13,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class PhoneIdentifierChallenge extends BaseContext implements PhoneIdentifierChallengeMembers {
+  static screenIdentifier: string = 'phone-identifier-challenge';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/phone-identifier-enrollment/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-enrollment/index.ts
@@ -13,6 +13,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class PhoneIdentifierEnrollment extends BaseContext implements PhoneIdentifierEnrollmentMembers {
+  static screenIdentifier: string = 'phone-identifier-enrollment';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/reset-password-email/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-email/index.ts
@@ -13,7 +13,9 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class ResetPasswordEmail extends BaseContext implements ResetPasswordEmailMembers {
+  static screenIdentifier: string = 'reset-password-email';
   screen: ScreenOptions;
+
   constructor() {
     super();
     const screenContext = this.getContext('screen') as ScreenContext;

--- a/packages/auth0-acul-js/src/screens/reset-password-error/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-error/index.ts
@@ -5,7 +5,9 @@ import { ScreenOverride } from './screen-override';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { ResetPasswordErrorMembers, ScreenMembersOnResetPasswordError as ScreenOptions } from '../../../interfaces/screens/reset-password-error';
 export default class ResetPasswordError extends BaseContext implements ResetPasswordErrorMembers {
+  static screenIdentifier: string = 'reset-password-error';
   screen: ScreenOptions;
+
   constructor() {
     super();
     const screenContext = this.getContext('screen') as ScreenContext;

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-email-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-email-challenge/index.ts
@@ -18,6 +18,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Class implementing the reset-password-mfa-email-challenge screen functionality
  */
 export default class ResetPasswordMfaEmailChallenge extends BaseContext implements ResetPasswordMfaEmailChallengeMembers {
+  static screenIdentifier: string = 'reset-password-mfa-email-challenge';
   screen: ScreenOptions;
 
   /**

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-push-challenge-push/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-push-challenge-push/index.ts
@@ -16,6 +16,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen is shown when a push notification has been sent to the user's device during password reset
  */
 export default class ResetPasswordMfaPushChallengePush extends BaseContext implements ResetPasswordMfaPushChallengePushMembers {
+  static screenIdentifier: string = 'reset-password-mfa-push-challenge-push';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-sms-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-sms-challenge/index.ts
@@ -17,6 +17,7 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * @extends BaseContext
  */
 export default class ResetPasswordMfaSmsChallenge extends BaseContext implements ResetPasswordMfaSmsChallengeMembers {
+  static screenIdentifier: string = 'reset-password-mfa-sms-challenge';
   screen: ScreenOptions;
 
   constructor() {

--- a/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
@@ -16,8 +16,10 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class ResetPasswordRequest extends BaseContext implements ResetPasswordRequestMembers {
+  static screenIdentifier: string = 'reset-password-request';
   screen: ScreenOptions;
   transaction: TransactionOptions;
+
   constructor() {
     super();
     const screenContext = this.getContext('screen') as ScreenContext;

--- a/packages/auth0-acul-js/src/screens/reset-password-success/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-success/index.ts
@@ -6,6 +6,8 @@ import type {
 } from '../../../interfaces/screens/reset-password-success';
 
 export default class ResetPasswordSuccess extends BaseContext implements ResetPasswordSuccessMembers {
+  static screenIdentifier: string = 'reset-password-success';
+
   constructor() {
     super();
   }

--- a/packages/auth0-acul-js/src/screens/reset-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password/index.ts
@@ -11,7 +11,9 @@ import type {
 } from '../../../interfaces/screens/reset-password';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 export default class ResetPassword extends BaseContext implements ResetPasswordMembers {
+  static screenIdentifier: string = 'reset-password';
   screen: ScreenOptions;
+
   constructor() {
     super();
     const screenContext = this.getContext('screen') as ScreenContext;

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -16,6 +16,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class SignupId extends BaseContext implements SignupIdMembers {
+  static screenIdentifier: string = 'signup-id';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -15,6 +15,7 @@ import type {
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 export default class SignupPassword extends BaseContext implements SignupPasswordMembers {
+  static screenIdentifier: string = 'signup-password';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../../interfaces/screens/signup';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 export default class Signup extends BaseContext implements SignupMembers {
+  static screenIdentifier: string = 'signup';
   screen: ScreenOptions;
   transaction: TransactionOptions;
 

--- a/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
@@ -12,6 +12,7 @@ describe('EmailIdentifierChallenge', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'email-identifier-challenge';
     window.universal_login_context = baseContextData;
 
     emailIdentifierChallenge = new EmailIdentifierChallenge();

--- a/packages/auth0-acul-js/tests/unit/screens/interstitial-captcha/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/interstitial-captcha/index.test.ts
@@ -11,6 +11,7 @@ describe('InterstitialCaptcha', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'interstitial-captcha';
     window.universal_login_context = baseContextData;
 
     interstitialCaptcha = new InterstitialCaptcha();

--- a/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
@@ -11,6 +11,7 @@ describe('LoginPassword', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'login-password';
     window.universal_login_context = baseContextData;
     loginPassword = new LoginPassword();
 

--- a/packages/auth0-acul-js/tests/unit/screens/login-passwordless-email-code/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-passwordless-email-code/index.test.ts
@@ -12,6 +12,7 @@ describe('LoginPasswordlessEmailCode', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'login-passwordless-email-code';
     window.universal_login_context = baseContextData;
 
     loginPasswordlessEmailCode = new LoginPasswordlessEmailCode();

--- a/packages/auth0-acul-js/tests/unit/screens/login-passwordless-sms-otp/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-passwordless-sms-otp/index.test.ts
@@ -12,6 +12,7 @@ describe('LoginPasswordlessSmsOtp', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'login-passwordless-sms-otp';
     window.universal_login_context = baseContextData;
 
     loginPasswordlessSmsOtp = new LoginPasswordlessSmsOtp();

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -11,6 +11,7 @@ describe('Login', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'login';
     window.universal_login_context = baseContextData;
     login = new Login();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-begin-enroll-options/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-begin-enroll-options/index.test.ts
@@ -11,6 +11,7 @@ describe('MfaBeginEnrollOptions', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-begin-enroll-options';
     window.universal_login_context = baseContextData;
     mfaBeginEnrollOptions = new MfaBeginEnrollOptions();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-country-codes/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-country-codes/index.test.ts
@@ -12,6 +12,7 @@ describe('MfaCountryCodes', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-country-codes';
     window.universal_login_context = baseContextData;
     mfaCountryCodes = new MfaCountryCodes();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-detect-browser-capabilities/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-detect-browser-capabilities/index.test.ts
@@ -18,6 +18,7 @@ describe('MfaDetectBrowserCapabilities', () => {
   beforeEach(() => {
     // Mock global context
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-detect-browser-capabilities';
     window.universal_login_context = baseContextData;
 
     // Initialize the class

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-email-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-email-challenge/index.test.ts
@@ -12,6 +12,7 @@ describe('MfaEmailChallenge', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-email-challenge';
     window.universal_login_context = baseContextData;
     mfaEmailChallenge = new MfaEmailChallenge();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-email-list/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-email-list/index.test.ts
@@ -12,6 +12,7 @@ describe('MfaEmailList', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-email-list';
     window.universal_login_context = {
       ...baseContextData,
       user: {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-login-options/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-login-options/index.test.ts
@@ -11,6 +11,7 @@ describe('MfaLoginOptions', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-login-options';
     window.universal_login_context = baseContextData;
     mfaLoginOptions = new MfaLoginOptions();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-push-challenge-push/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-push-challenge-push/index.test.ts
@@ -11,6 +11,7 @@ describe('MfaPushChallengePush', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-push-challenge-push';
     window.universal_login_context = baseContextData;
     mfaPushChallengePush = new MfaPushChallengePush();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-push-enrollment-qr/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-push-enrollment-qr/index.test.ts
@@ -11,6 +11,7 @@ describe('MfaPushEnrollmentQr', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-push-enrollment-qr';
     window.universal_login_context = baseContextData;
     mfaPushEnrollmentQr = new MfaPushEnrollmentQr();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-push-list/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-push-list/index.test.ts
@@ -12,6 +12,7 @@ describe('MfaPushList', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-push-list';
     window.universal_login_context = baseContextData;
     mfaPushList = new MfaPushList();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-push-welcome/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-push-welcome/index.test.ts
@@ -11,6 +11,7 @@ describe('MfaPushWelcome', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-push-welcome';
     window.universal_login_context = baseContextData;
     mfaPushWelcome = new MfaPushWelcome();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-sms-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-sms-challenge/index.test.ts
@@ -12,6 +12,7 @@ describe('MfaSmsChallenge', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-sms-challenge';
     window.universal_login_context = baseContextData;
     mfaSmsChallenge = new MfaSmsChallenge();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-sms-enrollment/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-sms-enrollment/index.test.ts
@@ -12,6 +12,7 @@ describe('MfaSmsEnrollment', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-sms-enrollment';
     window.universal_login_context = baseContextData;
     mfaSmsEnrollment = new MfaSmsEnrollment();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-sms-list/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-sms-list/index.test.ts
@@ -10,6 +10,7 @@ describe('MfaSmsList', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'mfa-sms-list';
     window.universal_login_context = {
       ...baseContextData,
       user: {

--- a/packages/auth0-acul-js/tests/unit/screens/passkey-enrollment-local/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/passkey-enrollment-local/index.test.ts
@@ -14,6 +14,7 @@ describe('PasskeyEnrollmentLocal', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'passkey-enrollment-local';
     window.universal_login_context = baseContextData;
 
     passkeyEnrollmentLocal = new PasskeyEnrollmentLocal();

--- a/packages/auth0-acul-js/tests/unit/screens/passkey-enrollment/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/passkey-enrollment/index.test.ts
@@ -13,6 +13,7 @@ describe('PasskeyEnrollment', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'passkey-enrollment';
     window.universal_login_context = baseContextData;
 
     passkeyEnrollment = new PasskeyEnrollment();

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
@@ -12,6 +12,7 @@ describe('PhoneIdentifierChallenge', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'phone-identifier-challenge';
     window.universal_login_context = baseContextData;
 
     phoneIdentifierChallenge = new PhoneIdentifierChallenge();

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-enrollment/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-enrollment/index.test.ts
@@ -12,6 +12,7 @@ describe('PhoneIdentifierEnrollment', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'phone-identifier-enrollment';
     window.universal_login_context = baseContextData;
 
     phoneIdentifierEnrollment = new PhoneIdentifierEnrollment();

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-email/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-email/index.test.ts
@@ -11,6 +11,7 @@ describe('ResetPasswordEmail', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'reset-password-email';
     window.universal_login_context = baseContextData;
     resetPasswordEmail = new ResetPasswordEmail();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-push-challenge-push/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-push-challenge-push/index.test.ts
@@ -11,6 +11,7 @@ describe('ResetPasswordMfaPushChallengePush', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'reset-password-mfa-push-challenge-push';
     window.universal_login_context = baseContextData;
     resetPasswordMfaPushChallengePush = new ResetPasswordMfaPushChallengePush();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/index.test.ts
@@ -12,6 +12,7 @@ describe('ResetPasswordMfaSmsChallenge', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'reset-password-mfa-sms-challenge';
     window.universal_login_context = baseContextData;
     resetPasswordMfaSmsChallenge = new ResetPasswordMfaSmsChallenge();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-request/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-request/index.test.ts
@@ -12,6 +12,7 @@ describe('ResetPasswordRequest', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'reset-password-request';
     window.universal_login_context = baseContextData;
     resetPasswordRequest = new ResetPasswordRequest();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password/index.test.ts
@@ -8,6 +8,7 @@ describe('ResetPassword', () => {
   let mockFormHandler: { submitData: jest.Mock };
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'reset-password';
     window.universal_login_context = baseContextData;
     resetPassword = new ResetPassword();
     mockFormHandler = {

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
@@ -14,6 +14,7 @@ describe('SignupId', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'signup-id';
     window.universal_login_context = baseContextData; // transaction.getRequiredIdentifiers() => { email, phone, username } from baseContext.
 
     signupId = new SignupId();

--- a/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
@@ -11,6 +11,7 @@ describe('SignupPassword', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
+    baseContextData.screen.name = 'signup-password';
     window.universal_login_context = baseContextData;
 
     signupPassword = new SignupPassword();


### PR DESCRIPTION
### 🛠️ Changes
- Now users see an error when they import and use the wrong screens

### 🧪 Testing
- Example: import and use `login-id` class on `signup-id` screen, and verify the error thrown on the console.