### PR TITLE
Remove unused links and editIdentifier properties

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
@@ -40,11 +40,6 @@ export interface ScreenMembersOnMfaVoiceChallenge extends ScreenMembers {
      */
     rememberDevice?: boolean;
   } | null;
-
-  /**
-   * Link to edit the user's identifier.
-   */
-  editIdentifierLink: string | null;
 }
 
 /**

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-voice-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-voice-challenge.ts
@@ -12,10 +12,6 @@ export interface ScreenMembersOnResetPasswordMfaVoiceChallenge extends ScreenMem
      */
     phoneNumber: string;
   } | null;
-  links: {
-    editIdentifier: string;
-  } | null;
-  editIdentifierLink: string | null;
 }
 
 /**

--- a/packages/auth0-acul-js/src/screens/mfa-voice-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-voice-challenge/screen-override.ts
@@ -1,5 +1,4 @@
 import { Screen } from '../../models/screen';
-import { getEditIdentifierLink } from '../../shared/screen';
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { ScreenMembersOnMfaVoiceChallenge as OverrideOptions } from '../../../interfaces/screens/mfa-voice-challenge';
@@ -8,11 +7,6 @@ import type { ScreenMembersOnMfaVoiceChallenge as OverrideOptions } from '../../
  * Extended Screen implementation for MFA Voice Challenge screen.
  */
 export class ScreenOverride extends Screen implements OverrideOptions {
-  /**
-   * Link to edit the user's identifier.
-   */
-  editIdentifierLink: OverrideOptions['editIdentifierLink'];
-
   /**
    * Additional screen data specific to MFA voice challenge.
    */
@@ -25,7 +19,6 @@ export class ScreenOverride extends Screen implements OverrideOptions {
    */
   constructor(screenContext: ScreenContext) {
     super(screenContext);
-    this.editIdentifierLink = getEditIdentifierLink(screenContext);
     this.data = ScreenOverride.getScreenData(screenContext);
   }
 

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-voice-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-voice-challenge/screen-override.ts
@@ -1,5 +1,4 @@
 import { Screen } from '../../models/screen';
-import { getEditIdentifierLink } from '../../shared/screen';
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { ScreenMembersOnResetPasswordMfaVoiceChallenge as OverrideOptions } from '../../../interfaces/screens/reset-password-mfa-voice-challenge';
@@ -10,8 +9,6 @@ import type { ScreenMembersOnResetPasswordMfaVoiceChallenge as OverrideOptions }
  */
 export class ScreenOverride extends Screen implements OverrideOptions {
   data: OverrideOptions['data'];
-  links: OverrideOptions['links'];
-  editIdentifierLink: OverrideOptions['editIdentifierLink'];
 
   /**
    * @constructor
@@ -20,8 +17,6 @@ export class ScreenOverride extends Screen implements OverrideOptions {
   constructor(screenContext: ScreenContext) {
     super(screenContext);
     this.data = ScreenOverride.getScreenData(screenContext);
-    this.links = ScreenOverride.getScreenLinks(screenContext);
-    this.editIdentifierLink = getEditIdentifierLink(screenContext);
   }
 
   /**
@@ -39,24 +34,6 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       phoneNumber: typeof data.phone_number === 'string' ? data.phone_number : '',
-    };
-  };
-
-  /**
-   * @static
-   * @method getScreenLinks
-   * @description Extracts screen links from the context
-   * @param {ScreenContext} screenContext - The screen context containing the links
-   * @returns {OverrideOptions['links']}
-   */
-  static getScreenLinks = (screenContext: ScreenContext): OverrideOptions['links'] => {
-    if (!screenContext.links) return null;
-
-    const { links } = screenContext;
-    const { edit_identifier, ...rest } = links;
-    return {
-      ...rest,
-      editIdentifier: edit_identifier,
     };
   };
 }

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
@@ -18,10 +18,7 @@ describe('MfaVoiceChallenge', () => {
       screen: {
         ...baseContextData.screen,
         name: 'mfa-voice-challenge',
-        links: {
-          ...baseContextData.screen.links,
-          edit_identifier: '/edit-identifier'
-        },
+        links: baseContextData.screen.links,
         data: {
           phone_number: '+15555555555',
           remember_device: false

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/screen-override.test.ts
@@ -1,11 +1,5 @@
 import { ScreenOverride } from '../../../../src/screens/reset-password-mfa-voice-challenge/screen-override';
-import { getEditIdentifierLink } from '../../../../src/shared/screen';
 import type { ScreenContext } from '../../../../interfaces/models/screen';
-
-// Mock dependencies
-jest.mock('../../../../src/shared/screen', () => ({
-  getEditIdentifierLink: jest.fn(() => 'MOCKED_EDIT_IDENTIFIER_LINK'),
-}));
 
 describe('ScreenOverride', () => {
   let screenContext: ScreenContext;
@@ -16,10 +10,6 @@ describe('ScreenOverride', () => {
       name: 'reset-password',
       data: {
         phone_number: '9999999999',
-      },
-      links: {
-        edit_identifier: 'EDIT_IDENTIFIER_LINK',
-        other_link: 'OTHER_LINK',
       },
     } as ScreenContext;
 
@@ -32,30 +22,9 @@ describe('ScreenOverride', () => {
     });
   });
 
-  it('should map edit_identifier to editIdentifier in links', () => {
-    expect(screenOverride.links).toHaveProperty('editIdentifier', 'EDIT_IDENTIFIER_LINK');
-  });
-
-  it('should retain other links if present', () => {
-    expect(screenOverride.links).toMatchObject({
-      other_link: 'OTHER_LINK',
-    });
-  });
-
-  it('should call getEditIdentifierLink and set editIdentifierLink', () => {
-    expect(getEditIdentifierLink).toHaveBeenCalledWith(screenContext);
-    expect(screenOverride.editIdentifierLink).toBe('MOCKED_EDIT_IDENTIFIER_LINK');
-  });
-
   it('should return null for data if screenContext.data is missing', () => {
     screenContext.data = undefined;
     const override = new ScreenOverride(screenContext);
     expect(override.data).toBeNull();
-  });
-
-  it('should return null for links if screenContext.links is missing', () => {
-    screenContext.links = undefined;
-    const override = new ScreenOverride(screenContext);
-    expect(override.links).toBeNull();
   });
 });


### PR DESCRIPTION
- remove unused links and editIdentifier properties from reset password mfa voice challenge screen
- remove editIdentifierLink from MFA Voice Challenge screen and related tests