### PR TITLE
fix: Fixed passkey enrollment issue

### DIFF
--- a/packages/auth0-acul-js/examples/passkey-enrollment-local.md
+++ b/packages/auth0-acul-js/examples/passkey-enrollment-local.md
@@ -1,5 +1,5 @@
 
-## continueWithPasskeyEnrollmentLocal
+## continuePasskeyEnrollment
 
 ```typescript
 
@@ -10,7 +10,7 @@ const passkeyEnrollment = new PasskeyEnrollment();
 
 // Begin the passkey enrollment process for local authentication
 // This will trigger the necessary flow for the user to enroll their passkey
-passkeyEnrollment.continueWithPasskeyEnrollmentLocal();
+passkeyEnrollment.continuePasskeyEnrollment();
 
 ```
 
@@ -22,7 +22,7 @@ passkeyEnrollment.continueWithPasskeyEnrollmentLocal();
 import PasskeyEnrollment from '@auth0/auth0-acul-js/passkey-enrollment-local';
 
 const passkeyEnrollment = new PasskeyEnrollmentLocal();
-passkeyEnrollment.abortPasskeyEnrollmentLocal({
+passkeyEnrollment.abortPasskeyEnrollment({
     doNotShowAgain: <boolean>
 });
 

--- a/packages/auth0-acul-js/examples/passkey-enrollment.md
+++ b/packages/auth0-acul-js/examples/passkey-enrollment.md
@@ -6,7 +6,7 @@
 import PasskeyEnrollment from '@auth0/auth0-acul-js/passkey-enrollment';
 
 const passkeyEnrollment = new PasskeyEnrollment();
-passkeyEnrollment.continueWithPasskeyEnrollment();
+passkeyEnrollment.continuePasskeyEnrollment();
 
 ```
 

--- a/packages/auth0-acul-js/src/screens/passkey-enrollment-local/index.ts
+++ b/packages/auth0-acul-js/src/screens/passkey-enrollment-local/index.ts
@@ -40,7 +40,7 @@ export default class PasskeyEnrollmentLocal extends BaseContext implements Passk
     };
 
     const publicKey = this.screen.publicKey;
-    const encoded = publicKey && createPasskeyCredentials(publicKey);
+    const encoded = publicKey && (await createPasskeyCredentials(publicKey));
 
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, passkey: JSON.stringify(encoded) });
   }

--- a/packages/auth0-acul-js/src/screens/passkey-enrollment/index.ts
+++ b/packages/auth0-acul-js/src/screens/passkey-enrollment/index.ts
@@ -36,7 +36,7 @@ export default class PasskeyEnrollment extends BaseContext implements PasskeyEnr
     };
 
     const publicKey = this.screen.publicKey;
-    const encoded = publicKey && createPasskeyCredentials(publicKey);
+    const encoded = publicKey && (await createPasskeyCredentials(publicKey));
 
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, passkey: JSON.stringify(encoded) });
   }


### PR DESCRIPTION
### 📃 Why this PR ?
This is a `bugfix` PR. `continuePasskeyEnrollment` action on `passkey-enrollment` screen was failing on chrome however it was working just fine on Safari. This PR contains fix for that issue

###  🛠️ Changes
We made some updates after the initial implementation. The issue was that we were mistakenly returning a promise instead of the actual value from `createPasskeyCredentials`. The fix is to `await` the response from `createPasskeyCredentials`.