### PR TITLE
Remove un-used interfaces on `reset-password-mfa-otp-challenge` screen

### DIFF
--- a/packages/auth0-acul-js/interfaces/export/extended-types.ts
+++ b/packages/auth0-acul-js/interfaces/export/extended-types.ts
@@ -35,7 +35,6 @@ export type { ScreenMembersOnMfaPushChallengePush } from '../screens/mfa-push-ch
 export type { ScreenMembersOnMfaOtpChallenge } from '../screens/mfa-otp-challenge';
 export type { ScreenMembersOnMfaOtpEnrollmentQr } from '../screens/mfa-otp-enrollment-qr';
 export type { ScreenMembersOnMfaOtpEnrollmentCode } from '../screens/mfa-otp-enrollment-code';
-export type { ScreenMembersOnResetPasswordMfaOtpChallenge } from '../screens/reset-password-mfa-otp-challenge';
 export type { ScreenMembersOnOrganizationSelection } from '../screens/organization-selection';
 export type { ScreenMembersOnAcceptInvitation } from '../screens/accept-invitation';
 export type { ScreenMembersOnCustomizedConsent } from '../screens/customized-consent';

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-otp-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-otp-challenge.ts
@@ -1,14 +1,4 @@
 import type { BaseMembers } from '../models/base-context';
-import type { ScreenMembers } from '../models/screen';
-
-/**
- * Interface for the screen data specific to reset-password-mfa-otp-challenge screen
- */
-export interface ScreenMembersOnResetPasswordMfaOtpChallenge extends ScreenMembers {
-  data: {
-    remember_device?: boolean;
-  } | null;
-}
 
 /**
  * Options for continuing with the OTP challenge.
@@ -32,7 +22,6 @@ export interface TryAnotherMethodOptions {
  * Interface defining the available methods and properties for the reset-password-mfa-otp-challenge screen
  */
 export interface ResetPasswordMfaOtpChallengeMembers extends BaseMembers {
-  screen: ScreenMembersOnResetPasswordMfaOtpChallenge;
   /**
    * Continues with the OTP challenge using the provided code.
    * @param payload The options containing the code.

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-otp-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-otp-challenge/index.ts
@@ -7,7 +7,6 @@ import type {
   ResetPasswordMfaOtpChallengeMembers,
   ContinueOptions,
   TryAnotherMethodOptions,
-  ScreenMembersOnResetPasswordMfaOtpChallenge as ScreenOptions,
 } from '../../../interfaces/screens/reset-password-mfa-otp-challenge';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
@@ -69,11 +68,6 @@ export default class ResetPasswordMfaOtpChallenge extends BaseContext implements
   }
 }
 
-export {
-  ResetPasswordMfaOtpChallengeMembers,
-  ContinueOptions,
-  TryAnotherMethodOptions,
-  ScreenOptions as ScreenMembersOnResetPasswordMfaOtpChallenge,
-};
+export { ResetPasswordMfaOtpChallengeMembers, ContinueOptions, TryAnotherMethodOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/screen-override.test.ts
@@ -28,36 +28,6 @@ describe('ScreenOverride', () => {
     expect(screenOverride.data).toBeNull();
   });
 
-  it('should handle remember_device as undefined', () => {
-    const screenContext: ScreenContext = {
-      name: 'reset-password-mfa-sms-challenge',
-      data: {
-        phone_number: '+15551234567'
-      },
-    } as ScreenContext;
-
-    const screenOverride = new ScreenOverride(screenContext);
-
-    expect(screenOverride.data).toEqual({
-      phoneNumber: '+15551234567'
-    });
-  });
-
-  it('should handle remember_device as false', () => {
-    const screenContext: ScreenContext = {
-      name: 'reset-password-mfa-sms-challenge',
-      data: {
-        phone_number: '+15551234567'
-      },
-    } as ScreenContext;
-
-    const screenOverride = new ScreenOverride(screenContext);
-
-    expect(screenOverride.data).toEqual({
-      phoneNumber: '+15551234567'
-    });
-  });
-
   it('should extend Screen class', () => {
     const screenContext: ScreenContext = {
       name: 'reset-password-mfa-sms-challenge',


### PR DESCRIPTION
###  🛠️ Changes
- Remove un-used interfaces
- Remove irrelevant tests