### PR TITLE
feat: add email verification result and login email verification screens

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -181,6 +181,8 @@ Get up and running quickly with our boilerplate starter template: [Link](https:/
 | 59     | logout | [Link](https://auth0.github.io/universal-login/classes/Classes.Logout.html) |
 | 60     | logout-aborted | [Link](https://auth0.github.io/universal-login/classes/Classes.LogoutAborted.html) |
 | 61     | logout-complete | [Link](https://auth0.github.io/universal-login/classes/Classes.LogoutComplete.html) |
+| 62     | Email Verification Result   | [Link](https://auth0.github.io/universal-login/classes/Classes.EmailVerificationResult.html)                     |
+| 63     | login-email-verification    | [Link](https://auth0.github.io/universal-login/classes/Classes.LoginEmailVerification.html)                     |
 
 </details>
 

--- a/packages/auth0-acul-js/examples/email-verification-result.md
+++ b/packages/auth0-acul-js/examples/email-verification-result.md
@@ -1,0 +1,134 @@
+import EmailVerificationResult from '@auth0/auth0-acul-js/email-verification-result';
+
+# Email Verification Result Screen
+
+This screen is displayed after a user attempts to verify their email address. It shows the status of the verification (e.g., success, failure, already verified) and provides a link to proceed to the login page. This screen is primarily informational.
+
+## React Component Example with TailwindCSS
+
+This example demonstrates how to build a UI for the Email Verification Result screen using React and TailwindCSS. It displays the verification status and a button to navigate to the login page.
+
+```tsx
+import React from 'react';
+import EmailVerificationResult from '@auth0/auth0-acul-js/email-verification-result';
+
+const EmailVerificationResultScreen: React.FC = () => {
+  // Instantiate the SDK class for the Email Verification Result screen
+  const emailVerificationResultManager = new EmailVerificationResult();
+  const { client, screen, transaction, organization } = emailVerificationResultManager;
+
+  // Determine the message and styling based on the verification status
+  let statusMessage = 'An unexpected error occurred.';
+  let statusColor = 'text-gray-700'; // Default color
+  let title = screen.texts?.title ?? 'Email Verification'; // Default title
+
+  const verificationStatus = screen.data?.status;
+  const loginLink = screen.loginLink;
+
+  if (verificationStatus === 'success') {
+    statusMessage = screen.texts?.descriptionSuccess ?? 'Your email has been successfully verified.';
+    statusColor = 'text-green-600';
+    title = screen.texts?.titleSuccess ?? 'Verification Successful';
+  } else if (verificationStatus === 'failure') {
+    statusMessage = screen.texts?.descriptionFailure ?? 'There was an issue verifying your email. Please try again or contact support.';
+    statusColor = 'text-red-600';
+    title = screen.texts?.titleFailure ?? 'Verification Failed';
+  } else if (verificationStatus === 'already_verified') {
+    statusMessage = screen.texts?.descriptionAlreadyVerified ?? 'This email address has already been verified.';
+    statusColor = 'text-blue-600';
+    title = screen.texts?.titleAlreadyVerified ?? 'Email Already Verified';
+  }
+  // Add more status checks as needed based on actual possible values
+
+  const handleGoToLogin = (): void => {
+    if (loginLink) {
+      window.location.href = loginLink;
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+      <div className="w-full max-w-md bg-white rounded-lg shadow-md p-8 text-center">
+        {client.logoUrl && (
+          <img src={client.logoUrl} alt={client.name ?? 'Application Logo'} className="mx-auto h-16 mb-6" />
+        )}
+        <h1 className={`text-2xl font-semibold mb-4 ${statusColor}`}>
+          {title}
+        </h1>
+
+        <p className={`text-gray-700 mb-6 ${statusColor}`}>
+          {statusMessage}
+        </p>
+
+        {organization?.name && (
+          <p className="text-sm text-gray-500 mb-2">
+            Organization: {organization.displayName || organization.name}
+          </p>
+        )}
+
+        {transaction.errors && transaction.errors.length > 0 && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4 text-left" role="alert">
+            <strong className="font-bold">Error(s):</strong>
+            {transaction.errors.map((err, index) => (
+              <p key={`tx-error-${index}`} className="block sm:inline ml-2">{err.message}</p>
+            ))}
+          </div>
+        )}
+
+        {loginLink && (
+          <button
+            onClick={handleGoToLogin}
+            className="w-full px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 transition duration-150 ease-in-out"
+          >
+            {screen.texts?.buttonText ?? 'Proceed to Login'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EmailVerificationResultScreen;
+```
+
+## Usage Examples
+
+### Accessing Screen Information
+
+The EmailVerificationResult screen class provides access to various pieces of context information.
+
+```typescript
+import EmailVerificationResult from '@auth0/auth0-acul-js/email-verification-result';
+
+const screenManager = new EmailVerificationResult();
+
+// Access client information
+console.log('Client Name:', screenManager.client.name);
+
+// Access organization information (if available)
+if (screenManager.organization) {
+  console.log('Organization Name:', screenManager.organization.name);
+}
+
+// Access prompt information
+console.log('Prompt Name:', screenManager.prompt.name);
+
+// Access screen-specific data
+const verificationStatus = screenManager.screen.data?.status;
+console.log('Verification Status:', verificationStatus);
+
+const loginLink = screenManager.screen.loginLink;
+if (loginLink) {
+  console.log('Login Link:', loginLink);
+  // You can use this link to redirect the user:
+  // window.location.href = loginLink;
+}
+
+// Access transaction details
+console.log('Transaction State:', screenManager.transaction.state);
+if (screenManager.transaction.hasErrors && screenManager.transaction.errors) {
+  screenManager.transaction.errors.forEach(error => {
+    console.error('Transaction Error:', error.message);
+  });
+}
+```

--- a/packages/auth0-acul-js/examples/login-email-verification.md
+++ b/packages/auth0-acul-js/examples/login-email-verification.md
@@ -1,0 +1,273 @@
+import LoginEmailVerification from '@auth0/auth0-acul-js/login-email-verification';
+
+# Login Email Verification Screen
+
+This screen is displayed during the login flow when a user's email address requires verification. The user is prompted to enter a one-time code that has been sent to their registered email. This SDK provides methods to submit the entered code or to request a new code.
+
+## React Component Example with TailwindCSS
+
+Below is an example of a React component for the Login Email Verification screen, styled with TailwindCSS. It includes:
+- An input field for the verification code.
+- A "Continue" button to submit the code.
+- A "Resend Code" button to request a new code.
+- Display of error messages from `transaction.errors`.
+
+```tsx
+import React, { useState, useEffect, FormEvent, ChangeEvent } from 'react';
+import LoginEmailVerification, { ContinueWithCodeOptions, ResendCodeOptions } from '@auth0/auth0-acul-js/login-email-verification'; // Adjust path as necessary
+
+const LoginEmailVerificationScreen: React.FC = () => {
+  const [code, setCode] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [uiMessages, setUiMessages] = useState<{ type: 'error' | 'success', text: string }[]>([]);
+
+  // Instantiate the SDK class for the Login Email Verification screen
+  // This should be done once per component instance.
+  const [loginEmailVerificationManager] = useState(() => new LoginEmailVerification());
+  const { screen, transaction, client } = loginEmailVerificationManager;
+
+  // Effect to update UI messages based on transaction errors
+  useEffect(() => {
+    if (transaction.errors && transaction.errors.length > 0) {
+      setUiMessages(transaction.errors.map(err => ({ type: 'error', text: err.message })));
+    } else {
+      // Clear errors if there are no transaction errors.
+      // You might want to preserve success messages differently.
+      // setUiMessages([]); 
+    }
+  }, [transaction.errors]);
+
+  /**
+   * Handles the change in the code input field.
+   */
+  const handleCodeChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setCode(event.target.value);
+  };
+
+  /**
+   * Handles the submission of the verification code.
+   */
+  const handleSubmitCode = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    if (!code.trim()) {
+      setUiMessages([{ type: 'error', text: screen.texts?.noCodeError || 'Please enter a code.' }]);
+      return;
+    }
+    setIsSubmitting(true);
+    setUiMessages([]); // Clear previous messages
+
+    try {
+      const payload: ContinueWithCodeOptions = { code };
+      await loginEmailVerificationManager.continueWithCode(payload);
+      // On successful submission, Auth0 typically handles redirection.
+      // If the page reloads with errors (e.g., invalid code), the useEffect hook will update uiMessages.
+    } catch (error: any) {
+      // Handles unexpected errors (e.g., network issues during form submission)
+      setUiMessages([{ type: 'error', text: error.message || 'An unexpected error occurred. Please try again.' }]);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * Handles the request to resend the verification code.
+   */
+  const handleResendCode = async (): Promise<void> => {
+    setIsSubmitting(true);
+    setUiMessages([]); // Clear previous messages
+
+    try {
+      const payload: ResendCodeOptions = {}; // Add custom options if needed
+      await loginEmailVerificationManager.resendCode(payload);
+      // UI can show a confirmation that the code has been resent.
+      setUiMessages([{type: 'success', text: screen.texts?.codeResentMessage || 'A new verification code has been sent to your email.'}]);
+    } catch (error: any) {
+      setUiMessages([{ type: 'error', text: error.message || 'Failed to resend code. Please try again.' }]);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Extract texts for UI elements, providing default fallbacks
+  const texts = screen?.texts ?? {};
+  const title = texts.title ?? 'Verify Your Email';
+  const description = texts.description ?? `We've sent a verification code to your email address. Please enter it below to continue.`;
+  const codeLabel = texts.codeLabel ?? 'Verification Code';
+  const codePlaceholder = texts.codePlaceholder ?? 'Enter 6-digit code';
+  const continueButtonText = texts.buttonText ?? 'Continue';
+  const resendButtonText = texts.resendActionText ?? 'Resend Code';
+  const submittingText = texts.submittingText ?? 'Processing...';
+
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 p-4 antialiased">
+      <div className="w-full max-w-md bg-white rounded-xl shadow-xl p-8 space-y-6">
+        {client.logoUrl && (
+          <img 
+            src={client.logoUrl} 
+            alt={client.name || 'Client Logo'} 
+            className="mx-auto h-12 w-auto mb-6" // Adjusted size
+          />
+        )}
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900">
+            {title}
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">
+            {description}
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmitCode} className="space-y-6">
+          <div>
+            <label htmlFor="code" className="block text-sm font-medium text-gray-700">
+              {codeLabel}
+            </label>
+            <input
+              id="code"
+              name="code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              required
+              value={code}
+              onChange={handleCodeChange}
+              className="mt-1 block w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm placeholder-gray-400 
+                         focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 
+                         sm:text-sm transition duration-150 ease-in-out"
+              placeholder={codePlaceholder}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {uiMessages.length > 0 && (
+            <div className="space-y-2">
+              {uiMessages.map((msg, idx) => (
+                <div 
+                  key={idx} 
+                  role="alert"
+                  className={`p-4 rounded-md text-sm ${
+                    msg.type === 'error' ? 'bg-red-50 text-red-700 border border-red-200' : 
+                                           'bg-green-50 text-green-700 border border-green-200'
+                  }`}
+                >
+                  {msg.text}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div>
+            <button
+              type="submit"
+              disabled={isSubmitting || !code.trim()}
+              className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm 
+                         text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 
+                         focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 
+                         disabled:opacity-60 disabled:cursor-not-allowed transition duration-150 ease-in-out"
+            >
+              {isSubmitting ? submittingText : continueButtonText}
+            </button>
+          </div>
+        </form>
+
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={handleResendCode}
+            disabled={isSubmitting}
+            className="text-sm font-medium text-indigo-600 hover:text-indigo-500 
+                       disabled:opacity-60 disabled:cursor-not-allowed transition duration-150 ease-in-out"
+          >
+            {isSubmitting ? submittingText : resendButtonText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginEmailVerificationScreen;
+```
+
+## Usage Examples
+### Initialize the SDK Class
+
+First, import and instantiate the class for the screen:
+
+```jsx
+import LoginEmailVerification from '@auth0/auth0-acul-js/login-email-verification';
+
+const loginEmailVerificationManager = new LoginEmailVerification();
+
+// You can now access screen data, transaction details, etc.
+// For example, to get the page title defined in Auth0 dashboard:
+const pageTitle = loginEmailVerificationManager.screen.texts?.title;
+
+// To check for errors from a previous submission attempt:
+const errors = loginEmailVerificationManager.transaction.errors;
+if (errors && errors.length > 0) {
+  errors.forEach(err => console.log(`Error: ${err.message}`));
+}
+```
+
+### Submit Verification Code
+
+This action is used when the user enters the verification code they received and attempts to continue.
+```jsx
+import LoginEmailVerification, { ContinueWithCodeOptions } from '@auth0/auth0-acul-js/login-email-verification';
+
+const loginEmailVerificationManager = new LoginEmailVerification();
+const userEnteredCode = "123456"; // Example code from user input
+
+const payload: ContinueWithCodeOptions = {
+  code: userEnteredCode,
+  // You can add any custom options here if needed
+  // customParam: "customValue" 
+};
+
+async function submitCode() {
+  try {
+    await loginEmailVerificationManager.continueWithCode(payload);
+    // If the submission is successful and the code is valid,
+    // Auth0 will typically redirect the user to the next step in the flow.
+  } catch (error) {
+    // This catch block handles unexpected errors during the submission itself (e.g., network issues).
+    // Specific validation errors from Auth0 (like "invalid-code") will be available in
+    // `loginEmailVerificationManager.transaction.errors` after the promise resolves or the page reloads.
+    console.error('Failed to submit verification code:', error);
+  }
+}
+
+submitCode();
+```
+
+### Resend Verification Code
+
+This action is used when the user requests a new verification code to be sent to their email.
+
+```jsx
+import LoginEmailVerification, { ResendCodeOptions } from '@auth0/auth0-acul-js/login-email-verification';
+
+const loginEmailVerificationManager = new LoginEmailVerification();
+
+// Optional: Define any custom options for the resend request
+const payload: ResendCodeOptions = {
+  // customParam: "anotherCustomValue"
+};
+
+async function resendVerificationCode() {
+  try {
+    await loginEmailVerificationManager.resendCode(payload);
+    // A new code will be sent to the user's email.
+    // The UI should ideally provide feedback to the user (e.g., "A new code has been sent.").
+    // If Auth0 encounters an issue (e.g., "too-many-emails"), it will be reflected in
+    // `loginEmailVerificationManager.transaction.errors` after the page re-renders or the promise resolves.
+  } catch (error) {
+    // Handles unexpected errors during the resend request (e.g., network issues).
+    console.error('Failed to resend verification code:', error);
+  }
+}
+
+resendVerificationCode();
+```

--- a/packages/auth0-acul-js/examples/login-email-verification.md
+++ b/packages/auth0-acul-js/examples/login-email-verification.md
@@ -13,7 +13,7 @@ Below is an example of a React component for the Login Email Verification screen
 - Display of error messages from `transaction.errors`.
 
 ```tsx
-import React, { useState, useEffect, FormEvent, ChangeEvent } from 'react';
+import React, { useState, FormEvent, ChangeEvent } from 'react';
 import LoginEmailVerification, { ContinueWithCodeOptions, ResendCodeOptions } from '@auth0/auth0-acul-js/login-email-verification'; // Adjust path as necessary
 
 const LoginEmailVerificationScreen: React.FC = () => {
@@ -25,17 +25,6 @@ const LoginEmailVerificationScreen: React.FC = () => {
   // This should be done once per component instance.
   const [loginEmailVerificationManager] = useState(() => new LoginEmailVerification());
   const { screen, transaction, client } = loginEmailVerificationManager;
-
-  // Effect to update UI messages based on transaction errors
-  useEffect(() => {
-    if (transaction.errors && transaction.errors.length > 0) {
-      setUiMessages(transaction.errors.map(err => ({ type: 'error', text: err.message })));
-    } else {
-      // Clear errors if there are no transaction errors.
-      // You might want to preserve success messages differently.
-      // setUiMessages([]); 
-    }
-  }, [transaction.errors]);
 
   /**
    * Handles the change in the code input field.
@@ -140,6 +129,16 @@ const LoginEmailVerificationScreen: React.FC = () => {
             />
           </div>
 
+          {/* Display errors from the transaction object (e.g., invalid state) */}
+          {transaction.errors && transaction.errors.length > 0 && (
+            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+              {transaction.errors.map((err, index) => (
+                <p key={`tx-error-${index}`}>{err.message}</p>
+              ))}
+            </div>
+          )}
+
+          {/* Display errors/success caught during form submission */}
           {uiMessages.length > 0 && (
             <div className="space-y-2">
               {uiMessages.map((msg, idx) => (

--- a/packages/auth0-acul-js/interfaces/export/extended-types.ts
+++ b/packages/auth0-acul-js/interfaces/export/extended-types.ts
@@ -47,3 +47,4 @@ export type { ScreenMembersOnResetPasswordMfaPhoneChallenge } from '../screens/r
 export type { ScreenMembersOnMfaRecoveryCodeChallengeNewCode } from '../screens/mfa-recovery-code-challenge-new-code';
 export type { LogoutMembers } from '../screens/logout';
 export type { LogoutAbortedMembers } from '../screens/logout-aborted';
+export type { ScreenMembersOnEmailVerificationResult } from '../screens/email-verification-result';

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -58,3 +58,4 @@ export type {
 } from '../screens/reset-password-mfa-phone-challenge';
 export type { ContinueOptions as MfaRecoveryCodeChallengeNewCodeContinueOptions } from '../screens/mfa-recovery-code-challenge-new-code';
 export type { ConfirmLogoutOptions } from '../screens/logout';
+export type { ContinueWithCodeOptions as ContinueWithCodeOptionPayload, ResendCodeOptions as ResendCodeOptionsPayload } from '../screens/login-email-verification';

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -60,3 +60,5 @@ export type { MfaRecoveryCodeChallengeNewCodeMembers } from '../screens/mfa-reco
 export type { LogoutMembers } from '../screens/logout';
 export type { LogoutAbortedMembers } from '../screens/logout-aborted';
 export type { LogoutCompleteMembers } from '../screens/logout-complete';
+export type { EmailVerificationResultMembers } from '../screens/email-verification-result'; // Added new export
+export type { LoginEmailVerificationMembers } from '../screens/login-email-verification'

--- a/packages/auth0-acul-js/interfaces/screens/email-verification-result.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-verification-result.ts
@@ -1,0 +1,52 @@
+import type { BaseMembers } from '../models/base-context';
+import type { ScreenMembers } from '../models/screen';
+
+/**
+ * @interface ScreenMembersOnEmailVerificationResult
+ * @extends ScreenMembers
+ * description Defines the specific properties available on the `screen` object for the Email Verification Result screen.
+ * It includes the verification status and a link to the login page.
+ *
+ * @property {object | null} data - Screen-specific data.
+ * @property {string} data.status - The status of the email verification attempt (e.g., "success", "failure", "already_verified").
+ *
+ * @property {object | null} links - Navigation links available on this screen.
+ * @property {string} links.login - The URL to navigate to the login page.
+ */
+export interface ScreenMembersOnEmailVerificationResult extends ScreenMembers {
+  /**
+   * Screen-specific data containing the status of the email verification.
+   * @type {{ status: string; } | null}
+   */
+  data: {
+    /**
+     * The status of the email verification process.
+     * Possible values might include "success", "failure", "already_verified", etc.
+     * This status should be displayed to the user to inform them of the outcome.
+     */
+    status: string;
+  } | null;
+
+  /**
+   * Navigation links available on this screen.
+   * @type {string | null}
+   */
+  loginLink: string | null;
+}
+
+/**
+ * @interface EmailVerificationResultMembers
+ * @extends BaseMembers
+ * description Defines all accessible members (properties and methods) for the Email Verification Result screen.
+ * This screen is informational and typically does not have operations other than navigation.
+ *
+ * @property {ScreenMembersOnEmailVerificationResult} screen - Screen-specific data, including verification status and login link.
+ */
+export interface EmailVerificationResultMembers extends BaseMembers {
+  /**
+   * Provides access to the specific properties and data of the Email Verification Result screen,
+   * including the verification `status` and the `login` link.
+   * @type {ScreenMembersOnEmailVerificationResult}
+   */
+  screen: ScreenMembersOnEmailVerificationResult;
+}

--- a/packages/auth0-acul-js/interfaces/screens/index.ts
+++ b/packages/auth0-acul-js/interfaces/screens/index.ts
@@ -47,3 +47,4 @@ export * as MfaRecoveryCodeChallenge from './mfa-recovery-code-challenge';
 export * as RedeemTicket from './redeem-ticket';
 export * as ResetPasswordMfaPhoneChallenge from './reset-password-mfa-phone-challenge';
 export * as MfaRecoveryCodeChallengeNewCode from './mfa-recovery-code-challenge-new-code';
+export * as LoginEmailVerification from './login-email-verification'

--- a/packages/auth0-acul-js/interfaces/screens/login-email-verification.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-email-verification.ts
@@ -1,0 +1,133 @@
+import type { CustomOptions } from '../common';
+import type { BaseMembers } from '../models/base-context';
+
+/**
+ * @interface ContinueWithCodeOptions
+ * description Options for the `continueWithCode` method on the Login Email Verification screen.
+ * This operation is used when the user submits the verification code they received via email
+ * to proceed with the authentication flow.
+ * @extends {CustomOptions}
+ */
+export interface ContinueWithCodeOptions extends CustomOptions {
+  /**
+   * The verification code sent to the user's email. This is typically a short numeric
+   * or alphanumeric string that the user must enter into the form.
+   * @type {string}
+   * @example "123456"
+   * @example "ABCXYZ"
+   */
+  code: string;
+}
+
+/**
+ * @interface ResendCodeOptions
+ * description Options for the `resendCode` method on the Login Email Verification screen.
+ * This operation is used when the user requests a new verification code to be sent to their email,
+ * for instance, if they did not receive the initial code or if it has expired.
+ * @extends {CustomOptions}
+ */
+export interface ResendCodeOptions extends CustomOptions {}
+
+/**
+ * @interface LoginEmailVerificationMembers
+ * description Defines the members (properties and methods) available for interacting with the Login Email Verification screen.
+ * This screen is a crucial part of email verification processes, typically during login, where a user must prove
+ * ownership of an email address by providing a one-time code. The SDK facilitates submitting this code
+ * or requesting a new one.
+ *
+ * The `universal_login_context` for this screen (`window.universal_login_context`) will contain:
+ * - `client`: Information about the Auth0 application.
+ * - `organization` (optional): Details if the authentication is for a specific organization.
+ * - `prompt`: Context of the current authentication prompt (e.g., 'login').
+ * - `screen`: UI texts and general screen information. No screen-specific `data` fields are uniquely defined for `login-email-verification` beyond standard ones.
+ * - `transaction`: Details of the ongoing transaction, including state and any errors from previous attempts (e.g., "invalid-code").
+ *
+ * @extends {BaseMembers}
+ */
+export interface LoginEmailVerificationMembers extends BaseMembers {
+  /**
+   * Submits the email verification code entered by the user.
+   * This action corresponds to the user entering the code they received via email and
+   * clicking a "Continue" or "Verify" button. The SDK will then POST this code
+   * to the Auth0 `/u/login-email-verification` endpoint.
+   *
+   * If the code is valid, Auth0 will typically redirect the user to the next step in the
+   * authentication flow. If the code is invalid, expired, or another error occurs,
+   * Auth0 will usually re-render the login-email-verification screen, and the
+   * `transaction.errors` array in the SDK's context will be updated with details
+   * about the failure (e.g., error code `invalid-code`).
+   *
+   * @param {ContinueWithCodeOptions} payload - An object containing the `code` string entered by the user.
+   *                                            It can also include any `CustomOptions` for extensibility.
+   * @returns {Promise<void>} A promise that resolves when the form submission is initiated.
+   *                          It does not return data directly upon resolution, as a redirect or
+   *                          page re-render is the common outcome.
+   * @throws {Error} Throws an error if `payload.code` is not provided or is not a string,
+   *                 or if the `FormHandler` encounters an unrecoverable issue during submission (e.g., network error).
+   *                 Validation errors from Auth0 (like an invalid code) are not thrown as JavaScript errors
+   *                 but are reflected in `this.transaction.errors` after the operation.
+   *
+   * @example
+   * ```typescript
+   * // Assuming 'manager' is an instance of LoginEmailVerification
+   * const userInputCode = "123456";
+   * try {
+   *   await manager.continueWithCode({ code: userInputCode });
+   *   // If successful, page redirects. No further client-side action needed here.
+   * } catch (error) {
+   *   // This catch is for unexpected errors, not for Auth0 validation errors.
+   *   console.error("Failed to submit the verification code:", error);
+   * }
+   * // After the await, always check manager.transaction.errors for server-side validation issues.
+   * if (manager.transaction.errors && manager.transaction.errors.length > 0) {
+   *   manager.transaction.errors.forEach(err => {
+   *     if (err.code === 'invalid-code') {
+   *       // Display "The code you entered is invalid" to the user.
+   *     }
+   *   });
+   * }
+   * ```
+   */
+  continueWithCode(payload: ContinueWithCodeOptions): Promise<void>;
+
+  /**
+   * Requests a new verification code to be sent to the user's email address.
+   * This action is typically invoked when the user clicks a "Resend Code" button, perhaps because
+   * they didn't receive the first email, the code expired, or they suspect an issue.
+   * The SDK will POST to the Auth0 `/u/login-email-verification` endpoint with an action indicating
+   * a resend request.
+   *
+   * Upon successful submission of this request, Auth0 attempts to send a new email.
+   * The page may re-render. If there are issues (e.g., too many resend attempts for the same email,
+   * identified by error code `too-many-emails`), `transaction.errors` will be updated.
+   *
+   * @param {ResendCodeOptions} [payload] - Optional. An object for `CustomOptions` if any
+   *                                        additional parameters need to be sent with the request.
+   * @returns {Promise<void>} A promise that resolves when the resend request is initiated.
+   *                          Like `continueWithCode`, this usually results in a page re-render or state update
+   *                          rather than direct data in the promise resolution.
+   * @throws {Error} Throws if the `FormHandler` encounters an unrecoverable issue (e.g., network error).
+   *                 Server-side errors (like rate limits) are reflected in `this.transaction.errors`.
+   *
+   * @example
+   * ```typescript
+   * // Assuming 'manager' is an instance of LoginEmailVerification
+   * try {
+   *   await manager.resendCode();
+   *   // Optionally, update UI to inform the user a new code has been sent.
+   *   alert("A new verification code has been dispatched to your email.");
+   * } catch (error) {
+   *   console.error("Failed to request a new code:", error);
+   * }
+   * // After the await, check manager.transaction.errors for server-side issues.
+   * if (manager.transaction.errors && manager.transaction.errors.length > 0) {
+   *   manager.transaction.errors.forEach(err => {
+   *     if (err.code === 'too-many-emails') {
+   *       // Display "You have requested too many emails. Please wait a few minutes."
+   *     }
+   *   });
+   * }
+   * ```
+   */
+  resendCode(payload?: ResendCodeOptions): Promise<void>;
+}

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -255,6 +255,14 @@
     "./logout-complete": {
       "import": "./dist/screens/logout-complete/index.js",
       "types": "./dist/types/src/screens/logout-complete/index.d.ts"
+    },
+    "./email-verification-result": {
+      "import": "./dist/screens/email-verification-result/index.js",
+      "types": "./dist/types/src/screens/email-verification-result/index.d.ts"
+    },
+    "./login-email-verification": {
+      "import": "./dist/screens/login-email-verification/index.js",
+      "types": "./dist/types/src/screens/login-email-verification/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/auth0-acul-js/src/constants/enums.ts
+++ b/packages/auth0-acul-js/src/constants/enums.ts
@@ -60,4 +60,6 @@ export const ScreenIds = {
   LOGOUT: 'logout',
   LOGOUT_ABORTED: 'logout-aborted',
   LOGOUT_COMPLETE: 'logout-complete',
+  EMAIL_VERIFICATION_RESULT: 'email-verification-result',
+  LOGIN_EMAIL_VERIFICATION: 'login-email-verification',
 };

--- a/packages/auth0-acul-js/src/screens/email-verification-result/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-verification-result/index.ts
@@ -1,0 +1,73 @@
+import { ScreenIds } from '../../constants';
+import { BaseContext } from '../../models/base-context';
+
+import { ScreenOverride } from './screen-override';
+
+import type { ScreenContext } from '../../../interfaces/models/screen';
+import type {
+  EmailVerificationResultMembers,
+  ScreenMembersOnEmailVerificationResult as ScreenOptions,
+} from '../../../interfaces/screens/email-verification-result';
+
+/**
+ * @class EmailVerificationResult
+ * @extends BaseContext
+ * implements EmailVerificationResultMembers
+ * description Manages the interactions and data for the Email Verification Result screen.
+ * This screen displays the outcome of an email verification process and offers a link to login.
+ * It typically doesn't involve form submissions or complex operations from the user beyond navigation.
+ *
+ * @example
+ * ```typescript
+ * import EmailVerificationResult from '@auth0/auth0-acul-js/email-verification-result';
+ *
+ * const emailVerificationResultScreen = new EmailVerificationResult();
+ *
+ * // Access screen data
+ * const status = emailVerificationResultScreen.screen.data?.status;
+ * const loginLink = emailVerificationResultScreen.screen.loginLink;
+ *
+ * console.log(`Verification Status: ${status}`);
+ * if (loginLink) {
+ *   console.log(`Proceed to login: ${loginLink}`);
+ *   // In a UI, you would use this link for a button or anchor tag
+ *   // e.g., <a href={loginLink}>Go to Login</a>
+ * }
+ * ```
+ */
+export default class EmailVerificationResult extends BaseContext implements EmailVerificationResultMembers {
+  /**
+   * static
+   * @property {string} screenIdentifier - The unique identifier for the Email Verification Result screen.
+   * This identifier is used by `BaseContext` to ensure the correct screen class is instantiated.
+   */
+  static screenIdentifier: string = ScreenIds.EMAIL_VERIFICATION_RESULT;
+
+  /**
+   * @property {ScreenOptions} screen - Holds the specific screen data and properties for the
+   * This includes the verification status and the login link.
+   */
+  screen: ScreenOptions;
+
+  /**
+   * Initializes a new instance of the `EmailVerificationResult` class.
+   * It retrieves the screen-specific context and sets up the `screen` property
+   * @throws {Error} If the Universal Login Context is not available or if the
+   * current screen name in the context does not match `EmailVerificationResult.screenIdentifier`.
+   */
+  constructor() {
+    super(); // Calls BaseContext constructor for global context initialization and validation.
+    const screenContext = this.getContext('screen') as ScreenContext;
+    this.screen = new ScreenOverride(screenContext);
+  }
+
+  // This screen is informational. No specific operations like form submissions are defined.
+  // Users will typically navigate away using the `loginLink` provided in `this.screen.loginLink`.
+}
+
+// Export the primary class and its relevant member and options interfaces.
+export { EmailVerificationResultMembers, ScreenOptions as ScreenMembersOnEmailVerificationResult };
+
+// Re-export common interfaces and base properties for convenience.
+export * from '../../../interfaces/export/common';
+export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/email-verification-result/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/email-verification-result/screen-override.ts
@@ -1,0 +1,66 @@
+import { Screen } from '../../models/screen';
+import { getLoginLink } from '../../shared/screen';
+
+
+import type { ScreenContext } from '../../../interfaces/models/screen';
+import type { ScreenMembersOnEmailVerificationResult as OverrideOptions } from '../../../interfaces/screens/email-verification-result';
+
+/**
+ * @class ScreenOverride
+ * @extends Screen
+ * @implements OverrideOptions
+ * @description Screen-specific override for the Email Verification Result screen.
+ * This class ensures that the `data.status` and `links.login` properties are correctly
+ * typed and accessible for this particular screen.
+ */
+export class ScreenOverride extends Screen implements OverrideOptions {
+  /**
+   * Screen-specific data containing the status of the email verification.
+   * @type {{ status: string; } | null}
+   */
+  data: OverrideOptions['data'];
+
+  /**
+   * Navigation links available on this screen, specifically the login link.
+   * @type {{ login: string; } | null}
+   */
+  loginLink: OverrideOptions['loginLink'];
+
+  /**
+   * Creates an instance of ScreenOverride for the Email Verification Result screen.
+   * It initializes the `data` and `links` properties by parsing the provided `screenContext`.
+   *
+   * @param {ScreenContext} screenContext - The screen context object from the Universal Login global context,
+   * specific to the 'email-verification-result' screen.
+   */
+  constructor(screenContext: ScreenContext) {
+    super(screenContext); // Call the base Screen constructor
+    this.data = ScreenOverride.getScreenData(screenContext);
+    // The base Screen constructor already populates this.links.
+    this.loginLink = getLoginLink(screenContext);
+  }
+
+  /**
+   * @static
+   * @method getScreenData
+   * @description Extracts and transforms the screen-specific data from the provided screen context.
+   * Specifically, it retrieves the `status` of the email verification.
+   *
+   * @param {ScreenContext} screenContext - The screen context containing the raw data for the screen.
+   * @returns {OverrideOptions['data']} The structured screen data containing the `status`,
+   * or `null` if the `status` is not present or not a string in the context data.
+   */
+  static getScreenData = (screenContext: ScreenContext): OverrideOptions['data'] => {
+    const data = screenContext.data; // Access the raw data object
+
+    // Check if data exists and contains the 'status' property as a string
+    if (!data || typeof data.status !== 'string') {
+      return null; // Return null if essential data is missing or not a string
+    }
+
+    // Return the structured data object
+    return {
+      status: data.status,
+    };
+  };
+}

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -60,3 +60,5 @@ export { default as MfaRecoveryCodeChallengeNewCode } from './mfa-recovery-code-
 export { default as Logout } from './logout';
 export { default as LogoutAborted } from './logout-aborted';
 export { default as LogoutComplete } from './logout-complete';
+export { default as EmailVerificationResult } from './email-verification-result';
+export { default as LoginEmailVerification } from './login-email-verification';

--- a/packages/auth0-acul-js/src/screens/login-email-verification/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-email-verification/index.ts
@@ -1,0 +1,198 @@
+import { ScreenIds, FormActions } from '../../constants';
+import { BaseContext } from '../../models/base-context';
+import { FormHandler } from '../../utils/form-handler';
+
+import type {
+  LoginEmailVerificationMembers,
+  ContinueWithCodeOptions,
+  ResendCodeOptions,
+} from '../../../interfaces/screens/login-email-verification';
+import type { FormOptions as InternalFormOptions } from '../../../interfaces/utils/form-handler';
+
+/**
+ * @class LoginEmailVerification
+ * classdesc Manages interactions for the "login-email-verification" screen.
+ * This screen prompts the user to enter a one-time code sent to their email address
+ * to verify their identity during the login process.
+ *
+ * It provides methods to submit the entered code (`continueWithCode`) or
+ * to request a new code if the original one was not received or has expired (`resendCode`).
+ *
+ * Inherits from `BaseContext` to access shared authentication flow data like
+ * transaction state, client information, and internationalization texts.
+ *
+ * @extends {BaseContext}
+ * implements {LoginEmailVerificationMembers}
+ *
+ * @example
+ * ```typescript
+ * // How to use the LoginEmailVerification screen SDK:
+ * import LoginEmailVerification from '@auth0/auth0-acul-js/login-email-verification';
+ *
+ * // Instantiate the manager for the login email verification screen
+ * const loginEmailVerificationManager = new LoginEmailVerification();
+ *
+ * // Accessing screen-specific texts (e.g., for titles, labels, button texts)
+ * const screenTexts = loginEmailVerificationManager.screen.texts;
+ * const pageTitle = screenTexts?.title || 'Verify Your Email';
+ * const codePlaceholder = screenTexts?.codePlaceholder || 'Enter code here';
+ *
+ * // Accessing transaction errors from a previous attempt
+ * const transactionErrors = loginEmailVerificationManager.transaction.errors;
+ * if (transactionErrors && transactionErrors.length > 0) {
+ *   transactionErrors.forEach(error => {
+ *     console.error(`Error Code: ${error.code}, Message: ${error.message}`);
+ *     // Display these errors to the user appropriately.
+ *   });
+ * }
+ *
+ * // Example of handling code submission from a form
+ * async function onCodeSubmit(enteredCode: string) {
+ *   try {
+ *     await loginEmailVerificationManager.continueWithCode({ code: enteredCode });
+ *     // On successful verification, Auth0 will typically redirect the user.
+ *     // If there's a validation error (e.g., invalid code), the page will
+ *     // re-render, and `loginEmailVerificationManager.transaction.errors` will be updated.
+ *   } catch (e) {
+ *     // This catch block is for unexpected errors during submission (e.g., network issues).
+ *     console.error('An unexpected error occurred while submitting the code:', e);
+ *   }
+ * }
+ *
+ * // Example of handling a resend code request
+ * async function onResendCodeClick() {
+ *   try {
+ *     await loginEmailVerificationManager.resendCode();
+ *     // Inform the user that a new code has been sent.
+ *     // The page might re-render; check `loginEmailVerificationManager.transaction.errors`
+ *     // for issues like "too-many-emails".
+ *   } catch (e) {
+ *     console.error('An unexpected error occurred while resending the code:', e);
+ *   }
+ * }
+ * ```
+ */
+export default class LoginEmailVerification extends BaseContext implements LoginEmailVerificationMembers {
+  /**
+   * The unique identifier for the Login Email Verification screen.
+   * This static property is used by the SDK's `BaseContext` to ensure that the
+   * class is instantiated in the correct screen context.
+   * @type {string}
+   * static
+   * @readonly
+   */
+  static screenIdentifier: string = ScreenIds.LOGIN_EMAIL_VERIFICATION;
+
+  /**
+   * Creates an instance of the `LoginEmailVerification` screen manager.
+   * The constructor initializes the `BaseContext`, which involves parsing the
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * Submits the email verification code entered by the user to Auth0.
+   * This method prepares and posts the form data, including the verification code
+   * and the required `action: "default"`, to the `/u/login-email-verification` endpoint.
+   *
+   * @param {ContinueWithCodeOptions} payload - An object containing the `code` (string)
+   *                                            entered by the user. May also contain
+   *                                            other custom parameters if needed.
+   * @returns {Promise<void>} A promise that resolves once the form submission is initiated.
+   *                          Typically, a successful submission leads to a server-side redirect.
+   *                          If the code is incorrect or an error occurs, the page will
+   *                          re-render, and `this.transaction.errors` will be populated.
+   * @throws {Error} If the `payload.code` is missing or not a string. It can also
+   *                 throw if `FormHandler` encounters an issue during submission (e.g. network error).
+   *                 Auth0 validation errors (e.g. "invalid-code") are not thrown as JS errors
+   *                 but are made available in `this.transaction.errors` post-operation.
+   *
+   * @example
+   * ```typescript
+   * const manager = new LoginEmailVerification();
+   * // Assuming 'userInputCode' is a string obtained from a form input
+   * manager.continueWithCode({ code: userInputCode })
+   *   .catch(err => {
+   *     // Handle unexpected submission errors
+   *     displayGlobalError("Could not submit your code. Please try again.");
+   *   });
+   * // After the operation, check manager.transaction.errors for validation messages.
+   * ```
+   */
+  async continueWithCode(payload: ContinueWithCodeOptions): Promise<void> {
+    if (!payload || typeof payload.code !== 'string') {
+      throw new Error('The `code` property in the payload is required and must be a string.');
+    }
+
+    const formOptions: InternalFormOptions = {
+      state: this.transaction.state,
+      telemetry: [LoginEmailVerification.screenIdentifier, 'continueWithCode'],
+      route: '/u/login-email-verification', // As per OpenAPI specification
+    };
+
+    // Prepare the data to be submitted.
+    // The `action: "default"` signals the server to process the code.
+    const submitPayload = {
+      ...payload, // Includes the 'code' and any other custom options passed in.
+      action: FormActions.DEFAULT,
+    };
+
+    // Use FormHandler to submit the data.
+    await new FormHandler(formOptions).submitData<typeof submitPayload>(submitPayload);
+  }
+
+  /**
+   * Requests Auth0 to send a new verification code to the user's email address.
+   * This is typically used when the user didn't receive the original code, or it has expired.
+   * This method posts form data with `action: "resend-code"` to the
+   * `/u/login-email-verification` endpoint.
+   *
+   * @param {ResendCodeOptions} [payload] - Optional. An object for any custom parameters
+   *                                        to be sent with the resend request.
+   * @returns {Promise<void>} A promise that resolves once the resend request is initiated.
+   *                          A successful request usually means a new email is dispatched.
+   *                          The page might re-render, and `this.transaction.errors` could
+   *                          be updated if, for example, rate limits (`too-many-emails`) are hit.
+   * @throws {Error} If `FormHandler` encounters an issue (e.g. network error).
+   *                 Server-side validation errors (e.g. rate limits) are not thrown
+   *                 as JS errors but are made available in `this.transaction.errors`.
+   *
+   * @example
+   * ```typescript
+   * const manager = new LoginEmailVerification();
+   * manager.resendCode()
+   *   .then(() => {
+   *     // Inform the user that a new code has been sent.
+   *     showNotification("A new verification code is on its way!");
+   *   })
+   *   .catch(err => {
+   *     // Handle unexpected submission errors
+   *     displayGlobalError("Could not request a new code. Please try again later.");
+   *   });
+   * // After the operation, check manager.transaction.errors for specific issues.
+   * ```
+   */
+  async resendCode(payload?: ResendCodeOptions): Promise<void> {
+    const formOptions: InternalFormOptions = {
+      state: this.transaction.state,
+      telemetry: [LoginEmailVerification.screenIdentifier, 'resendCode'],
+      route: '/u/login-email-verification', // As per OpenAPI specification
+    };
+
+    // Prepare the data for resending the code.
+    // The `action: "resend-code"` signals the server to dispatch a new code.
+    const submitPayload = {
+      ...payload, // Includes any custom options passed in.
+      action: FormActions.RESEND_CODE,
+    };
+
+    // Use FormHandler to submit the data.
+    await new FormHandler(formOptions).submitData<typeof submitPayload>(submitPayload);
+  }
+}
+
+// Export all necessary types and members for this screen
+export { LoginEmailVerificationMembers, ContinueWithCodeOptions, ResendCodeOptions };
+export * from '../../../interfaces/export/common';
+export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/tests/unit/screens/email-verification-result/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-verification-result/index.test.ts
@@ -1,0 +1,125 @@
+import { ScreenIds } from '../../../../src/constants';
+import { BaseContext } from '../../../../src/models/base-context';
+import EmailVerificationResult from '../../../../src/screens/email-verification-result';
+import { ScreenOverride } from '../../../../src/screens/email-verification-result/screen-override';
+
+import type { BrandingContext } from '../../../../interfaces/models/branding';
+import type { ClientContext } from '../../../../interfaces/models/client';
+import type { OrganizationContext } from '../../../../interfaces/models/organization';
+import type { PromptContext } from '../../../../interfaces/models/prompt';
+import type { ScreenContext } from '../../../../interfaces/models/screen';
+import type { TenantContext } from '../../../../interfaces/models/tenant';
+import type { TransactionContext } from '../../../../interfaces/models/transaction';
+import type { UserContext } from '../../../../interfaces/models/user';
+
+// Mock the ScreenOverride to isolate testing of EmailVerificationResult class logic
+jest.mock('../../../../src/screens/email-verification-result/screen-override');
+
+describe('EmailVerificationResult Screen', () => {
+  let mockScreenContext: ScreenContext;
+  let mockClientContext: ClientContext;
+  let mockTransactionContext: TransactionContext;
+  let mockPromptContext: PromptContext;
+  let mockOrganizationContext: OrganizationContext | undefined;
+  let mockTenantContext: TenantContext;
+  let mockUserContext: UserContext;
+  let mockBrandingContext: BrandingContext;
+
+  const setupGlobalContext = (screenName: string, status: string, loginLink: string, orgContext?: OrganizationContext): void => {
+    mockClientContext = { id: 'client123', name: 'Test App' };
+    mockTransactionContext = { state: 'stateXYZ', locale: 'en' };
+    mockPromptContext = { name: 'login' }; // Or whatever prompt leads to this
+    mockTenantContext = { name: 'test-tenant' };
+    mockUserContext = { id: 'user-abc' };
+    mockBrandingContext = {};
+    mockOrganizationContext = orgContext;
+
+    mockScreenContext = {
+      name: screenName,
+      data: { status },
+      links: { login: loginLink },
+    };
+
+    // Set up the global universal_login_context
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'universal_login_context', {
+      value: {
+        client: mockClientContext,
+        transaction: mockTransactionContext,
+        prompt: mockPromptContext,
+        screen: mockScreenContext,
+        organization: mockOrganizationContext,
+        tenant: mockTenantContext,
+        user: mockUserContext,
+        branding: mockBrandingContext,
+        untrusted_data: {},
+      },
+      writable: true,
+    });
+  };
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+    // Reset the static context cache in BaseContext
+    (BaseContext as any).context = null;
+  });
+
+  it('should correctly set the static screenIdentifier', () => {
+    expect(EmailVerificationResult.screenIdentifier).toBe(ScreenIds.EMAIL_VERIFICATION_RESULT);
+  });
+
+  it('should instantiate correctly and set up screen property with ScreenOverride', () => {
+    setupGlobalContext(ScreenIds.EMAIL_VERIFICATION_RESULT, 'success', '/login');
+    const emailVerificationResultScreen = new EmailVerificationResult();
+
+    expect(emailVerificationResultScreen).toBeInstanceOf(EmailVerificationResult);
+    expect(emailVerificationResultScreen).toBeInstanceOf(BaseContext);
+    expect(ScreenOverride).toHaveBeenCalledWith(mockScreenContext);
+    expect(emailVerificationResultScreen.screen).toBeInstanceOf(ScreenOverride);
+  });
+
+  it('should throw an error if the screen name in context does not match screenIdentifier', () => {
+    setupGlobalContext('some-other-screen', 'failure', '/login-error');
+    expect(() => new EmailVerificationResult()).toThrow(
+      `Incorrect import: The current screen name does not match the imported screen class. Imported Screen: ${ScreenIds.EMAIL_VERIFICATION_RESULT}, Current Screen: some-other-screen`,
+    );
+  });
+
+  it('should correctly parse and expose client, transaction, prompt, and screen data via BaseContext and ScreenOverride', () => {
+    const status = 'already_verified';
+    const loginLink = '/custom-login';
+    setupGlobalContext(ScreenIds.EMAIL_VERIFICATION_RESULT, status, loginLink);
+
+    // Mock the behavior of ScreenOverride instance
+    const mockScreenOverrideInstance = {
+      name: ScreenIds.EMAIL_VERIFICATION_RESULT,
+      data: { status },
+      loginLink: loginLink,
+      // other ScreenMembers properties if needed for assertion
+    };
+    (ScreenOverride as unknown as jest.Mock).mockImplementation(() => mockScreenOverrideInstance);
+
+    const screenInstance = new EmailVerificationResult();
+
+    // Check data parsed by BaseContext
+    expect(screenInstance.client.id).toBe(mockClientContext.id);
+    expect(screenInstance.transaction.state).toBe(mockTransactionContext.state);
+    expect(screenInstance.prompt.name).toBe(mockPromptContext.name);
+
+    // Check data parsed by ScreenOverride (via the mocked instance)
+    expect(screenInstance.screen.name).toBe(ScreenIds.EMAIL_VERIFICATION_RESULT);
+    expect(screenInstance.screen.data?.status).toBe(status);
+    expect(screenInstance.screen.loginLink).toBe(loginLink);
+  });
+
+  it('should correctly parse organization when present in context', () => {
+    const orgContext = { id: 'org_123', name: 'Test Org', usage: 'allow' };
+    setupGlobalContext(ScreenIds.EMAIL_VERIFICATION_RESULT, 'success', '/login', orgContext);
+    const screenInstance = new EmailVerificationResult();
+    expect(screenInstance.organization?.id).toBe(orgContext.id);
+    expect(screenInstance.organization?.name).toBe(orgContext.name);
+  });
+
+  // Since there are no operations, no tests for operations are needed.
+});

--- a/packages/auth0-acul-js/tests/unit/screens/email-verification-result/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-verification-result/screen-override.test.ts
@@ -1,0 +1,126 @@
+import { Screen } from '../../../../src/models/screen';
+import { ScreenOverride } from '../../../../src/screens/email-verification-result/screen-override';
+
+import type { ScreenContext } from '../../../../interfaces/models/screen';
+
+describe('EmailVerificationResult ScreenOverride', () => {
+  /**
+   * Test suite for the constructor and data parsing.
+   */
+  describe('constructor and data parsing', () => {
+    it('should correctly initialize with valid screen context data', () => {
+      const screenContext: ScreenContext = {
+        name: 'email-verification-result',
+        data: {
+          status: 'success', // Example status
+        },
+        links: {
+          login: '/login-url', // Example login link
+        },
+      } as ScreenContext; // Cast to ScreenContext for test purposes
+
+      const screenOverride = new ScreenOverride(screenContext);
+
+      // Check inheritance
+      expect(screenOverride).toBeInstanceOf(Screen);
+
+      // Check parsed data
+      expect(screenOverride.data).toBeDefined();
+      expect(screenOverride.data).toEqual({
+        status: 'success',
+      });
+
+      // Check parsed links (inherited and typed)
+      expect(screenOverride.links).toBeDefined();
+      expect(screenOverride.links).toEqual({
+        login: '/login-url',
+      });
+    });
+
+    it('should return null for data.status if status is missing in screenContext.data', () => {
+      const screenContextMissingStatus: ScreenContext = {
+        name: 'email-verification-result',
+        data: {
+          // status is missing
+        },
+        links: { login: '/login-url' },
+      } as ScreenContext;
+      let screenOverride = new ScreenOverride(screenContextMissingStatus);
+      expect(screenOverride.data).toBeNull();
+
+      const screenContextInvalidStatus: ScreenContext = {
+        name: 'email-verification-result',
+        links: { login: '/login-url' },
+      } as ScreenContext;
+      screenOverride = new ScreenOverride(screenContextInvalidStatus);
+      expect(screenOverride.data).toBeNull();
+    });
+
+    it('should return null for data if screenContext.data itself is missing', () => {
+      const screenContextNoData: ScreenContext = {
+        name: 'email-verification-result',
+        // data property is missing
+        links: { login: '/login-url' },
+      } as ScreenContext;
+      const screenOverride = new ScreenOverride(screenContextNoData);
+      expect(screenOverride.data).toBeNull();
+    });
+
+    it('should correctly handle links if screenContext.links is missing or login link is absent', () => {
+      const screenContextNoLinks: ScreenContext = {
+        name: 'email-verification-result',
+        data: { status: 'failure' },
+        // links property is missing
+      } as ScreenContext;
+      let screenOverride = new ScreenOverride(screenContextNoLinks);
+      // Base Screen class initializes links to null if screenContext.links is undefined.
+      expect(screenOverride.links).toBeNull();
+
+      const screenContextNoLoginLink: ScreenContext = {
+        name: 'email-verification-result',
+        data: { status: 'failure' },
+        links: {
+          // login link is missing
+        },
+      } as ScreenContext;
+      screenOverride = new ScreenOverride(screenContextNoLoginLink);
+      // The type cast `as OverrideOptions['links']` expects `login` to be there.
+      // The base Screen would have `links` as an object, but `login` would be undefined.
+      // For strong typing, if `login` is mandatory per interface, this implies an issue with context.
+      // Here, we test how the base `Screen` populates it.
+      expect(screenOverride.loginLink).toBeNull(); // Base Screen model populates it as an empty object if links is present but login isn't
+    });
+  });
+
+  /**
+   * Test suite for the static getScreenData method.
+   */
+  describe('getScreenData static method', () => {
+    it('should extract status correctly when present and valid', () => {
+      const screenContext: ScreenContext = {
+        name: 'email-verification-result',
+        data: { status: 'already_verified' },
+      } as ScreenContext;
+      const data = ScreenOverride.getScreenData(screenContext);
+      expect(data).toEqual({ status: 'already_verified' });
+    });
+
+    it('should return null if data object is missing', () => {
+      const screenContext: ScreenContext = {
+        name: 'email-verification-result',
+        // no data property
+      } as ScreenContext;
+      const data = ScreenOverride.getScreenData(screenContext);
+      expect(data).toBeNull();
+    });
+
+    it('should return null if status property is missing in data', () => {
+      const screenContext: ScreenContext = {
+        name: 'email-verification-result',
+        data: { other_prop: 'value' }, // status missing
+      } as ScreenContext;
+      const data = ScreenOverride.getScreenData(screenContext);
+      expect(data).toBeNull();
+    });
+  });
+});

--- a/packages/auth0-acul-js/tests/unit/screens/login-email-verification/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-email-verification/index.test.ts
@@ -1,0 +1,158 @@
+import { ScreenIds, FormActions } from '../../../../src/constants';
+import { BaseContext } from '../../../../src/models/base-context';
+import LoginEmailVerification from '../../../../src/screens/login-email-verification';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
+import type { ContinueWithCodeOptions, ResendCodeOptions } from '../../../../interfaces/screens/login-email-verification';
+
+// Mock FormHandler to spy on its methods and prevent actual form submissions
+jest.mock('../../../../src/utils/form-handler');
+
+/**
+ * @group unit
+ * @group screens
+ */
+describe('LoginEmailVerification Screen SDK', () => {
+  let loginEmailVerification: LoginEmailVerification;
+  let mockFormHandlerInstance: { submitData: jest.Mock };
+  const testTransactionState = 'login-email-verification-state-123';
+  const screenName = ScreenIds.LOGIN_EMAIL_VERIFICATION;
+  const endpoint = '/u/login-email-verification';
+
+  beforeEach(() => {
+    // Clear all mocks before each test to ensure test isolation
+    jest.clearAllMocks();
+
+    // Mock the global window object and the universal_login_context
+    global.window = Object.create(window); // Ensure a clean window object
+    Object.defineProperty(window, 'universal_login_context', {
+      value: {
+        ...baseContextData, // Spread base test data
+        screen: { // Override screen-specific parts
+          ...baseContextData.screen,
+          name: screenName, // Set the correct screen name for this test suite
+        },
+        transaction: { // Override transaction-specific parts
+          ...baseContextData.transaction,
+          state: testTransactionState, // Use a defined state for predictability
+        },
+      },
+      writable: true, // Make it writable for subsequent tests if needed
+    });
+
+    // Reset the static context cache in BaseContext before each test
+    // This is crucial if BaseContext caches the context statically.
+    (BaseContext as any).context = null;
+
+    // Instantiate the class under test
+    loginEmailVerification = new LoginEmailVerification();
+
+    // Setup the mock for FormHandler instance methods
+    mockFormHandlerInstance = {
+      submitData: jest.fn().mockResolvedValue(undefined), // Default mock to resolve successfully
+    };
+    // Configure the FormHandler mock constructor to return our mock instance
+    (FormHandler as jest.Mock).mockImplementation(() => mockFormHandlerInstance);
+  });
+
+  it('should have the correct static screenIdentifier property', () => {
+    expect(LoginEmailVerification.screenIdentifier).toBe(screenName);
+  });
+
+  it('should correctly initialize and extend BaseContext', () => {
+    expect(loginEmailVerification).toBeInstanceOf(LoginEmailVerification);
+    expect(loginEmailVerification).toBeInstanceOf(BaseContext); // Verify inheritance
+    expect(loginEmailVerification.screen.name).toBe(screenName);
+    expect(loginEmailVerification.transaction.state).toBe(testTransactionState);
+  });
+
+  describe('continueWithCode method', () => {
+    const validPayload: ContinueWithCodeOptions = { code: '123456' };
+    const validPayloadWithCustomOptions: ContinueWithCodeOptions = { code: '654321', customField: 'customValue' };
+
+    it('should call FormHandler with correct state, telemetry, route, code, and default action', async () => {
+      await loginEmailVerification.continueWithCode(validPayload);
+
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: testTransactionState,
+        telemetry: [screenName, 'continueWithCode'],
+        route: endpoint,
+      });
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        code: '123456',
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should include custom options in the payload passed to FormHandler', async () => {
+      await loginEmailVerification.continueWithCode(validPayloadWithCustomOptions);
+
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        code: '654321',
+        customField: 'customValue',
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should throw an error if payload is missing', async () => {
+      // @ts-expect-error Testing invalid input for missing payload
+      await expect(loginEmailVerification.continueWithCode(undefined)).rejects.toThrow(
+        'The `code` property in the payload is required and must be a string.'
+      );
+    });
+    
+    it('should throw an error if code property is missing in payload', async () => {
+      await expect(loginEmailVerification.continueWithCode({} as ContinueWithCodeOptions)).rejects.toThrow(
+        'The `code` property in the payload is required and must be a string.'
+      );
+    });
+
+    it('should throw an error if code is not a string', async () => {
+       // @ts-expect-error Testing invalid input for code type
+      await expect(loginEmailVerification.continueWithCode({ code: 12345 })).rejects.toThrow(
+        'The `code` property in the payload is required and must be a string.'
+      );
+    });
+
+    it('should propagate errors if FormHandler.submitData rejects', async () => {
+      const submissionError = new Error('Network Error during code submission');
+      mockFormHandlerInstance.submitData.mockRejectedValue(submissionError);
+
+      await expect(loginEmailVerification.continueWithCode(validPayload)).rejects.toThrow(submissionError);
+    });
+  });
+
+  describe('resendCode method', () => {
+    const customOptionsPayload: ResendCodeOptions = { customField: 'resendCustomValue' };
+
+    it('should call FormHandler with correct state, telemetry, route, and resend-code action', async () => {
+      await loginEmailVerification.resendCode();
+
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: testTransactionState,
+        telemetry: [screenName, 'resendCode'],
+        route: endpoint,
+      });
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        action: FormActions.RESEND_CODE,
+      });
+    });
+
+    it('should include custom options in the payload for resendCode if provided', async () => {
+      await loginEmailVerification.resendCode(customOptionsPayload);
+
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        customField: 'resendCustomValue',
+        action: FormActions.RESEND_CODE,
+      });
+    });
+
+    it('should propagate errors if FormHandler.submitData rejects during resendCode', async () => {
+      const submissionError = new Error('Network Error during resend request');
+      mockFormHandlerInstance.submitData.mockRejectedValue(submissionError);
+
+      await expect(loginEmailVerification.resendCode()).rejects.toThrow(submissionError);
+    });
+  });
+});


### PR DESCRIPTION

This PR adds support for two new authentication screens to the Auth0 ACUL JS SDK:

1. **✅ Email Verification Result**: An informational screen that displays the outcome of an email verification process (success, failure, already verified) with a link to proceed to login.

2. **✅ Login Email Verification**: A functional screen that handles verification code entry during login, with support for submitting codes and requesting new ones.

## Changes
- 📝 Added TypeScript interfaces for both screens
- 🛠️ Implemented screen classes with appropriate methods
- 🧪 Added comprehensive unit tests
- 📚 Created example documentation with React/TailwindCSS implementations
- 📋 Updated README.md to include the new screens in the reference table
- 📦 Updated package.json to expose the new screens in the exports

## Testing
- ✅ Unit tests for both screens covering all functionality
- 🧪 Manual testing in development environment
