### PR TITLE
feat: add EmailOTPChallengeScreen for email OTP verification

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -181,6 +181,7 @@ Get up and running quickly with our boilerplate starter template: [Link](https:/
 | 59     | logout | [Link](https://auth0.github.io/universal-login/classes/Classes.Logout.html) |
 | 60     | logout-aborted | [Link](https://auth0.github.io/universal-login/classes/Classes.LogoutAborted.html) |
 | 61     | logout-complete | [Link](https://auth0.github.io/universal-login/classes/Classes.LogoutComplete.html) |
+| 62     | email-otp-challenge                       | [Link](https://auth0.github.io/universal-login/classes/Classes.EmailOTPChallenge.html)    |
 
 </details>
 

--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -181,7 +181,7 @@ Get up and running quickly with our boilerplate starter template: [Link](https:/
 | 59     | logout | [Link](https://auth0.github.io/universal-login/classes/Classes.Logout.html) |
 | 60     | logout-aborted | [Link](https://auth0.github.io/universal-login/classes/Classes.LogoutAborted.html) |
 | 61     | logout-complete | [Link](https://auth0.github.io/universal-login/classes/Classes.LogoutComplete.html) |
-| 62     | email-otp-challenge                       | [Link](https://auth0.github.io/universal-login/classes/Classes.EmailOTPChallenge.html)    |
+| 62     | email-otp-challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.EmailOTPChallenge.html) |
 
 </details>
 

--- a/packages/auth0-acul-js/examples/email-otp-challenge.md
+++ b/packages/auth0-acul-js/examples/email-otp-challenge.md
@@ -1,0 +1,145 @@
+import EmailOTPChallenge from '@auth0/auth0-acul-js/email-otp-challenge';
+
+## submitCode
+
+```typescript
+
+//Creates an instance of EmailOTPChallenge and calls the method with sample data.
+import EmailOTPChallenge from '@auth0/auth0-acul-js/email-otp-challenge';
+const emailOTPChallenge = new EmailOTPChallenge();
+
+emailOTPChallenge.submitCode("123456");
+
+```
+
+
+## resendCode
+
+```typescript
+
+import EmailOTPChallenge from '@auth0/auth0-acul-js/email-otp-challenge';
+
+const emailOTPChallenge = new EmailOTPChallenge();
+emailOTPChallenge.resendCode();
+
+```
+
+## React Component Example with TailwindCSS
+
+```tsx
+import React, { useState } from 'react';
+import EmailOTPChallenge from '@auth0/auth0-acul-js/email-otp-challenge';
+
+const EmailOTPChallengeScreen: React.FC = () => {
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  const emailOTPChallengeManager = new EmailOTPChallenge();
+  const { screen } = emailOTPChallengeManager;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSuccess(false);
+
+    try {
+      await emailOTPChallengeManager.submitCode(code);
+      setSuccess(true);
+    } catch (err: any) {
+      setError(err.message || 'Failed to submit code. Please try again.');
+    }
+  };
+
+  const handleResendCode = async () => {
+    setError('');
+    setSuccess(false);
+
+    try {
+      await emailOTPChallengeManager.resendCode();
+      setSuccess(true);
+    } catch (err: any) {
+      setError(err.message || 'Failed to resend code. Please try again.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          Email OTP Challenge
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div>
+              <label htmlFor="code" className="block text-sm font-medium text-gray-700">
+                Verification Code
+              </label>
+              <div className="mt-1">
+                <input
+                  id="code"
+                  name="code"
+                  type="text"
+                  required
+                  value={code}
+                  onChange={(e) => setCode(e.target.value)}
+                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+            </div>
+
+            {error && (
+              <div className="text-red-600 text-sm">
+                {error}
+              </div>
+            )}
+
+            {success && (
+              <div className="text-green-600 text-sm">
+                Code submitted successfully!
+              </div>
+            )}
+
+            <div>
+              <button
+                type="submit"
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                Submit Code
+              </button>
+            </div>
+          </form>
+
+          <div className="mt-6">
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="px-2 bg-white text-gray-500">
+                  Need a new code?
+                </span>
+              </div>
+            </div>
+
+            <div className="mt-6">
+              <button
+                type="button"
+                onClick={handleResendCode}
+                className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-500 hover:bg-gray-50"
+              >
+                Resend Code
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EmailOTPChallengeScreen;
+```

--- a/packages/auth0-acul-js/examples/email-otp-challenge.md
+++ b/packages/auth0-acul-js/examples/email-otp-challenge.md
@@ -44,7 +44,7 @@ const EmailOTPChallengeScreen: React.FC = () => {
     setSuccess(false);
 
     try {
-      await emailOTPChallengeManager.submitCode(code);
+      await emailOTPChallengeManager.submitCode({ code });
       setSuccess(true);
     } catch (err: any) {
       setError(err.message || 'Failed to submit code. Please try again.');

--- a/packages/auth0-acul-js/interfaces/export/extended-types.ts
+++ b/packages/auth0-acul-js/interfaces/export/extended-types.ts
@@ -47,5 +47,5 @@ export type { ScreenMembersOnResetPasswordMfaPhoneChallenge } from '../screens/r
 export type { ScreenMembersOnMfaRecoveryCodeChallengeNewCode } from '../screens/mfa-recovery-code-challenge-new-code';
 export type { LogoutMembers } from '../screens/logout';
 export type { LogoutAbortedMembers } from '../screens/logout-aborted';
-export type { ScreenMembersOnEmailOTPChallenge } from '../screens/email-otp-challenge'
+export type { ScreenMembersOnEmailOTPChallenge, OTPCodeOptions } from '../screens/email-otp-challenge'
 export type { ScreenMembersOnEmailVerificationResult } from '../screens/email-verification-result';

--- a/packages/auth0-acul-js/interfaces/export/extended-types.ts
+++ b/packages/auth0-acul-js/interfaces/export/extended-types.ts
@@ -47,5 +47,5 @@ export type { ScreenMembersOnResetPasswordMfaPhoneChallenge } from '../screens/r
 export type { ScreenMembersOnMfaRecoveryCodeChallengeNewCode } from '../screens/mfa-recovery-code-challenge-new-code';
 export type { LogoutMembers } from '../screens/logout';
 export type { LogoutAbortedMembers } from '../screens/logout-aborted';
-export type { ScreenMembersOnEmailOTPChallenge, OTPCodeOptions } from '../screens/email-otp-challenge'
+export type { ScreenMembersOnEmailOTPChallenge, OtpCodeOptions } from '../screens/email-otp-challenge'
 export type { ScreenMembersOnEmailVerificationResult } from '../screens/email-verification-result';

--- a/packages/auth0-acul-js/interfaces/export/extended-types.ts
+++ b/packages/auth0-acul-js/interfaces/export/extended-types.ts
@@ -47,3 +47,4 @@ export type { ScreenMembersOnResetPasswordMfaPhoneChallenge } from '../screens/r
 export type { ScreenMembersOnMfaRecoveryCodeChallengeNewCode } from '../screens/mfa-recovery-code-challenge-new-code';
 export type { LogoutMembers } from '../screens/logout';
 export type { LogoutAbortedMembers } from '../screens/logout-aborted';
+export type { ScreenMembersOnEmailOTPChallenge } from '../screens/email-otp-challenge'

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -60,3 +60,5 @@ export type { MfaRecoveryCodeChallengeNewCodeMembers } from '../screens/mfa-reco
 export type { LogoutMembers } from '../screens/logout';
 export type { LogoutAbortedMembers } from '../screens/logout-aborted';
 export type { LogoutCompleteMembers } from '../screens/logout-complete';
+export type { EmailOTPChallengeMembers } from '../screens/email-otp-challenge';
+

--- a/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
@@ -1,0 +1,27 @@
+import type { ScreenMembers } from '../../interfaces/models/screen';
+
+/**
+ * Represents the members of the Email OTP Challenge screen.
+ * Extends the base ScreenMembers interface.
+ */
+export interface ScreenMembersOnEmailOTPChallenge extends ScreenMembers {
+  // Add any specific members for this screen here
+}
+
+/**
+ * Represents the Email OTP Challenge screen interface.
+ */
+export interface EmailOTPChallengeMembers {
+  screen: ScreenMembersOnEmailOTPChallenge;
+  /**
+   * Submits the OTP code entered by the user.
+   * @param code The OTP code to submit.
+   * @param options Optional parameters to include in the submission.
+   */
+  submitCode(code: string, options?: { [key: string]: string | number | boolean }): Promise<void>;
+  /**
+   * Requests a new OTP code to be sent to the user's email.
+   * @param options Optional parameters to include in the resend request.
+   */
+  resendCode(options?: { [key: string]: string | number | boolean }): Promise<void>;
+}

--- a/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
@@ -12,7 +12,6 @@ export interface ScreenMembersOnEmailOTPChallenge extends ScreenMembers {
  * Represents the Email OTP Challenge screen interface.
  */
 export interface EmailOTPChallengeMembers {
-  screen: ScreenMembersOnEmailOTPChallenge;
   /**
    * Submits the OTP code entered by the user.
    * @param code The OTP code to submit.

--- a/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
@@ -9,16 +9,22 @@ export interface ScreenMembersOnEmailOTPChallenge extends ScreenMembers {
   // Add any specific members for this screen here
 }
 
+export interface OTPCodeOptions extends CustomOptions {
+   /**
+   * The OTP code that the user enters to submit.
+   */
+  code: string;
+}
+// test data*********
 /**
  * Represents the Email OTP Challenge screen interface.
  */
 export interface EmailOTPChallengeMembers {
   /**
    * Submits the OTP code entered by the user.
-   * @param code The OTP code to submit.
    * @param options Optional parameters to include in the submission.
    */
-  submitCode(code: string, options?: CustomOptions): Promise<void>;
+  submitCode(options: OTPCodeOptions): Promise<void>;
   /**
    * Requests a new OTP code to be sent to the user's email.
    * @param options Optional parameters to include in the resend request.

--- a/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
@@ -1,4 +1,5 @@
 import type { ScreenMembers } from '../../interfaces/models/screen';
+import type { CustomOptions } from '../common';
 
 /**
  * Represents the members of the Email OTP Challenge screen.
@@ -17,10 +18,10 @@ export interface EmailOTPChallengeMembers {
    * @param code The OTP code to submit.
    * @param options Optional parameters to include in the submission.
    */
-  submitCode(code: string, options?: { [key: string]: string | number | boolean }): Promise<void>;
+  submitCode(code: string, options?: CustomOptions): Promise<void>;
   /**
    * Requests a new OTP code to be sent to the user's email.
    * @param options Optional parameters to include in the resend request.
    */
-  resendCode(options?: { [key: string]: string | number | boolean }): Promise<void>;
+  resendCode(options?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-otp-challenge.ts
@@ -9,7 +9,7 @@ export interface ScreenMembersOnEmailOTPChallenge extends ScreenMembers {
   // Add any specific members for this screen here
 }
 
-export interface OTPCodeOptions extends CustomOptions {
+export interface OtpCodeOptions extends CustomOptions {
    /**
    * The OTP code that the user enters to submit.
    */
@@ -24,7 +24,7 @@ export interface EmailOTPChallengeMembers {
    * Submits the OTP code entered by the user.
    * @param options Optional parameters to include in the submission.
    */
-  submitCode(options: OTPCodeOptions): Promise<void>;
+  submitCode(options: OtpCodeOptions): Promise<void>;
   /**
    * Requests a new OTP code to be sent to the user's email.
    * @param options Optional parameters to include in the resend request.

--- a/packages/auth0-acul-js/interfaces/screens/index.ts
+++ b/packages/auth0-acul-js/interfaces/screens/index.ts
@@ -47,3 +47,4 @@ export * as MfaRecoveryCodeChallenge from './mfa-recovery-code-challenge';
 export * as RedeemTicket from './redeem-ticket';
 export * as ResetPasswordMfaPhoneChallenge from './reset-password-mfa-phone-challenge';
 export * as MfaRecoveryCodeChallengeNewCode from './mfa-recovery-code-challenge-new-code';
+export * as EmailOTPChallenge from './email-otp-challenge';

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -255,7 +255,11 @@
     "./logout-complete": {
       "import": "./dist/screens/logout-complete/index.js",
       "types": "./dist/types/src/screens/logout-complete/index.d.ts"
-    }
+    },
+     "./email-otp-challenge": {
+        "import": "./dist/screens/email-otp-challenge/index.js",
+        "types": "./dist/types/src/screens/email-otp-challenge/index.d.ts"
+     }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/auth0-acul-js/src/constants/enums.ts
+++ b/packages/auth0-acul-js/src/constants/enums.ts
@@ -60,4 +60,5 @@ export const ScreenIds = {
   LOGOUT: 'logout',
   LOGOUT_ABORTED: 'logout-aborted',
   LOGOUT_COMPLETE: 'logout-complete',
+  EMAIL_OTP_CHALLENGE: 'email-otp-challenge',
 };

--- a/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
@@ -3,7 +3,6 @@ import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
 import type { CustomOptions } from '../../../interfaces/common';
-import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { EmailOTPChallengeMembers, ScreenMembersOnEmailOTPChallenge as ScreenOptions } from '../../../interfaces/screens/email-otp-challenge';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
@@ -11,7 +10,6 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Represents the Email OTP Challenge screen.
  */
 export default class EmailOTPChallenge extends BaseContext implements EmailOTPChallengeMembers {
-  screen: ScreenOptions;
   static screenIdentifier: string = ScreenIds.EMAIL_OTP_CHALLENGE;
 
   /**
@@ -19,8 +17,6 @@ export default class EmailOTPChallenge extends BaseContext implements EmailOTPCh
    */
   constructor() {
     super();
-    const screenContext = this.getContext('screen') as ScreenContext;
-    this.screen = screenContext as ScreenOptions;
   }
 
   /**
@@ -45,7 +41,7 @@ export default class EmailOTPChallenge extends BaseContext implements EmailOTPCh
 
     const payload = {
       code,
-      action: 'default',
+      action: FormActions.DEFAULT,
       ...options,
     };
 

--- a/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
@@ -1,0 +1,84 @@
+import { FormActions, ScreenIds } from '../../constants';
+import { BaseContext } from '../../models/base-context';
+import { FormHandler } from '../../utils/form-handler';
+
+import type { CustomOptions } from '../../../interfaces/common';
+import type { ScreenContext } from '../../../interfaces/models/screen';
+import type { EmailOTPChallengeMembers, ScreenMembersOnEmailOTPChallenge as ScreenOptions } from '../../../interfaces/screens/email-otp-challenge';
+import type { FormOptions } from '../../../interfaces/utils/form-handler';
+
+/**
+ * Represents the Email OTP Challenge screen.
+ */
+export default class EmailOTPChallenge extends BaseContext implements EmailOTPChallengeMembers {
+  screen: ScreenOptions;
+  static screenIdentifier: string = ScreenIds.EMAIL_OTP_CHALLENGE;
+
+  /**
+   * Creates an instance of the EmailOTPChallenge screen.
+   */
+  constructor() {
+    super();
+    const screenContext = this.getContext('screen') as ScreenContext;
+    this.screen = screenContext as ScreenOptions;
+  }
+
+  /**
+   * Submits the OTP code entered by the user.
+   * @param code The OTP code to submit.
+   * @param options Optional parameters to include in the submission.
+   * @example
+   * ```typescript
+   * import EmailOTPChallenge from '@auth0/auth0-acul-js/email-otp-challenge';
+   *
+   * const emailOTPChallenge = new EmailOTPChallenge();
+   * emailOTPChallenge.submitCode({
+   *   code: '123456',
+   * });
+   * ```
+   */
+  async submitCode(code: string, options?: CustomOptions): Promise<void> {
+    const formOptions: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [EmailOTPChallenge.screenIdentifier, 'continue'],
+    };
+
+    const payload = {
+      code,
+      action: 'default',
+      ...options,
+    };
+
+    await new FormHandler(formOptions).submitData(payload);
+  }
+
+  /**
+   * Requests a new OTP code to be sent to the user's email.
+   * @param options Optional parameters to include in the resend request.
+   * @example
+   * ```typescript
+   * import EmailOTPChallenge from '@auth0/auth0-acul-js/email-otp-challenge';
+   *
+   * const emailOTPChallenge = new EmailOTPChallenge();
+   * emailOTPChallenge.resendCode();
+   * ```
+   */
+  async resendCode(options?: CustomOptions): Promise<void> {
+    const formOptions: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [EmailOTPChallenge.screenIdentifier, 'resendCode'],
+    };
+
+    const payload = {
+      action: FormActions.RESEND_CODE,
+      ...options,
+    };
+
+    await new FormHandler(formOptions).submitData(payload);
+  }
+}
+
+export { EmailOTPChallengeMembers, ScreenOptions as ScreenMembersOnEmailOTPChallenge };
+
+export * from '../../../interfaces/export/common';
+export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
@@ -3,7 +3,7 @@ import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
 import type { CustomOptions } from '../../../interfaces/common';
-import type { EmailOTPChallengeMembers, OTPCodeOptions, ScreenMembersOnEmailOTPChallenge as ScreenOptions } from '../../../interfaces/screens/email-otp-challenge';
+import type { EmailOTPChallengeMembers, OtpCodeOptions, ScreenMembersOnEmailOTPChallenge as ScreenOptions } from '../../../interfaces/screens/email-otp-challenge';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 /**
@@ -29,16 +29,14 @@ export default class EmailOTPChallenge extends BaseContext implements EmailOTPCh
    * });
    * ```
    */
-  async submitCode(options: OTPCodeOptions): Promise<void> {
+  async submitCode(options: OtpCodeOptions): Promise<void> {
     const formOptions: FormOptions = {
       state: this.transaction.state,
-      telemetry: [EmailOTPChallenge.screenIdentifier, 'continue'],
+      telemetry: [EmailOTPChallenge.screenIdentifier, 'submitCode'],
     };
-    const { code, ...restOptions } = options;
     const payload = {
-      code,
+      ...options,
       action: FormActions.DEFAULT,
-      ...restOptions,
     };
 
     await new FormHandler(formOptions).submitData(payload);
@@ -62,8 +60,8 @@ export default class EmailOTPChallenge extends BaseContext implements EmailOTPCh
     };
 
     const payload = {
-      action: FormActions.RESEND_CODE,
       ...options,
+      action: FormActions.RESEND_CODE,
     };
 
     await new FormHandler(formOptions).submitData(payload);

--- a/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
@@ -3,7 +3,7 @@ import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
 import type { CustomOptions } from '../../../interfaces/common';
-import type { EmailOTPChallengeMembers, ScreenMembersOnEmailOTPChallenge as ScreenOptions } from '../../../interfaces/screens/email-otp-challenge';
+import type { EmailOTPChallengeMembers, OTPCodeOptions, ScreenMembersOnEmailOTPChallenge as ScreenOptions } from '../../../interfaces/screens/email-otp-challenge';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 /**
@@ -18,7 +18,6 @@ export default class EmailOTPChallenge extends BaseContext implements EmailOTPCh
 
   /**
    * Submits the OTP code entered by the user.
-   * @param code The OTP code to submit.
    * @param options Optional parameters to include in the submission.
    * @example
    * ```typescript
@@ -30,16 +29,16 @@ export default class EmailOTPChallenge extends BaseContext implements EmailOTPCh
    * });
    * ```
    */
-  async submitCode(code: string, options?: CustomOptions): Promise<void> {
+  async submitCode(options: OTPCodeOptions): Promise<void> {
     const formOptions: FormOptions = {
       state: this.transaction.state,
       telemetry: [EmailOTPChallenge.screenIdentifier, 'continue'],
     };
-
+    const { code, ...restOptions } = options;
     const payload = {
       code,
       action: FormActions.DEFAULT,
-      ...options,
+      ...restOptions,
     };
 
     await new FormHandler(formOptions).submitData(payload);

--- a/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-otp-challenge/index.ts
@@ -12,9 +12,6 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
 export default class EmailOTPChallenge extends BaseContext implements EmailOTPChallengeMembers {
   static screenIdentifier: string = ScreenIds.EMAIL_OTP_CHALLENGE;
 
-  /**
-   * Creates an instance of the EmailOTPChallenge screen.
-   */
   constructor() {
     super();
   }

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -60,3 +60,4 @@ export { default as MfaRecoveryCodeChallengeNewCode } from './mfa-recovery-code-
 export { default as Logout } from './logout';
 export { default as LogoutAborted } from './logout-aborted';
 export { default as LogoutComplete } from './logout-complete';
+export { default as EmailOTPChallenge } from './email-otp-challenge'

--- a/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
@@ -25,37 +25,36 @@ describe('EmailOTPChallenge', () => {
   describe('submitCode method', () => {
     it('should handle submitCode with valid code correctly', async () => {
       const code = '123456';
-      await emailOTPChallenge.submitCode(code);
+      const options = { code: '123456' }; 
+      await emailOTPChallenge.submitCode(options);
 
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.objectContaining({
-          code: code,
+          code: options.code,
           action: FormActions.DEFAULT,
         })
       );
     });
 
     it('should handle submitCode with valid code and options correctly', async () => {
-      const code = '123456';
-      const options: CustomOptions = { customParam: 'customValue' };
-      await emailOTPChallenge.submitCode(code, options);
+      const options = { code: '123456', customParam: 'customValue' };
+      await emailOTPChallenge.submitCode(options);
 
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.objectContaining({
-          code: code,
+          code: options.code,
           action: FormActions.DEFAULT,
-          ...options,
+          customParam: options.customParam,
         })
       );
     });
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      const code = '123456';
-
-      await expect(emailOTPChallenge.submitCode(code)).rejects.toThrow(
+      const options = { code: '123456' };
+      await expect(emailOTPChallenge.submitCode(options)).rejects.toThrow(
         'Mocked reject'
       );
     });

--- a/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
@@ -1,0 +1,96 @@
+import EmailOTPChallenge from '../../../../src/screens/email-otp-challenge';
+import { baseContextData } from '../../../data/test-data';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { CustomOptions } from 'interfaces/common';
+import { ScreenIds } from '../../../../src/constants';
+
+jest.mock('../../../../src/utils/form-handler');
+
+describe('EmailOTPChallenge', () => {
+  let emailOTPChallenge: EmailOTPChallenge;
+  let mockFormHandler: { submitData: jest.Mock };
+
+  beforeEach(() => {
+    global.window = Object.create(window);
+    baseContextData.screen.name = ScreenIds.EMAIL_OTP_CHALLENGE;
+    window.universal_login_context = baseContextData;
+    emailOTPChallenge = new EmailOTPChallenge();
+    mockFormHandler = {
+      submitData: jest.fn(),
+    };
+    (FormHandler as jest.Mock).mockImplementation(() => mockFormHandler);
+  });
+
+  describe('submitCode method', () => {
+    it('should handle submitCode with valid code correctly', async () => {
+      const code = '123456';
+      await emailOTPChallenge.submitCode(code);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: code,
+          action: 'default',
+        })
+      );
+    });
+
+    it('should handle submitCode with valid code and options correctly', async () => {
+      const code = '123456';
+      const options: CustomOptions = { customParam: 'customValue' };
+      await emailOTPChallenge.submitCode(code, options);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: code,
+          action: 'default',
+          ...options,
+        })
+      );
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
+      const code = '123456';
+
+      await expect(emailOTPChallenge.submitCode(code)).rejects.toThrow(
+        'Mocked reject'
+      );
+    });
+  });
+
+  describe('resendCode method', () => {
+    it('should handle resendCode correctly', async () => {
+      await emailOTPChallenge.resendCode();
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'resend-code',
+        })
+      );
+    });
+
+    it('should handle resendCode with options correctly', async () => {
+      const options: CustomOptions = { customParam: 'customValue' };
+      await emailOTPChallenge.resendCode(options);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'resend-code',
+          ...options,
+        })
+      );
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
+
+      await expect(emailOTPChallenge.resendCode()).rejects.toThrow(
+        'Mocked reject'
+      );
+    });
+  });
+});

--- a/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
@@ -3,6 +3,7 @@ import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
 import { CustomOptions } from 'interfaces/common';
 import { ScreenIds } from '../../../../src/constants';
+import { FormActions } from '../../../../src/constants';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -30,7 +31,7 @@ describe('EmailOTPChallenge', () => {
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.objectContaining({
           code: code,
-          action: 'default',
+          action: FormActions.DEFAULT,
         })
       );
     });
@@ -44,7 +45,7 @@ describe('EmailOTPChallenge', () => {
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.objectContaining({
           code: code,
-          action: 'default',
+          action: FormActions.DEFAULT,
           ...options,
         })
       );
@@ -67,7 +68,7 @@ describe('EmailOTPChallenge', () => {
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.objectContaining({
-          action: 'resend-code',
+          action: FormActions.RESEND_CODE,
         })
       );
     });
@@ -79,7 +80,7 @@ describe('EmailOTPChallenge', () => {
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.objectContaining({
-          action: 'resend-code',
+          action: FormActions.RESEND_CODE,
           ...options,
         })
       );

--- a/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
@@ -24,7 +24,6 @@ describe('EmailOTPChallenge', () => {
 
   describe('submitCode method', () => {
     it('should handle submitCode with valid code correctly', async () => {
-      const code = '123456';
       const options = { code: '123456' }; 
       await emailOTPChallenge.submitCode(options);
 


### PR DESCRIPTION
- Implemented `EmailOTPChallengeScreen` React component using TailwindCSS for styling.
- Added functionality to submit and resend OTP codes using `EmailOTPChallenge` class.
- Included error and success handling for better user feedback.
- Updated documentation with examples for `submitCode` and `resendCode` methods.
- Created unit tests to ensure functionality and data handling for the new screen.
