### PR TITLE
refactor: update remember_device to showRememberDevice across MFA screens and examples

### DIFF
--- a/packages/auth0-acul-js/examples/mfa-email-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-email-challenge.md
@@ -5,20 +5,20 @@ This screen is displayed when a user needs to verify their email during MFA.
 ## React Component Example with TailwindCSS
 
 ```tsx
-import React, { useState } from "react";
-import MfaEmailChallenge from "@auth0/auth0-acul-js/mfa-email-challenge";
+import React, { useState } from 'react';
+import MfaEmailChallenge from '@auth0/auth0-acul-js/mfa-email-challenge';
 
 const MfaEmailChallengeScreen: React.FC = () => {
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState('');
   const [rememberDevice, setRememberDevice] = useState(false);
-  const [error, setError] = useState("");
+  const [error, setError] = useState('');
 
   const mfaEmailChallenge = new MfaEmailChallenge();
   const { screen } = mfaEmailChallenge;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError("");
+    setError('');
 
     try {
       await mfaEmailChallenge.continue({
@@ -26,7 +26,7 @@ const MfaEmailChallengeScreen: React.FC = () => {
         rememberDevice,
       });
     } catch (err) {
-      setError("Failed to verify code. Please try again.");
+      setError('Failed to verify code. Please try again.');
     }
   };
 
@@ -34,14 +34,14 @@ const MfaEmailChallengeScreen: React.FC = () => {
     try {
       await mfaEmailChallenge.resendCode();
     } catch (err) {
-      setError("Failed to resend code. Please try again.");
+      setError('Failed to resend code. Please try again.');
     }
   };
   const handlePickEmail = async () => {
     try {
       await mfaEmailChallenge.pickEmail();
     } catch (err) {
-      setError("Failed pick email. Please try again.");
+      setError('Failed pick email. Please try again.');
     }
   };
 
@@ -49,7 +49,7 @@ const MfaEmailChallengeScreen: React.FC = () => {
     try {
       await mfaEmailChallenge.tryAnotherMethod();
     } catch (err) {
-      setError("Failed to try another method. Please try again.");
+      setError('Failed to try another method. Please try again.');
     }
   };
 

--- a/packages/auth0-acul-js/examples/mfa-email-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-email-challenge.md
@@ -5,20 +5,20 @@ This screen is displayed when a user needs to verify their email during MFA.
 ## React Component Example with TailwindCSS
 
 ```tsx
