### PR TITLE
feature/telemetrey update

### DIFF
--- a/packages/auth0-acul-js/interfaces/utils/form-handler.ts
+++ b/packages/auth0-acul-js/interfaces/utils/form-handler.ts
@@ -10,10 +10,3 @@ export interface PostPayloadOptions {
   state: string;
   [key: string]: string | number | boolean | null | undefined;
 }
-
-export interface TelemetryOptions {
-  screenName: string;
-  methodName: string;
-  sdkName: string;
-  sdkVersion: string;
-}

--- a/packages/auth0-acul-js/src/utils/form-handler.ts
+++ b/packages/auth0-acul-js/src/utils/form-handler.ts
@@ -1,4 +1,4 @@
-import type { FormOptions, PostPayloadOptions, TelemetryOptions } from '../../interfaces/utils/form-handler';
+import type { FormOptions, PostPayloadOptions } from '../../interfaces/utils/form-handler';
 
 export class FormHandler {
   options: FormOptions;
@@ -39,18 +39,11 @@ export class FormHandler {
 
   private addTelemetryField(form: HTMLFormElement): HTMLFormElement {
     const input = document.createElement('input');
-    const [screenName, methodName] = this.options.telemetry ?? [];
     const sdkName = __SDK_NAME__;
     const sdkVersion = __SDK_VERSION__;
-    const telemetryPayload: TelemetryOptions = {
-      sdkVersion,
-      sdkName,
-      screenName,
-      methodName,
-    };
     input.type = 'hidden';
-    input.name = 'x-acul-sdk-analytics';
-    input.value = JSON.stringify(telemetryPayload);
+    input.name = 'acul-sdk';
+    input.value = `${sdkName}@${sdkVersion}`;
     form.appendChild(input);
 
     return form;

--- a/packages/auth0-acul-js/tests/unit/utils/form-handler.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/form-handler.test.ts
@@ -7,6 +7,10 @@ describe('FormHandler', () => {
   const currentLocation = window.location.href;
 
   beforeEach(() => {
+    // Mock SDK window variables
+    (window as any).__SDK_NAME__ = '@auth0/auth0-acul-js';
+    (window as any).__SDK_VERSION__ = '1.0.0';
+    
     options = { route: '/submit', state: 'testState', telemetry: ['testScreen', 'testMethod'] };
     formHandler = new FormHandler(options);
     jest.spyOn(document.body, 'appendChild').mockImplementation((node: Node) => node);
@@ -15,6 +19,9 @@ describe('FormHandler', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     document.body.innerHTML = '';
+    // Clean up window mocks
+    delete (window as any).__SDK_NAME__;
+    delete (window as any).__SDK_VERSION__;
   });
 
   it('should initialize FormHandler with provided options', () => {
@@ -101,5 +108,15 @@ describe('FormHandler', () => {
 
     expect(mockSubmit).toHaveBeenCalled();
     expect(document.body.appendChild).toHaveBeenCalled();
+  });
+
+  it('should add SDK telemetry field to form', () => {
+    const form = document.createElement('form');
+    const updatedForm = formHandler['addTelemetryField'](form);
+    
+    const telemetryInput = updatedForm.querySelector('input[name="acul-sdk"]') as HTMLInputElement;
+    expect(telemetryInput).toBeTruthy();
+    expect(telemetryInput.type).toBe('hidden');
+    expect(telemetryInput.value).toContain('@auth0/auth0-acul-js@1.0.0');
   });
 });


### PR DESCRIPTION
### Changes
- Removed the `TelemetryOptions` interface, simplifying the code.
- Modified the `FormHandler` class to directly add SDK telemetry information to the form as a hidden input field named 'acul-sdk'.  The value of this field now contains the SDK name and version in the format `${sdkName}@${sdkVersion}`.
- Updated the tests to reflect the changes in telemetry handling. The tests now verify that the 'acul-sdk' field is added to the form with the correct value.
- Added mocking of window variables `__SDK_NAME__` and `__SDK_VERSION__` in tests for better isolation and cleanup.


### Testing
- Unit tests were updated to verify the new implementation of adding the SDK telemetry field to the form.
- The tests confirm the presence, type, and value of the hidden input field.


### Impact
- This change simplifies the telemetry data structure and directly embeds the SDK information into the form submission, making the telemetry data more concise and easier to handle.
- This should not directly impact customers, as the telemetry data is still collected but in a slightly different format.