-import React, { useState } from 'react';
-import MfaEmailChallenge from '@auth0/auth0-acul-js/mfa-email-challenge';
+import React, { useState } from "react";
+import MfaEmailChallenge from "@auth0/auth0-acul-js/mfa-email-challenge";
 
 const MfaEmailChallengeScreen: React.FC = () => {
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState("");
   const [rememberDevice, setRememberDevice] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
 
   const mfaEmailChallenge = new MfaEmailChallenge();
   const { screen } = mfaEmailChallenge;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
+    setError("");
 
     try {
       await mfaEmailChallenge.continue({
@@ -26,7 +26,7 @@ const MfaEmailChallengeScreen: React.FC = () => {
         rememberDevice,
       });
     } catch (err) {
-      setError('Failed to verify code. Please try again.');
+      setError("Failed to verify code. Please try again.");
     }
   };
 
@@ -34,14 +34,14 @@ const MfaEmailChallengeScreen: React.FC = () => {
     try {
       await mfaEmailChallenge.resendCode();
     } catch (err) {
-      setError('Failed to resend code. Please try again.');
+      setError("Failed to resend code. Please try again.");
     }
   };
   const handlePickEmail = async () => {
     try {
       await mfaEmailChallenge.pickEmail();
     } catch (err) {
-      setError('Failed pick email. Please try again.');
+      setError("Failed pick email. Please try again.");
     }
   };
 
@@ -49,7 +49,7 @@ const MfaEmailChallengeScreen: React.FC = () => {
     try {
       await mfaEmailChallenge.tryAnotherMethod();
     } catch (err) {
-      setError('Failed to try another method. Please try again.');
+      setError("Failed to try another method. Please try again.");
     }
   };
 
@@ -68,7 +68,10 @@ const MfaEmailChallengeScreen: React.FC = () => {
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label htmlFor="code" className="block text-sm font-medium text-gray-700">
+              <label
+                htmlFor="code"
+                className="block text-sm font-medium text-gray-700"
+              >
                 Code
               </label>
               <div className="mt-1">
@@ -84,28 +87,29 @@ const MfaEmailChallengeScreen: React.FC = () => {
               </div>
             </div>
 
-            <div className="flex items-center">
-              <input
-                id="rememberDevice"
-                name="rememberDevice"
-                type="checkbox"
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                checked={rememberDevice}
-                onChange={(e) => setRememberDevice(e.target.checked)}
-              />
-              <label htmlFor="rememberDevice" className="ml-2 block text-sm text-gray-900">
-                Remember this device
-              </label>
-            </div>
-
-            {error && (
-              <div className="text-red-600 text-sm">
-                {error}
+            {screen.data?.showRememberDevice && (
+              <div className="flex items-center">
+                <input
+                  id="rememberDevice"
+                  name="rememberDevice"
+                  type="checkbox"
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  checked={rememberDevice}
+                  onChange={(e) => setRememberDevice(e.target.checked)}
+                />
+                <label
+                  htmlFor="rememberDevice"
+                  className="ml-2 block text-sm text-gray-900"
+                >
+                  Remember this device
+                </label>
               </div>
             )}
 
+            {error && <div className="text-red-600 text-sm">{error}</div>}
+
             <div>
-            <button
+              <button
                 type="submit"
                 className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               >
@@ -143,6 +147,7 @@ const MfaEmailChallengeScreen: React.FC = () => {
 };
 
 export default MfaEmailChallengeScreen;
+
 ```
 
 ## Usage Examples

--- a/packages/auth0-acul-js/examples/mfa-otp-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-otp-challenge.md
@@ -7,20 +7,23 @@ This screen is displayed when the user needs to enter the code sent to their aut
 ## React Component Example with TailwindCSS
 
 ```tsx
-import React, { useState } from 'react';
-import MfaOtpChallenge from '@auth0/auth0-acul-js/mfa-otp-challenge';
+import React, { useState } from "react";
+import MfaOtpChallenge from "@auth0/auth0-acul-js/mfa-otp-challenge";
 
 const MfaOtpChallengeScreen: React.FC = () => {
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState("");
   const [rememberBrowser, setRememberBrowser] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
 
   const mfaOtpChallenge = new MfaOtpChallenge();
-  const { screen: { texts }, transaction } = mfaOtpChallenge;
+  const {
+    screen: { texts, data },
+    transaction,
+  } = mfaOtpChallenge;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
+    setError("");
 
     try {
       await mfaOtpChallenge.continue({
@@ -28,7 +31,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
         rememberBrowser,
       });
     } catch (err) {
-      setError('Failed to verify code. Please try again.');
+      setError("Failed to verify code. Please try again.");
       console.error(err);
     }
   };
@@ -37,7 +40,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
     try {
       await mfaOtpChallenge.tryAnotherMethod();
     } catch (err) {
-      setError('Failed to try another method. Please try again.');
+      setError("Failed to try another method. Please try again.");
       console.error(err);
     }
   };
@@ -46,10 +49,11 @@ const MfaOtpChallengeScreen: React.FC = () => {
     <div className="min-h-screen bg-gray-100 flex flex-col py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-          {texts?.title ?? 'Verify Your Identity'}
+          {texts?.title ?? "Verify Your Identity"}
         </h2>
         <p className="mt-2 text-center text-sm text-gray-600">
-          {texts?.description ?? 'Check your preferred one-time password application for a code.'}
+          {texts?.description ??
+            "Check your preferred one-time password application for a code."}
         </p>
       </div>
 
@@ -57,15 +61,20 @@ const MfaOtpChallengeScreen: React.FC = () => {
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label htmlFor="code" className="block text-sm font-medium text-gray-700">
-                {texts?.codePlaceholder ?? 'Enter your one-time code'}
+              <label
+                htmlFor="code"
+                className="block text-sm font-medium text-gray-700"
+              >
+                {texts?.codePlaceholder ?? "Enter your one-time code"}
               </label>
               <div className="mt-1">
                 <input
                   id="code"
                   name="code"
                   type="text"
-                  placeholder={texts?.codePlaceholder ?? 'Enter your one-time code'}
+                  placeholder={
+                    texts?.codePlaceholder ?? "Enter your one-time code"
+                  }
                   required
                   value={code}
                   onChange={(e) => setCode(e.target.value)}
@@ -82,25 +91,26 @@ const MfaOtpChallengeScreen: React.FC = () => {
               </div>
             )}
 
-            <div className="flex items-center">
-              <input
-                id="rememberBrowser"
-                name="rememberBrowser"
-                type="checkbox"
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                checked={rememberBrowser}
-                onChange={(e) => setRememberBrowser(e.target.checked)}
-              />
-              <label htmlFor="rememberBrowser" className="ml-2 block text-sm text-gray-900">
-                {texts?.rememberMeText ?? 'Remember this browser for 30 days'}
-              </label>
-            </div>
-
-            {error && (
-              <div className="text-red-600 text-sm">
-                {error}
+            {data?.showRememberDevice && (
+              <div className="flex items-center">
+                <input
+                  id="rememberBrowser"
+                  name="rememberBrowser"
+                  type="checkbox"
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  checked={rememberBrowser}
+                  onChange={(e) => setRememberBrowser(e.target.checked)}
+                />
+                <label
+                  htmlFor="rememberBrowser"
+                  className="ml-2 block text-sm text-gray-900"
+                >
+                  {texts?.rememberMeText ?? "Remember this browser for 30 days"}
+                </label>
               </div>
             )}
+
+            {error && <div className="text-red-600 text-sm">{error}</div>}
 
             <div>
               <button
@@ -118,7 +128,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
                 onClick={handleTryAnotherMethod}
                 className="text-sm text-blue-600 hover:text-blue-500"
               >
-                {texts?.pickAuthenticatorText ?? 'Try Another Method'}
+                {texts?.pickAuthenticatorText ?? "Try Another Method"}
               </button>
             </div>
           </div>
@@ -129,6 +139,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
 };
 
 export default MfaOtpChallengeScreen;
+
 ```
 
 ## Usage Examples

--- a/packages/auth0-acul-js/examples/mfa-otp-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-otp-challenge.md
@@ -7,13 +7,13 @@ This screen is displayed when the user needs to enter the code sent to their aut
 ## React Component Example with TailwindCSS
 
 ```tsx
-import React, { useState } from "react";
-import MfaOtpChallenge from "@auth0/auth0-acul-js/mfa-otp-challenge";
+import React, { useState } from 'react';
+import MfaOtpChallenge from '@auth0/auth0-acul-js/mfa-otp-challenge';
 
 const MfaOtpChallengeScreen: React.FC = () => {
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState('');
   const [rememberBrowser, setRememberBrowser] = useState(false);
-  const [error, setError] = useState("");
+  const [error, setError] = useState('');
 
   const mfaOtpChallenge = new MfaOtpChallenge();
   const {
@@ -23,7 +23,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError("");
+    setError('');
 
     try {
       await mfaOtpChallenge.continue({
@@ -31,7 +31,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
         rememberBrowser,
       });
     } catch (err) {
-      setError("Failed to verify code. Please try again.");
+      setError('Failed to verify code. Please try again.');
       console.error(err);
     }
   };
@@ -40,7 +40,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
     try {
       await mfaOtpChallenge.tryAnotherMethod();
     } catch (err) {
-      setError("Failed to try another method. Please try again.");
+      setError('Failed to try another method. Please try again.');
       console.error(err);
     }
   };
@@ -49,11 +49,11 @@ const MfaOtpChallengeScreen: React.FC = () => {
     <div className="min-h-screen bg-gray-100 flex flex-col py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-          {texts?.title ?? "Verify Your Identity"}
+          {texts?.title ?? 'Verify Your Identity'}
         </h2>
         <p className="mt-2 text-center text-sm text-gray-600">
           {texts?.description ??
-            "Check your preferred one-time password application for a code."}
+            'Check your preferred one-time password application for a code.'}
         </p>
       </div>
 
@@ -65,7 +65,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
                 htmlFor="code"
                 className="block text-sm font-medium text-gray-700"
               >
-                {texts?.codePlaceholder ?? "Enter your one-time code"}
+                {texts?.codePlaceholder ?? 'Enter your one-time code'}
               </label>
               <div className="mt-1">
                 <input
@@ -73,7 +73,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
                   name="code"
                   type="text"
                   placeholder={
-                    texts?.codePlaceholder ?? "Enter your one-time code"
+                    texts?.codePlaceholder ?? 'Enter your one-time code'
                   }
                   required
                   value={code}
@@ -105,7 +105,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
                   htmlFor="rememberBrowser"
                   className="ml-2 block text-sm text-gray-900"
                 >
-                  {texts?.rememberMeText ?? "Remember this browser for 30 days"}
+                  {texts?.rememberMeText ?? 'Remember this browser for 30 days'}
                 </label>
               </div>
             )}
@@ -128,7 +128,7 @@ const MfaOtpChallengeScreen: React.FC = () => {
                 onClick={handleTryAnotherMethod}
                 className="text-sm text-blue-600 hover:text-blue-500"
               >
-                {texts?.pickAuthenticatorText ?? "Try Another Method"}
+                {texts?.pickAuthenticatorText ?? 'Try Another Method'}
               </button>
             </div>
           </div>

--- a/packages/auth0-acul-js/examples/mfa-push-challenge-push.md
+++ b/packages/auth0-acul-js/examples/mfa-push-challenge-push.md
@@ -11,8 +11,8 @@ import React, {
   useRef,
   useCallback,
   useMemo,
-} from "react";
-import MfaPushChallengePush from "@auth0/auth0-acul-js/mfa-push-challenge-push";
+} from 'react';
+import MfaPushChallengePush from '@auth0/auth0-acul-js/mfa-push-challenge-push';
 
 const MfaPushChallengePushScreen: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -24,22 +24,22 @@ const MfaPushChallengePushScreen: React.FC = () => {
     mfaPushChallengePush.screen.data || {};
 
   const screenText = {
-    title: screen.texts?.title ?? "Push Notification Sent",
+    title: screen.texts?.title ?? 'Push Notification Sent',
     description:
       screen.texts?.description ??
       "We've sent a push notification to your device",
     rememberMe:
-      screen.texts?.rememberMeText ?? "Remember this device for 30 days",
-    resend: screen.texts?.resendActionText ?? "Resend Push Notification",
-    enterCode: screen.texts?.enterOtpCode ?? "Enter Code Manually",
-    tryAnother: screen.texts?.pickAuthenticatorText ?? "Try Another Method",
+      screen.texts?.rememberMeText ?? 'Remember this device for 30 days',
+    resend: screen.texts?.resendActionText ?? 'Resend Push Notification',
+    enterCode: screen.texts?.enterOtpCode ?? 'Enter Code Manually',
+    tryAnother: screen.texts?.pickAuthenticatorText ?? 'Try Another Method',
     waiting:
       screen.texts?.spinner_push_notification_label ??
-      "Waiting for you to accept the push notification...",
-    errorResend: "Failed to resend push notification. Please try again.",
-    errorManualCode: "Failed to switch to manual code entry. Please try again.",
+      'Waiting for you to accept the push notification...',
+    errorResend: 'Failed to resend push notification. Please try again.',
+    errorManualCode: 'Failed to switch to manual code entry. Please try again.',
     errorAnotherMethod:
-      "Failed to switch authentication method. Please try again.",
+      'Failed to switch authentication method. Please try again.',
   };
 
   const startPolling = useCallback(async () => {

--- a/packages/auth0-acul-js/examples/mfa-push-challenge-push.md
+++ b/packages/auth0-acul-js/examples/mfa-push-challenge-push.md
@@ -5,63 +5,62 @@ This screen is displayed when a push notification has been sent to the user's de
 ## React Component Example with TailwindCSS
 
 ```tsx
-import React, { useState, useEffect } from 'react';
-import MfaPushChallengePush from '@auth0/auth0-acul-js/mfa-push-challenge-push';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
+import MfaPushChallengePush from "@auth0/auth0-acul-js/mfa-push-challenge-push";
 
 const MfaPushChallengePushScreen: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [rememberDevice, setRememberDevice] = useState(false);
-  const [pollingError, setPollingError] = useState<string | null>(null);
-
-  const mfaPushChallengePush = new MfaPushChallengePush();
-  const { screen } = mfaPushChallengePush;
-  const { deviceName } = mfaPushChallengePush.screen.data || {};
+  const pollInterval: React.MutableRefObject<number> = useRef(0);
+  const mfaPushChallengePush = useMemo(() => new MfaPushChallengePush(), []);
+  const { screen, transaction } = mfaPushChallengePush;
+  const { deviceName, showRememberDevice } =
+    mfaPushChallengePush.screen.data || {};
 
   const screenText = {
-    title: screen.texts?.title ?? 'Push Notification Sent',
-    description: screen.texts?.description ?? 'We\'ve sent a push notification to your device',
-    rememberMe: screen.texts?.rememberMeText ?? 'Remember this device for 30 days',
-    resend: screen.texts?.resendActionText ?? 'Resend Push Notification',
-    enterCode: screen.texts?.enterOtpCode ?? 'Enter Code Manually',
-    tryAnother: screen.texts?.pickAuthenticatorText ?? 'Try Another Method',
-    waiting: screen.texts?.spinner_push_notification_label ?? 'Waiting for you to accept the push notification...',
-    errorResend: 'Failed to resend push notification. Please try again.',
-    errorManualCode: 'Failed to switch to manual code entry. Please try again.',
-    errorAnotherMethod: 'Failed to switch authentication method. Please try again.',
+    title: screen.texts?.title ?? "Push Notification Sent",
+    description:
+      screen.texts?.description ??
+      "We've sent a push notification to your device",
+    rememberMe:
+      screen.texts?.rememberMeText ?? "Remember this device for 30 days",
+    resend: screen.texts?.resendActionText ?? "Resend Push Notification",
+    enterCode: screen.texts?.enterOtpCode ?? "Enter Code Manually",
+    tryAnother: screen.texts?.pickAuthenticatorText ?? "Try Another Method",
+    waiting:
+      screen.texts?.spinner_push_notification_label ??
+      "Waiting for you to accept the push notification...",
+    errorResend: "Failed to resend push notification. Please try again.",
+    errorManualCode: "Failed to switch to manual code entry. Please try again.",
+    errorAnotherMethod:
+      "Failed to switch authentication method. Please try again.",
   };
 
+  const startPolling = useCallback(async () => {
+    mfaPushChallengePush.continue({ rememberDevice });
+  }, [mfaPushChallengePush, rememberDevice]);
+
   useEffect(() => {
-    let pollInterval: ReturnType<typeof setTimeout> | null = null;
-
-    const startPolling = async () => {
-      try {
-        await mfaPushChallengePush.continue({ rememberDevice });
-        setPollingError(null);
-      } catch (error) {
-        console.error('Polling error:', error);
-        setPollingError('Error contacting server. Please try again later.');
-      }
-    };
-
-    pollInterval = setInterval(startPolling, 5000);
-    startPolling();
+    clearInterval(pollInterval.current);
+    pollInterval.current = setInterval(startPolling, 5000);
 
     return () => {
-      if (pollInterval) {
-        clearInterval(pollInterval);
-      }
+      clearInterval(pollInterval.current);
     };
-  }, [rememberDevice]);
+  }, [startPolling]);
 
   const handleResend = async () => {
     setIsLoading(true);
-    setError(null);
     try {
       await mfaPushChallengePush.resendPushNotification({ rememberDevice });
     } catch (err) {
       console.log(err);
-      setError(screenText.errorResend);
     } finally {
       setIsLoading(false);
     }
@@ -69,12 +68,10 @@ const MfaPushChallengePushScreen: React.FC = () => {
 
   const handleEnterCodeManually = async () => {
     setIsLoading(true);
-    setError(null);
     try {
       await mfaPushChallengePush.enterCodeManually({ rememberDevice });
     } catch (err) {
       console.log(err);
-      setError(screenText.errorManualCode);
     } finally {
       setIsLoading(false);
     }
@@ -82,12 +79,10 @@ const MfaPushChallengePushScreen: React.FC = () => {
 
   const handleTryAnotherMethod = async () => {
     setIsLoading(true);
-    setError(null);
     try {
       await mfaPushChallengePush.tryAnotherMethod({ rememberDevice });
     } catch (err) {
       console.log(err);
-      setError(screenText.errorAnotherMethod);
     } finally {
       setIsLoading(false);
     }
@@ -107,9 +102,6 @@ const MfaPushChallengePushScreen: React.FC = () => {
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          {error && <div className="mb-4 text-sm text-red-600" role="alert">{error}</div>}
-          {pollingError && <div className="mb-4 text-sm text-red-600" role="alert">{pollingError}</div>}
-
           <div className="space-y-4">
             <div className="flex items-center justify-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500" />
@@ -119,18 +111,33 @@ const MfaPushChallengePushScreen: React.FC = () => {
               {screenText.waiting}
             </p>
 
-            <div className="flex items-center flex-start">
-              <input
-                id="rememberDevice"
-                type="checkbox"
-                checked={rememberDevice}
-                onChange={(e) => setRememberDevice(e.target.checked)}
-                className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-              />
-              <label htmlFor="rememberDevice" className="ml-2 block text-sm text-left text-gray-700">
-                {screenText.rememberMe}
-              </label>
-            </div>
+            {showRememberDevice && (
+              <div className="flex items-center flex-start">
+                <input
+                  id="rememberDevice"
+                  type="checkbox"
+                  checked={rememberDevice}
+                  onChange={(e) => setRememberDevice(e.target.checked)}
+                  className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                />
+                <label
+                  htmlFor="rememberDevice"
+                  className="ml-2 block text-sm text-left text-gray-700"
+                >
+                  {screenText.rememberMe}
+                </label>
+              </div>
+            )}
+
+            {transaction?.errors?.length && (
+              <div className="mb-4 space-y-1">
+                {transaction.errors.map((err, index) => (
+                  <p key={index} className="text-red-600 text-sm text-center">
+                    {err.message}
+                  </p>
+                ))}
+              </div>
+            )}
 
             <button
               onClick={handleResend}
@@ -163,6 +170,7 @@ const MfaPushChallengePushScreen: React.FC = () => {
 };
 
 export default MfaPushChallengePushScreen;
+
 ```
 
 ## Individual Method Examples

--- a/packages/auth0-acul-js/examples/mfa-sms-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-sms-challenge.md
@@ -4,8 +4,8 @@ import MfaSmsChallenge from '@auth0/auth0-acul-js/mfa-sms-challenge';
 const mfaSmsChallenge = new MfaSmsChallenge();
 
 // Access screen data
-const phoneNumber = mfaSmsChallenge.screen.data?.phone_number;
-const rememberDevice = mfaSmsChallenge.screen.data?.remember_device;
+const phoneNumber = mfaSmsChallenge.screen.data?.phoneNumber;
+const showRememberDevice = mfaSmsChallenge.screen.data?.showRememberDevice;
 
 // Example of submitting the MFA SMS challenge
 mfaSmsChallenge.continueMfaSmsChallenge({
@@ -28,15 +28,16 @@ mfaSmsChallenge.getACall();
 ## React Component Example with TailwindCSS
 
 ```jsx
-import React, { useState } from 'react';
-import MfaSmsChallenge from '@auth0/auth0-acul-js/mfa-sms-challenge';
+import { useState } from "react";
+import MfaSmsChallenge from "@auth0/auth0-acul-js/mfa-sms-challenge";
 
 const MfaSmsChallengeScreen = () => {
   const mfaSmsChallenge = new MfaSmsChallenge();
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState("");
   const [rememberDevice, setRememberDevice] = useState(false);
+  const { phoneNumber, showRememberDevice } = mfaSmsChallenge.screen.data || {};
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
     try {
       await mfaSmsChallenge.continueMfaSmsChallenge({
@@ -44,7 +45,7 @@ const MfaSmsChallengeScreen = () => {
         rememberBrowser: rememberDevice,
       });
     } catch (error) {
-      console.error('MFA SMS Challenge failed:', error);
+      console.error("MFA SMS Challenge failed:", error);
     }
   };
 
@@ -52,7 +53,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.pickSms();
     } catch (error) {
-      console.error('Pick SMS failed:', error);
+      console.error("Pick SMS failed:", error);
     }
   };
 
@@ -60,7 +61,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.resendCode();
     } catch (error) {
-      console.error('Resend code failed:', error);
+      console.error("Resend code failed:", error);
     }
   };
 
@@ -68,7 +69,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.tryAnotherMethod();
     } catch (error) {
-      console.error('Try another method failed:', error);
+      console.error("Try another method failed:", error);
     }
   };
 
@@ -76,7 +77,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.getACall();
     } catch (error) {
-      console.error('Get a call failed:', error);
+      console.error("Get a call failed:", error);
     }
   };
 
@@ -86,13 +87,21 @@ const MfaSmsChallengeScreen = () => {
         <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
           MFA SMS Challenge
         </h2>
+        {phoneNumber && (
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Enter the code sent to {phoneNumber}
+          </p>
+        )}
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label htmlFor="code" className="block text-sm font-medium text-gray-700">
+              <label
+                htmlFor="code"
+                className="block text-sm font-medium text-gray-700"
+              >
                 Enter Code
               </label>
               <div className="mt-1">
@@ -108,19 +117,24 @@ const MfaSmsChallengeScreen = () => {
               </div>
             </div>
 
-            <div className="flex items-center">
-              <input
-                id="rememberDevice"
-                name="rememberDevice"
-                type="checkbox"
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                checked={rememberDevice}
-                onChange={(e) => setRememberDevice(e.target.checked)}
-              />
-              <label htmlFor="rememberDevice" className="ml-2 block text-sm text-gray-900">
-                Remember this device
-              </label>
-            </div>
+            {showRememberDevice && (
+              <div className="flex items-center">
+                <input
+                  id="rememberDevice"
+                  name="rememberDevice"
+                  type="checkbox"
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  checked={rememberDevice}
+                  onChange={(e) => setRememberDevice(e.target.checked)}
+                />
+                <label
+                  htmlFor="rememberDevice"
+                  className="ml-2 block text-sm text-gray-900"
+                >
+                  Remember this device
+                </label>
+              </div>
+            )}
 
             <div>
               <button
@@ -165,4 +179,5 @@ const MfaSmsChallengeScreen = () => {
 };
 
 export default MfaSmsChallengeScreen;
+
 ```

--- a/packages/auth0-acul-js/examples/mfa-sms-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-sms-challenge.md
@@ -6,6 +6,7 @@ const mfaSmsChallenge = new MfaSmsChallenge();
 // Access screen data
 const phoneNumber = mfaSmsChallenge.screen.data?.phoneNumber;
 const showRememberDevice = mfaSmsChallenge.screen.data?.showRememberDevice;
+const showLinkVoice = mfaSmsChallenge.screen.data?.showLinkVoice;
 
 // Example of submitting the MFA SMS challenge
 mfaSmsChallenge.continueMfaSmsChallenge({
@@ -35,7 +36,7 @@ const MfaSmsChallengeScreen = () => {
   const mfaSmsChallenge = new MfaSmsChallenge();
   const [code, setCode] = useState("");
   const [rememberDevice, setRememberDevice] = useState(false);
-  const { phoneNumber, showRememberDevice } = mfaSmsChallenge.screen.data || {};
+  const { phoneNumber, showRememberDevice, showLinkVoice } = mfaSmsChallenge.screen.data || {};
 
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
@@ -165,12 +166,14 @@ const MfaSmsChallengeScreen = () => {
             >
               Try Another Method
             </button>
-            <button
-              onClick={handleGetACall}
-              className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 mt-2"
-            >
-              Get a Call
-            </button>
+            {showLinkVoice && (
+              <button
+                onClick={handleGetACall}
+                className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 mt-2"
+              >
+                Get a Call
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -179,5 +182,4 @@ const MfaSmsChallengeScreen = () => {
 };
 
 export default MfaSmsChallengeScreen;
-
 ```

--- a/packages/auth0-acul-js/examples/mfa-sms-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-sms-challenge.md
@@ -29,12 +29,12 @@ mfaSmsChallenge.getACall();
 ## React Component Example with TailwindCSS
 
 ```jsx
-import { useState } from "react";
-import MfaSmsChallenge from "@auth0/auth0-acul-js/mfa-sms-challenge";
+import { useState } from 'react';
+import MfaSmsChallenge from '@auth0/auth0-acul-js/mfa-sms-challenge';
 
 const MfaSmsChallengeScreen = () => {
   const mfaSmsChallenge = new MfaSmsChallenge();
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState('');
   const [rememberDevice, setRememberDevice] = useState(false);
   const { phoneNumber, showRememberDevice, showLinkVoice } = mfaSmsChallenge.screen.data || {};
 
@@ -46,7 +46,7 @@ const MfaSmsChallengeScreen = () => {
         rememberBrowser: rememberDevice,
       });
     } catch (error) {
-      console.error("MFA SMS Challenge failed:", error);
+      console.error('MFA SMS Challenge failed:', error);
     }
   };
 
@@ -54,7 +54,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.pickSms();
     } catch (error) {
-      console.error("Pick SMS failed:", error);
+      console.error('Pick SMS failed:', error);
     }
   };
 
@@ -62,7 +62,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.resendCode();
     } catch (error) {
-      console.error("Resend code failed:", error);
+      console.error('Resend code failed:', error);
     }
   };
 
@@ -70,7 +70,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.tryAnotherMethod();
     } catch (error) {
-      console.error("Try another method failed:", error);
+      console.error('Try another method failed:', error);
     }
   };
 
@@ -78,7 +78,7 @@ const MfaSmsChallengeScreen = () => {
     try {
       await mfaSmsChallenge.getACall();
     } catch (error) {
-      console.error("Get a call failed:", error);
+      console.error('Get a call failed:', error);
     }
   };
 

--- a/packages/auth0-acul-js/examples/mfa-voice-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-voice-challenge.md
@@ -59,8 +59,8 @@ mfaVoiceChallenge.tryAnotherMethod();
 ### Below is a complete React component implementing the MFA Voice Challenge screen with TailwindCSS:
 
 ```typescript
-import React, { useState, useEffect, FormEvent, ChangeEvent } from "react";
-import MfaVoiceChallenge from "@auth0/auth0-acul-js/mfa-voice-challenge";
+import React, { useState, useEffect, FormEvent, ChangeEvent } from 'react';
+import MfaVoiceChallenge from '@auth0/auth0-acul-js/mfa-voice-challenge';
 
 /**
  * MFA Voice Challenge Screen Component
@@ -70,13 +70,13 @@ import MfaVoiceChallenge from "@auth0/auth0-acul-js/mfa-voice-challenge";
  */
 const MfaVoiceChallengeScreen: React.FC = () => {
   // State for form inputs
-  const [code, setCode] = useState<string>("");
+  const [code, setCode] = useState<string>('');
   const [rememberBrowser, setRememberBrowser] = useState<boolean>(false);
 
   // UI state
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [phoneNumber, setPhoneNumber] = useState<string>("");
+  const [phoneNumber, setPhoneNumber] = useState<string>('');
   const [showRememberDevice, setShowRememberDevice] = useState<boolean>(false);
   const [showLinkSms, setShowLinkSms] = useState<boolean>(false);
 
@@ -112,7 +112,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
         rememberBrowser,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to verify code");
+      setError(err instanceof Error ? err.message : 'Failed to verify code');
     } finally {
       setIsLoading(false);
     }
@@ -129,7 +129,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
       await mfaVoiceChallenge.resendCode();
       // Could set a success message here if needed
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to resend code");
+      setError(err instanceof Error ? err.message : 'Failed to resend code');
     } finally {
       setIsLoading(false);
     }
@@ -159,7 +159,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
     try {
       await mfaVoiceChallenge.switchToSms();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to switch to SMS");
+      setError(err instanceof Error ? err.message : 'Failed to switch to SMS');
       setIsLoading(false);
     }
   };
@@ -175,7 +175,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
       setError(
         err instanceof Error
           ? err.message
-          : "Failed to navigate to phone selection"
+          : 'Failed to navigate to phone selection'
       );
       setIsLoading(false);
     }
@@ -192,7 +192,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
       setError(
         err instanceof Error
           ? err.message
-          : "Failed to navigate to method selection"
+          : 'Failed to navigate to method selection'
       );
       setIsLoading(false);
     }
@@ -207,7 +207,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
         <p className="mt-2 text-center text-sm text-gray-600">
           {phoneNumber ? (
             <>
-              We've called <span className="font-medium">{phoneNumber}</span>{" "}
+              We've called <span className="font-medium">{phoneNumber}</span>{' '}
               with your verification code.
             </>
           ) : (
@@ -279,11 +279,11 @@ const MfaVoiceChallengeScreen: React.FC = () => {
                 className={`w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white 
                   ${
                     isLoading
-                      ? "bg-blue-400 cursor-not-allowed"
-                      : "bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                      ? 'bg-blue-400 cursor-not-allowed'
+                      : 'bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
                   }`}
               >
-                {isLoading ? "Verifying..." : "Verify"}
+                {isLoading ? 'Verifying...' : 'Verify'}
               </button>
             </div>
           </form>

--- a/packages/auth0-acul-js/examples/mfa-voice-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-voice-challenge.md
@@ -59,35 +59,41 @@ mfaVoiceChallenge.tryAnotherMethod();
 ### Below is a complete React component implementing the MFA Voice Challenge screen with TailwindCSS:
 
 ```typescript
-import React, { useState, useEffect, FormEvent, ChangeEvent } from 'react';
-import MfaVoiceChallenge from '@auth0/auth0-acul-js/mfa-voice-challenge';
+import React, { useState, useEffect, FormEvent, ChangeEvent } from "react";
+import MfaVoiceChallenge from "@auth0/auth0-acul-js/mfa-voice-challenge";
 
 /**
  * MFA Voice Challenge Screen Component
- * 
+ *
  * This component renders a form for users to submit their voice verification code
  * received during multi-factor authentication.
  */
 const MfaVoiceChallengeScreen: React.FC = () => {
   // State for form inputs
-  const [code, setCode] = useState<string>('');
+  const [code, setCode] = useState<string>("");
   const [rememberBrowser, setRememberBrowser] = useState<boolean>(false);
-  
+
   // UI state
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [phoneNumber, setPhoneNumber] = useState<string>('');
-  
+  const [phoneNumber, setPhoneNumber] = useState<string>("");
+  const [showRememberDevice, setShowRememberDevice] = useState<boolean>(false);
+
   // Initialize MFA Voice Challenge SDK
   const mfaVoiceChallenge = new MfaVoiceChallenge();
-  
+
   useEffect(() => {
-    // Get the phone number from the screen data when component mounts
-    if (mfaVoiceChallenge.screen.data && mfaVoiceChallenge.screen.data.phoneNumber) {
-      setPhoneNumber(mfaVoiceChallenge.screen.data.phoneNumber);
+    // Get the phone number and showRememberDevice flag from the screen data when component mounts
+    if (mfaVoiceChallenge.screen.data) {
+      if (mfaVoiceChallenge.screen.data.phoneNumber) {
+        setPhoneNumber(mfaVoiceChallenge.screen.data.phoneNumber);
+      }
+      if (mfaVoiceChallenge.screen.data.showRememberDevice !== undefined) {
+        setShowRememberDevice(mfaVoiceChallenge.screen.data.showRememberDevice);
+      }
     }
   }, [mfaVoiceChallenge.screen.data]);
-  
+
   /**
    * Handles the form submission to verify the voice code
    */
@@ -95,50 +101,52 @@ const MfaVoiceChallengeScreen: React.FC = () => {
     e.preventDefault();
     setIsLoading(true);
     setError(null);
-    
+
     try {
       await mfaVoiceChallenge.continue({
         code,
-        rememberBrowser
+        rememberBrowser,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to verify code');
+      setError(err instanceof Error ? err.message : "Failed to verify code");
     } finally {
       setIsLoading(false);
     }
   };
-  
+
   /**
    * Handles the resend code action
    */
   const handleResendCode = async (): Promise<void> => {
     setIsLoading(true);
     setError(null);
-    
+
     try {
       await mfaVoiceChallenge.resendCode();
       // Could set a success message here if needed
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to resend code');
+      setError(err instanceof Error ? err.message : "Failed to resend code");
     } finally {
       setIsLoading(false);
     }
   };
-  
+
   /**
    * Handles the change event for the code input field
    */
   const handleCodeChange = (e: ChangeEvent<HTMLInputElement>): void => {
     setCode(e.target.value);
   };
-  
+
   /**
    * Handles the change event for the remember browser checkbox
    */
-  const handleRememberBrowserChange = (e: ChangeEvent<HTMLInputElement>): void => {
+  const handleRememberBrowserChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ): void => {
     setRememberBrowser(e.target.checked);
   };
-  
+
   /**
    * Handles switching to SMS verification
    */
@@ -147,11 +155,11 @@ const MfaVoiceChallengeScreen: React.FC = () => {
     try {
       await mfaVoiceChallenge.switchToSms();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to switch to SMS');
+      setError(err instanceof Error ? err.message : "Failed to switch to SMS");
       setIsLoading(false);
     }
   };
-  
+
   /**
    * Handles navigating to pick a different phone number
    */
@@ -160,11 +168,15 @@ const MfaVoiceChallengeScreen: React.FC = () => {
     try {
       await mfaVoiceChallenge.pickPhone();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to navigate to phone selection');
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to navigate to phone selection"
+      );
       setIsLoading(false);
     }
   };
-  
+
   /**
    * Handles navigating to try another MFA method
    */
@@ -173,11 +185,15 @@ const MfaVoiceChallengeScreen: React.FC = () => {
     try {
       await mfaVoiceChallenge.tryAnotherMethod();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to navigate to method selection');
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to navigate to method selection"
+      );
       setIsLoading(false);
     }
   };
-  
+
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
@@ -187,10 +203,11 @@ const MfaVoiceChallengeScreen: React.FC = () => {
         <p className="mt-2 text-center text-sm text-gray-600">
           {phoneNumber ? (
             <>
-              We've called <span className="font-medium">{phoneNumber}</span> with your verification code.
+              We've called <span className="font-medium">{phoneNumber}</span>{" "}
+              with your verification code.
             </>
           ) : (
-            'We\'ve called your phone with a verification code.'
+            "We've called your phone with a verification code."
           )}
         </p>
       </div>
@@ -199,7 +216,10 @@ const MfaVoiceChallengeScreen: React.FC = () => {
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label htmlFor="code" className="block text-sm font-medium text-gray-700">
+              <label
+                htmlFor="code"
+                className="block text-sm font-medium text-gray-700"
+              >
                 Verification Code
               </label>
               <div className="mt-1">
@@ -218,19 +238,24 @@ const MfaVoiceChallengeScreen: React.FC = () => {
               </div>
             </div>
 
-            <div className="flex items-center">
-              <input
-                id="remember-browser"
-                name="remember-browser"
-                type="checkbox"
-                checked={rememberBrowser}
-                onChange={handleRememberBrowserChange}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              />
-              <label htmlFor="remember-browser" className="ml-2 block text-sm text-gray-900">
-                Remember this device for 30 days
-              </label>
-            </div>
+            {showRememberDevice && (
+              <div className="flex items-center">
+                <input
+                  id="remember-browser"
+                  name="remember-browser"
+                  type="checkbox"
+                  checked={rememberBrowser}
+                  onChange={handleRememberBrowserChange}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                />
+                <label
+                  htmlFor="remember-browser"
+                  className="ml-2 block text-sm text-gray-900"
+                >
+                  Remember this device for 30 days
+                </label>
+              </div>
+            )}
 
             {error && (
               <div className="rounded-md bg-red-50 p-4">
@@ -248,9 +273,13 @@ const MfaVoiceChallengeScreen: React.FC = () => {
                 type="submit"
                 disabled={isLoading}
                 className={`w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white 
-                  ${isLoading ? 'bg-blue-400 cursor-not-allowed' : 'bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'}`}
+                  ${
+                    isLoading
+                      ? "bg-blue-400 cursor-not-allowed"
+                      : "bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  }`}
               >
-                {isLoading ? 'Verifying...' : 'Verify'}
+                {isLoading ? "Verifying..." : "Verify"}
               </button>
             </div>
           </form>
@@ -274,7 +303,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
               >
                 Resend code
               </button>
-              
+
               <button
                 onClick={handleSwitchToSms}
                 disabled={isLoading}
@@ -283,7 +312,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
               >
                 Send a text message instead
               </button>
-              
+
               <button
                 onClick={handlePickPhone}
                 disabled={isLoading}
@@ -292,7 +321,7 @@ const MfaVoiceChallengeScreen: React.FC = () => {
               >
                 Use a different phone
               </button>
-              
+
               <button
                 onClick={handleTryAnotherMethod}
                 disabled={isLoading}
@@ -310,4 +339,5 @@ const MfaVoiceChallengeScreen: React.FC = () => {
 };
 
 export default MfaVoiceChallengeScreen;
+
 ```

--- a/packages/auth0-acul-js/examples/mfa-voice-challenge.md
+++ b/packages/auth0-acul-js/examples/mfa-voice-challenge.md
@@ -78,18 +78,22 @@ const MfaVoiceChallengeScreen: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [phoneNumber, setPhoneNumber] = useState<string>("");
   const [showRememberDevice, setShowRememberDevice] = useState<boolean>(false);
+  const [showLinkSms, setShowLinkSms] = useState<boolean>(false);
 
   // Initialize MFA Voice Challenge SDK
   const mfaVoiceChallenge = new MfaVoiceChallenge();
 
   useEffect(() => {
-    // Get the phone number and showRememberDevice flag from the screen data when component mounts
+    // Get data from the screen when component mounts
     if (mfaVoiceChallenge.screen.data) {
       if (mfaVoiceChallenge.screen.data.phoneNumber) {
         setPhoneNumber(mfaVoiceChallenge.screen.data.phoneNumber);
       }
       if (mfaVoiceChallenge.screen.data.showRememberDevice !== undefined) {
         setShowRememberDevice(mfaVoiceChallenge.screen.data.showRememberDevice);
+      }
+      if (mfaVoiceChallenge.screen.data.showLinkSms !== undefined) {
+        setShowLinkSms(mfaVoiceChallenge.screen.data.showLinkSms);
       }
     }
   }, [mfaVoiceChallenge.screen.data]);
@@ -304,14 +308,16 @@ const MfaVoiceChallengeScreen: React.FC = () => {
                 Resend code
               </button>
 
-              <button
-                onClick={handleSwitchToSms}
-                disabled={isLoading}
-                type="button"
-                className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50"
-              >
-                Send a text message instead
-              </button>
+              {showLinkSms && (
+                <button
+                  onClick={handleSwitchToSms}
+                  disabled={isLoading}
+                  type="button"
+                  className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50"
+                >
+                  Send a text message instead
+                </button>
+              )}
 
               <button
                 onClick={handlePickPhone}

--- a/packages/auth0-acul-js/examples/reset-password-mfa-sms-challenge.md
+++ b/packages/auth0-acul-js/examples/reset-password-mfa-sms-challenge.md
@@ -4,8 +4,8 @@ import ResetPasswordMfaSmsChallenge from '@auth0/auth0-acul-js/reset-password-mf
 const resetPasswordMfaSmsChallenge = new ResetPasswordMfaSmsChallenge();
 
 // Access screen data
-const phoneNumber = resetPasswordMfaSmsChallenge.screen.data?.phone_number;
-const rememberDevice = resetPasswordMfaSmsChallenge.screen.data?.remember_device;
+const phoneNumber = resetPasswordMfaSmsChallenge.screen.data?.phoneNumber;
+const showLinkVoice = resetPasswordMfaSmsChallenge.screen.data?.showLinkVoice;
 
 // Example of submitting the MFA SMS challenge
 resetPasswordMfaSmsChallenge.continueMfaSmsChallenge({
@@ -121,7 +121,7 @@ const ResetPasswordMfaSmsChallengeScreen = () => {
             >
               { screen?.texts?.pickAuthenticatorText ?? 'Try Another Method' }
             </button>
-            { screen.data?.isVoiceEnabled && (
+            { screen.data?.showLinkVoice && (
               <button
                 onClick={handleGetACall}
                 className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 mt-2"

--- a/packages/auth0-acul-js/examples/reset-password-mfa-voice-challenge.md
+++ b/packages/auth0-acul-js/examples/reset-password-mfa-voice-challenge.md
@@ -12,9 +12,17 @@ import ResetPasswordMfaVoiceChallenge from '@auth0/auth0-acul-js/reset-password-
 
 const ResetPasswordMfaVoiceChallengeScreen: React.FC = () => {
   const [code, setCode] = useState('');
+  const [showLinkSms, setShowLinkSms] = useState(false);
   const resetPasswordMfaVoiceChallenge = new ResetPasswordMfaVoiceChallenge();
   const { screen, transaction } = resetPasswordMfaVoiceChallenge;
   const texts = screen?.texts ?? {};
+
+  // Initialize state from screen data
+  React.useEffect(() => {
+    if (screen?.data?.showLinkSms !== undefined) {
+      setShowLinkSms(screen.data.showLinkSms);
+    }
+  }, [screen?.data]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -97,13 +105,17 @@ const ResetPasswordMfaVoiceChallengeScreen: React.FC = () => {
           >
             {texts.resendActionText ?? 'Call Again'}
           </button>
-          <button
-            onClick={handleSwitchToSms}
-            className="text-blue-600 hover:underline"
-            type="button"
-          >
-            {texts.resendSmsActionText ?? 'Send a text'}
-          </button>
+          
+          {showLinkSms && (
+            <button
+              onClick={handleSwitchToSms}
+              className="text-blue-600 hover:underline"
+              type="button"
+            >
+              {texts.resendSmsActionText ?? 'Send a text'}
+            </button>
+          )}
+          
           <button
             onClick={handleTryAnotherMethod}
             className="text-blue-600 hover:underline"

--- a/packages/auth0-acul-js/interfaces/screens/mfa-email-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-email-challenge.ts
@@ -7,7 +7,7 @@ import type { ScreenMembers } from '../models/screen';
 export interface ScreenMembersOnMfaEmailChallenge extends ScreenMembers {
   data: {
     email: string;
-    remember_device?: boolean;
+    showRememberDevice?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/mfa-otp-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-otp-challenge.ts
@@ -6,7 +6,7 @@ import type { ScreenMembers } from '../models/screen';
  */
 export interface ScreenMembersOnMfaOtpChallenge extends ScreenMembers {
   data: {
-    remember_device?: boolean;
+    showRememberDevice?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/mfa-push-challenge-push.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-push-challenge-push.ts
@@ -9,8 +9,8 @@ export interface ScreenMembersOnMfaPushChallengePush extends ScreenMembers {
   data: {
     /** The name of the device receiving the push notification */
     deviceName: string;
-    /** Whether to remember this device for future authentications */
-    rememberDevice?: boolean;
+    /** Whether to show the remember device option */
+    showRememberDevice?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/mfa-sms-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-sms-challenge.ts
@@ -8,10 +8,19 @@ export interface MfaSmsChallengeOptions {
   [key: string]: string | number | boolean | undefined;
 }
 
+/**
+ * Interface for the screen data specific to mfa-sms-challenge screen
+ */
 export interface ScreenMembersOnMfaSmsChallenge extends ScreenMembers {
   data: {
-    phone_number?: string;
-    remember_device?: boolean;
+    /**
+     * The phone number where the SMS was sent
+     */
+    phoneNumber?: string;
+    /**
+     * Whether to show the remember device option
+     */
+    showRememberDevice?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/mfa-sms-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-sms-challenge.ts
@@ -21,6 +21,10 @@ export interface ScreenMembersOnMfaSmsChallenge extends ScreenMembers {
      * Whether to show the remember device option
      */
     showRememberDevice?: boolean;
+    /**
+     * Whether to show the link to switch to voice call verification
+     */
+    showLinkVoice?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
@@ -36,9 +36,9 @@ export interface ScreenMembersOnMfaVoiceChallenge extends ScreenMembers {
     phoneNumber?: string;
 
     /**
-     * The state of the remember device option.
+     * Whether to show the remember device option.
      */
-    rememberDevice?: boolean;
+    showRememberDevice?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
@@ -39,6 +39,11 @@ export interface ScreenMembersOnMfaVoiceChallenge extends ScreenMembers {
      * Whether to show the remember device option.
      */
     showRememberDevice?: boolean;
+
+    /**
+     * Whether to show the link to switch to SMS verification.
+     */
+    showLinkSms?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-sms-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-sms-challenge.ts
@@ -10,7 +10,10 @@ export interface MfaSmsChallengeOptions {
 export interface ScreenMembersOnResetPasswordMfaSmsChallenge extends ScreenMembers {
   data: {
     phoneNumber: string;
-    isVoiceEnabled: boolean;
+    /**
+     * Whether to show the link to switch to voice call verification
+     */
+    showLinkVoice?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-voice-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-voice-challenge.ts
@@ -11,6 +11,11 @@ export interface ScreenMembersOnResetPasswordMfaVoiceChallenge extends ScreenMem
      * The phone number to send the voice call to.
      */
     phoneNumber: string;
+
+    /**
+     * Whether to show the link to switch to SMS verification.
+     */
+    showLinkSms?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/src/screens/mfa-email-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-email-challenge/screen-override.ts
@@ -26,7 +26,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     }
     return {
       email: typeof data.email === 'string' ? data.email : '',
-      remember_device: typeof data.remember_device === 'boolean' ? data.remember_device : undefined,
+      showRememberDevice: typeof data.show_remember_device === 'boolean' ? data.show_remember_device : undefined,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/mfa-otp-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-otp-challenge/screen-override.ts
@@ -31,7 +31,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     }
 
     return {
-      remember_device: typeof data.remember_device === 'boolean' ? data.remember_device : undefined,
+      showRememberDevice: typeof data.show_remember_device === 'boolean' ? data.show_remember_device : undefined,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/mfa-push-challenge-push/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-challenge-push/screen-override.ts
@@ -29,7 +29,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       deviceName: typeof data.device_name === 'string' ? data.device_name : '',
-      rememberDevice: typeof data.remember_device === 'boolean' ? data.remember_device : undefined,
+      showRememberDevice: typeof data.show_remember_device === 'boolean' ? data.show_remember_device : undefined,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/mfa-sms-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-sms-challenge/screen-override.ts
@@ -32,8 +32,8 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     }
 
     return {
-      phone_number: data.phone_number as string,
-      remember_device: data.remember_device === true,
+      phoneNumber: data.phone_number as string,
+      showRememberDevice: data.show_remember_device === true,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/mfa-sms-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-sms-challenge/screen-override.ts
@@ -33,7 +33,8 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       phoneNumber: data.phone_number as string,
-      showRememberDevice: data.show_remember_device === true,
+      showRememberDevice: data.show_remember_device as boolean,
+      showLinkVoice: data.show_link_voice as boolean,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/mfa-voice-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-voice-challenge/screen-override.ts
@@ -35,6 +35,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     return {
       phoneNumber: data.phone_number as string,
       showRememberDevice: data.show_remember_device as boolean,
+      showLinkSms: !!data.show_link_sms,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/mfa-voice-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-voice-challenge/screen-override.ts
@@ -34,7 +34,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       phoneNumber: data.phone_number as string,
-      rememberDevice: data.remember_device as boolean,
+      showRememberDevice: data.show_remember_device as boolean,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-sms-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-sms-challenge/screen-override.ts
@@ -34,7 +34,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       phoneNumber: data.phone_number as string,
-      isVoiceEnabled: data.show_link_voice as boolean,
+      showLinkVoice: data.show_link_voice as boolean,
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-voice-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-voice-challenge/screen-override.ts
@@ -34,6 +34,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       phoneNumber: typeof data.phone_number === 'string' ? data.phone_number : '',
+      showLinkSms: data.show_link_sms as boolean,
     };
   };
 }

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-email-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-email-challenge/screen-override.test.ts
@@ -8,13 +8,13 @@ describe('ScreenOverride', () => {
       name: 'mfa-email-challenge',
       data: {
         email: 'test@example.com',
-        remember_device: true,
+        show_remember_device: true,
       },
     } as ScreenContext;
     const screenOverride = new ScreenOverride(screenContext);
     expect(screenOverride.data).toEqual({
       email: 'test@example.com',
-      remember_device: true,
+      showRememberDevice: true,
     });
   });
 
@@ -26,33 +26,33 @@ describe('ScreenOverride', () => {
     expect(screenOverride.data).toBeNull();
   });
 
-  it('should handle remember_device as undefined', () => {
+  it('should handle show_remember_device as undefined', () => {
     const screenContext: ScreenContext = {
       name: 'mfa-email-challenge',
       data: {
         email: 'test@example.com',
-        remember_device: undefined,
+        show_remember_device: undefined,
       },
     } as ScreenContext;
     const screenOverride = new ScreenOverride(screenContext);
     expect(screenOverride.data).toEqual({
       email: 'test@example.com',
-      remember_device: undefined,
+      showRememberDevice: undefined,
     });
   });
 
-  it('should handle remember_device as false', () => {
+  it('should handle show_remember_device as false', () => {
     const screenContext: ScreenContext = {
       name: 'mfa-email-challenge',
       data: {
         email: 'test@example.com',
-        remember_device: false,
+        show_remember_device: false,
       },
     } as ScreenContext;
     const screenOverride = new ScreenOverride(screenContext);
     expect(screenOverride.data).toEqual({
       email: 'test@example.com',
-      remember_device: false,
+      showRememberDevice: false,
     });
   });
 
@@ -61,7 +61,7 @@ describe('ScreenOverride', () => {
       name: 'mfa-email-challenge',
       data: {
         email: 'test@example.com',
-        remember_device: true,
+        show_remember_device: true,
       },
     } as ScreenContext;
     const screenOverride = new ScreenOverride(screenContext);

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-otp-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-otp-challenge/screen-override.test.ts
@@ -10,7 +10,7 @@ describe('ScreenOverride', () => {
     screenContext = {
       name: 'mfa-otp-challenge',
       data: {
-        remember_device: true,
+        show_remember_device: true,
       },
     } as ScreenContext;
 
@@ -19,7 +19,7 @@ describe('ScreenOverride', () => {
 
   it('should initialize data correctly', () => {
     expect(screenOverride.data).toEqual({
-      remember_device: true,
+      showRememberDevice: true,
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-push-challenge-push/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-push-challenge-push/screen-override.test.ts
@@ -11,7 +11,7 @@ describe('ScreenOverride', () => {
       name: 'mfa-push-challenge-push',
       data: {
         device_name: 'Test Device',
-        remember_device: true
+        show_remember_device: true
       }
     } as ScreenContext;
     screenOverride = new ScreenOverride(screenContext);
@@ -20,7 +20,7 @@ describe('ScreenOverride', () => {
   it('should initialize data correctly', () => {
     expect(screenOverride.data).toEqual({
       deviceName: 'Test Device',
-      rememberDevice: true
+      showRememberDevice: true
     });
   });
 
@@ -34,7 +34,7 @@ describe('ScreenOverride', () => {
     const result = ScreenOverride.getScreenData(screenContext);
     expect(result).toEqual({
       deviceName: 'Test Device',
-      rememberDevice: true
+      showRememberDevice: true
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-sms-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-sms-challenge/screen-override.test.ts
@@ -8,7 +8,7 @@ describe('ScreenOverride', () => {
       name: 'mfa-sms-challenge',
       data: {
         phone_number: '+15551234567',
-        show_remember_device: 'true',
+        show_remember_device: true,
       },
     } as ScreenContext;
 
@@ -17,6 +17,7 @@ describe('ScreenOverride', () => {
     expect(screenOverride.data).toEqual({
       phoneNumber: '+15551234567',
       showRememberDevice: true,
+      showLinkVoice: undefined
     });
   });
 
@@ -27,10 +28,7 @@ describe('ScreenOverride', () => {
 
     const screenOverride = new ScreenOverride(screenContext);
 
-    expect(screenOverride.data).toEqual({
-      phoneNumber: undefined,
-      showRememberDevice: undefined,
-    });
+    expect(screenOverride.data).toBeNull();
   });
 
   it('should handle show_remember_device as undefined', () => {
@@ -47,6 +45,7 @@ describe('ScreenOverride', () => {
     expect(screenOverride.data).toEqual({
       phoneNumber: '+15551234567',
       showRememberDevice: undefined,
+      showLinkVoice: undefined
     });
   });
 
@@ -55,7 +54,7 @@ describe('ScreenOverride', () => {
       name: 'mfa-sms-challenge',
       data: {
         phone_number: '+15551234567',
-        show_remember_device: 'false',
+        show_remember_device: false,
       },
     } as ScreenContext;
 
@@ -64,6 +63,60 @@ describe('ScreenOverride', () => {
     expect(screenOverride.data).toEqual({
       phoneNumber: '+15551234567',
       showRememberDevice: false,
+      showLinkVoice: undefined
+    });
+  });
+
+  it('should handle show_link_voice correctly when true', () => {
+    const screenContext: ScreenContext = {
+      name: 'mfa-sms-challenge',
+      data: {
+        phone_number: '+15551234567',
+        show_link_voice: true
+      },
+    } as ScreenContext;
+
+    const screenOverride = new ScreenOverride(screenContext);
+
+    expect(screenOverride.data).toEqual({
+      phoneNumber: '+15551234567',
+      showLinkVoice: true,
+      showRememberDevice: undefined
+    });
+  });
+
+  it('should handle show_link_voice correctly when false', () => {
+    const screenContext: ScreenContext = {
+      name: 'mfa-sms-challenge',
+      data: {
+        phone_number: '+15551234567',
+        show_link_voice: false
+      },
+    } as ScreenContext;
+
+    const screenOverride = new ScreenOverride(screenContext);
+
+    expect(screenOverride.data).toEqual({
+      phoneNumber: '+15551234567',
+      showLinkVoice: false,
+      showRememberDevice: undefined
+    });
+  });
+
+  it('should handle show_link_voice correctly when missing', () => {
+    const screenContext: ScreenContext = {
+      name: 'mfa-sms-challenge',
+      data: {
+        phone_number: '+15551234567'
+      },
+    } as ScreenContext;
+
+    const screenOverride = new ScreenOverride(screenContext);
+
+    expect(screenOverride.data).toEqual({
+      phoneNumber: '+15551234567',
+      showLinkVoice: undefined,
+      showRememberDevice: undefined
     });
   });
 
@@ -72,7 +125,7 @@ describe('ScreenOverride', () => {
       name: 'mfa-sms-challenge',
       data: {
         phone_number: '+15551234567',
-        show_remember_device: 'true',
+        show_remember_device: true,
       },
     } as ScreenContext;
     const screenOverride = new ScreenOverride(screenContext);

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-sms-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-sms-challenge/screen-override.ts
@@ -8,15 +8,15 @@ describe('ScreenOverride', () => {
       name: 'mfa-sms-challenge',
       data: {
         phone_number: '+15551234567',
-        remember_device: 'true',
+        show_remember_device: 'true',
       },
     } as ScreenContext;
 
     const screenOverride = new ScreenOverride(screenContext);
 
     expect(screenOverride.data).toEqual({
-      phone_number: '+15551234567',
-      remember_device: true,
+      phoneNumber: '+15551234567',
+      showRememberDevice: true,
     });
   });
 
@@ -28,42 +28,42 @@ describe('ScreenOverride', () => {
     const screenOverride = new ScreenOverride(screenContext);
 
     expect(screenOverride.data).toEqual({
-      phone_number: undefined,
-      remember_device: undefined,
+      phoneNumber: undefined,
+      showRememberDevice: undefined,
     });
   });
 
-  it('should handle remember_device as undefined', () => {
+  it('should handle show_remember_device as undefined', () => {
     const screenContext: ScreenContext = {
       name: 'mfa-sms-challenge',
       data: {
         phone_number: '+15551234567',
-        remember_device: undefined,
+        show_remember_device: undefined,
       },
     } as ScreenContext;
 
     const screenOverride = new ScreenOverride(screenContext);
 
     expect(screenOverride.data).toEqual({
-      phone_number: '+15551234567',
-      remember_device: undefined,
+      phoneNumber: '+15551234567',
+      showRememberDevice: undefined,
     });
   });
 
-  it('should handle remember_device as false', () => {
+  it('should handle show_remember_device as false', () => {
     const screenContext: ScreenContext = {
       name: 'mfa-sms-challenge',
       data: {
         phone_number: '+15551234567',
-        remember_device: 'false',
+        show_remember_device: 'false',
       },
     } as ScreenContext;
 
     const screenOverride = new ScreenOverride(screenContext);
 
     expect(screenOverride.data).toEqual({
-      phone_number: '+15551234567',
-      remember_device: false,
+      phoneNumber: '+15551234567',
+      showRememberDevice: false,
     });
   });
 
@@ -72,7 +72,7 @@ describe('ScreenOverride', () => {
       name: 'mfa-sms-challenge',
       data: {
         phone_number: '+15551234567',
-        remember_device: 'true',
+        show_remember_device: 'true',
       },
     } as ScreenContext;
     const screenOverride = new ScreenOverride(screenContext);

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
@@ -21,7 +21,7 @@ describe('MfaVoiceChallenge', () => {
         links: baseContextData.screen.links,
         data: {
           phone_number: '+15555555555',
-          remember_device: false
+          show_remember_device: true
         }
       }
     };

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/screen-override.test.ts
@@ -14,7 +14,7 @@ describe('ScreenOverride', () => {
       name: 'mfa-voice-challenge',
       data: { 
         phone_number: '+15555555555', 
-        remember_device: false 
+        show_remember_device: false 
       },
     } as ScreenContext;
     
@@ -24,7 +24,7 @@ describe('ScreenOverride', () => {
   it('should initialize data correctly', () => {
     expect(screenOverride.data).toEqual({
       phoneNumber: '+15555555555',
-      rememberDevice: false,
+      showRememberDevice: false,
     });
   });
 
@@ -34,11 +34,11 @@ describe('ScreenOverride', () => {
     expect(result).toBeNull();
   });
 
-  it('should map phone_number to phoneNumber and remember_device to rememberDevice', () => {
+  it('should map phone_number to phoneNumber and show_remember_device', () => {
     const result = ScreenOverride.getScreenData(screenContext);
     expect(result).toEqual({
       phoneNumber: '+15555555555',
-      rememberDevice: false,
+      showRememberDevice: false,
     });
   });
 
@@ -51,7 +51,7 @@ describe('ScreenOverride', () => {
     const result = ScreenOverride.getScreenData(partialContext);
     expect(result).toEqual({
       phoneNumber: '+15555555555',
-      rememberDevice: undefined,
+      showRememberDevice: undefined,
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/screen-override.test.ts
@@ -14,7 +14,8 @@ describe('ScreenOverride', () => {
       name: 'mfa-voice-challenge',
       data: { 
         phone_number: '+15555555555', 
-        show_remember_device: false 
+        show_remember_device: false,
+        show_link_sms: true
       },
     } as ScreenContext;
     
@@ -25,6 +26,7 @@ describe('ScreenOverride', () => {
     expect(screenOverride.data).toEqual({
       phoneNumber: '+15555555555',
       showRememberDevice: false,
+      showLinkSms: true
     });
   });
 
@@ -39,7 +41,42 @@ describe('ScreenOverride', () => {
     expect(result).toEqual({
       phoneNumber: '+15555555555',
       showRememberDevice: false,
+      showLinkSms: true
     });
+  });
+
+  it('should handle show_link_sms field correctly', () => {
+    // Test with explicit true value
+    const contextWithShowLinkSmsTrue = {
+      name: 'mfa-voice-challenge',
+      data: { 
+        phone_number: '+15555555555',
+        show_link_sms: true
+      },
+    } as ScreenContext;
+    let result = ScreenOverride.getScreenData(contextWithShowLinkSmsTrue);
+    expect(result?.showLinkSms).toBe(true);
+    
+    // Test with explicit false value
+    const contextWithShowLinkSmsFalse = {
+      name: 'mfa-voice-challenge',
+      data: { 
+        phone_number: '+15555555555',
+        show_link_sms: false
+      },
+    } as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithShowLinkSmsFalse);
+    expect(result?.showLinkSms).toBe(false);
+    
+    // Test with missing show_link_sms (should be falsy)
+    const contextWithoutShowLinkSms = {
+      name: 'mfa-voice-challenge',
+      data: { 
+        phone_number: '+15555555555' 
+      },
+    } as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithoutShowLinkSms);
+    expect(result?.showLinkSms).toBe(false);
   });
 
   it('should handle missing fields gracefully', () => {
@@ -51,6 +88,7 @@ describe('ScreenOverride', () => {
     const result = ScreenOverride.getScreenData(partialContext);
     expect(result).toEqual({
       phoneNumber: '+15555555555',
+      showLinkSms: false,
       showRememberDevice: undefined,
     });
   });

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/screen-override.test.ts
@@ -39,4 +39,54 @@ describe('ScreenOverride', () => {
     const screenOverride = new ScreenOverride(screenContext);
     expect(screenOverride).toBeInstanceOf(Screen);
   });
+
+  it('should initialize data correctly with show_link_voice true', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-sms-challenge',
+      data: {
+        phone_number: '+15551234567',
+        show_link_voice: true
+      },
+    } as ScreenContext;
+
+    const screenOverride = new ScreenOverride(screenContext);
+
+    expect(screenOverride.data).toEqual({
+      phoneNumber: '+15551234567',
+      showLinkVoice: true
+    });
+  });
+
+  it('should initialize data correctly with show_link_voice false', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-sms-challenge',
+      data: {
+        phone_number: '+15551234567',
+        show_link_voice: false
+      },
+    } as ScreenContext;
+
+    const screenOverride = new ScreenOverride(screenContext);
+
+    expect(screenOverride.data).toEqual({
+      phoneNumber: '+15551234567',
+      showLinkVoice: false
+    });
+  });
+
+  it('should handle missing show_link_voice correctly', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-sms-challenge',
+      data: {
+        phone_number: '+15551234567'
+      },
+    } as ScreenContext;
+
+    const screenOverride = new ScreenOverride(screenContext);
+
+    expect(screenOverride.data).toEqual({
+      phoneNumber: '+15551234567',
+      showLinkVoice: undefined
+    });
+  });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/screen-override.test.ts
@@ -10,6 +10,7 @@ describe('ScreenOverride', () => {
       name: 'reset-password',
       data: {
         phone_number: '9999999999',
+        show_link_sms: true
       },
     } as ScreenContext;
 
@@ -19,6 +20,7 @@ describe('ScreenOverride', () => {
   it('should initialize data correctly', () => {
     expect(screenOverride.data).toEqual({
       phoneNumber: '9999999999',
+      showLinkSms: true
     });
   });
 
@@ -26,5 +28,49 @@ describe('ScreenOverride', () => {
     screenContext.data = undefined;
     const override = new ScreenOverride(screenContext);
     expect(override.data).toBeNull();
+  });
+
+  it('should handle show_link_sms field correctly', () => {
+    // Test with explicit true value
+    const contextWithShowLinkSmsTrue = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: { 
+        phone_number: '9999999999',
+        show_link_sms: true
+      },
+    } as ScreenContext;
+    let result = ScreenOverride.getScreenData(contextWithShowLinkSmsTrue);
+    expect(result?.showLinkSms).toBe(true);
+    
+    // Test with explicit false value
+    const contextWithShowLinkSmsFalse = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: { 
+        phone_number: '9999999999',
+        show_link_sms: false
+      },
+    } as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithShowLinkSmsFalse);
+    expect(result?.showLinkSms).toBe(false);
+    
+    // Test with missing show_link_sms (should be falsy)
+    const contextWithoutShowLinkSms = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: { 
+        phone_number: '9999999999'
+      },
+    } as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithoutShowLinkSms);
+    expect(result?.showLinkSms).toBe(undefined);
+    
+    const contextWithTruthyValue = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: { 
+        phone_number: '9999999999',
+        show_link_sms: true
+      },
+    } as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithTruthyValue);
+    expect(result?.showLinkSms).toBe(true);
   });
 });


### PR DESCRIPTION
### 🛠️ Changes
- Changed all instances of `remember_device` to `showRememberDevice` in the MFA email, OTP, push, SMS, and voice challenge screens and their respective overrides.
- Updated example components to reflect the new `showRememberDevice` property.
- changed variable name from `snake_case` to `camelCase` for the mentioned screens