### PR TITLE
Reset password roaming challenge

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -201,6 +201,7 @@ Get up and running quickly with our boilerplate starter template: [Link](https:/
 | 69     |mfa-webauthn                    | mfa-webauthn-enrollment-success          | [Link](https://auth0.github.io/universal-login/classes/Classes.MfaWebAuthnEnrollmentSuccess.html)   |
 | 71     |mfa-webauthn                    | mfa-webauthn-change-key-nickname          | [Link](https://auth0.github.io/universal-login/classes/Classes.MfaWebAuthnChangeKeyNickname.html)   |
 | 72     |reset-password                    | reset-password-mfa-webauthn-platform-challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordMfaWebAuthnPlatformChallenge.html)                |
+| 73     |reset-password                    | Reset Password MFA WebAuthn Roaming Challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordMfaWebAuthnRoamingChallenge.html)   |
 </details>
 
 

--- a/packages/auth0-acul-js/examples/reset-password-mfa-webauthn-roaming-challenge.md
+++ b/packages/auth0-acul-js/examples/reset-password-mfa-webauthn-roaming-challenge.md
@@ -1,0 +1,303 @@
+import ResetPasswordMfaWebAuthnRoamingChallenge from '@auth0/auth0-acul-js/reset-password-mfa-webauthn-roaming-challenge';
+import type { UseSecurityKeyOptions, ShowErrorOptions, TryAnotherMethodOptions, WebAuthnErrorDetails } from '@auth0/auth0-acul-js/reset-password-mfa-webauthn-roaming-challenge';
+
+# Reset Password MFA WebAuthn Roaming Challenge Screen
+
+This screen is part of the multi-factor authentication (MFA) process during password reset, specifically when a WebAuthn roaming authenticator (like a FIDO2 security key) is required. The user will be prompted by their browser to interact with their security key.
+
+The SDK provides methods to:
+- Initiate the security key verification (`useSecurityKey`).
+- Report client-side WebAuthn API errors (`showError`).
+- Allow the user to choose a different MFA method (`tryAnotherMethod`).
+
+## React Component Example with TailwindCSS
+
+This example demonstrates a React component for the "Reset Password MFA WebAuthn Roaming Challenge" screen, styled with TailwindCSS. It allows users to trigger the security key interaction and provides options for alternative actions.
+
+```tsx
+import React, { useState, useMemo, useCallback } from 'react';
+import ResetPasswordMfaWebAuthnRoamingChallenge, {
+  type UseSecurityKeyOptions,
+  type TryAnotherMethodOptions,
+  type WebAuthnErrorDetails,
+  type ResetPasswordMfaWebAuthnRoamingChallengeMembers
+} from '@auth0/auth0-acul-js/reset-password-mfa-webauthn-roaming-challenge';
+
+const ResetPasswordMfaWebAuthnRoamingChallengeComponent: React.FC = () => {
+  // Instantiate the SDK class. Memoized to avoid re-creation on re-renders.
+  const sdk = useMemo(() => new ResetPasswordMfaWebAuthnRoamingChallenge(), []);
+
+  const { screen, transaction, client, organization }: ResetPasswordMfaWebAuthnRoamingChallengeMembers = sdk;
+  const texts = screen?.texts ?? {};
+  const publicKeyChallenge = screen?.publicKey?.challenge; // Challenge string for WebAuthn API
+
+  const [rememberDevice, setRememberDevice] = useState(false);
+
+  const handleUseSecurityKey = useCallback(async () => {
+    const opts: UseSecurityKeyOptions = {};
+    if (sdk.screen.showRememberDevice) {
+      opts.rememberDevice = rememberDevice;
+    }
+    sdk.useSecurityKey(opts);
+  }, [sdk, rememberDevice]);
+
+  const handleTryAnotherMethod = useCallback(async () => {
+    const opts: TryAnotherMethodOptions = {};
+    if (sdk.screen.showRememberDevice) {
+      opts.rememberDevice = rememberDevice;
+    }
+    sdk.tryAnotherMethod(opts);
+  }, [sdk, rememberDevice]);
+
+  // Example: Simulate a client-side error to demonstrate showError
+  const handleSimulateWebAuthnError = async () => {
+    const simulatedError: WebAuthnErrorDetails = {
+      name: "NotSupportedError",
+      message: "The browser does not support the requested WebAuthn operation on this device (simulated)."
+    };
+    sdk.showError({ error: simulatedError, rememberDevice: sdk.screen.showRememberDevice && rememberDevice });
+  };
+
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4 antialiased">
+      <div className="w-full max-w-md bg-white rounded-lg shadow-xl p-8 space-y-6">
+        {client?.logoUrl && (
+          <img src={client.logoUrl} alt={client.name ?? 'Client Logo'} className="mx-auto h-12 mb-6" />
+        )}
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-gray-800">
+            {texts.title ?? 'Verify with Security Key'}
+          </h1>
+          <p className="mt-2 text-gray-600">
+            {texts.description ?? 'Please insert your security key and follow the browser prompts to continue resetting your password.'}
+          </p>
+          {organization?.name && (
+            <p className="mt-1 text-sm text-gray-500">
+              Organization: {organization.displayName || organization.name}
+            </p>
+          )}
+           {publicKeyChallenge && (
+            <p className="mt-1 text-xs text-gray-400 break-all">
+              Challenge: {typeof publicKeyChallenge === 'string' ? publicKeyChallenge : JSON.stringify(publicKeyChallenge)}
+            </p>
+          )}
+        </div>
+
+        {/* Display transaction errors (e.g., from previous failed attempts, invalid state) */}
+        {transaction?.errors && transaction.errors.length > 0 && (
+          <div className="bg-red-50 border-l-4 border-red-400 text-red-700 p-4 rounded-md" role="alert">
+            <p className="font-bold">{texts.alertListTitle ?? 'Errors:'}</p>
+            {transaction.errors.map((err, index) => (
+              <p key={`tx-err-${index}`}>{err.message}</p>
+            ))}
+          </div>
+        )}
+
+        {/* Remember device checkbox */}
+        {sdk.screen.showRememberDevice && (
+          <div className="flex items-center">
+            <input
+              id="rememberDevice"
+              name="rememberDevice"
+              type="checkbox"
+              checked={rememberDevice}
+              onChange={(e) => setRememberDevice(e.target.checked)}
+              className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+            />
+            <label htmlFor="rememberDevice" className="ml-2 block text-sm text-gray-900">
+              {texts.rememberMeText ?? 'Remember this device for 30 days'}
+            </label>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <button
+            onClick={handleUseSecurityKey}
+            disabled={!publicKeyChallenge}
+            className="w-full flex justify-center items-center px-4 py-2.5 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors duration-150"
+          >
+            {(texts.buttonText ?? 'Use Security Key')}
+          </button>
+
+          <button
+            onClick={handleTryAnotherMethod}
+            className="w-full flex justify-center px-4 py-2.5 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors duration-150"
+          >
+            {texts.pickAuthenticatorText ?? 'Try Another Method'}
+          </button>
+
+          <button
+            onClick={handleSimulateWebAuthnError}
+            className="w-full flex justify-center px-4 py-2.5 border border-amber-500 rounded-md shadow-sm text-sm font-medium text-amber-700 bg-amber-100 hover:bg-amber-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors duration-150"
+          >
+            {texts.simulateErrorButtonText ?? 'Simulate WebAuthn Error & Report'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordMfaWebAuthnRoamingChallengeComponent;
+```
+
+## Usage Examples
+
+### Initialize the SDK Class
+
+First, import and instantiate the class for the screen:
+
+```typescript
+import ResetPasswordMfaWebAuthnRoamingChallenge from '@auth0/auth0-acul-js/reset-password-mfa-webauthn-roaming-challenge';
+
+const sdk = new ResetPasswordMfaWebAuthnRoamingChallenge();
+
+// Access screen data
+const publicKeyChallengeOptions = sdk.screen.publicKey; // Contains the challenge for navigator.credentials.get()
+const shouldShowRememberDeviceOption = sdk.screen.showRememberDevice;
+const uiTexts = sdk.screen.texts; // For UI labels, titles, button texts
+
+if (!publicKeyChallengeOptions) {
+  console.error("WebAuthn challenge options (publicKey) are not available from the server.");
+  // Handle this case, e.g., by showing an error message to the user.
+}
+```
+
+### Use Security Key (Verify Identity)
+
+This is the primary action. It triggers the browser's WebAuthn API (`navigator.credentials.get()`) using the challenge options provided by Auth0 (`sdk.screen.publicKey`). The SDK handles the API call and submits the resulting credential.
+
+```typescript
+import ResetPasswordMfaWebAuthnRoamingChallenge, {
+  type UseSecurityKeyOptions,
+  type WebAuthnErrorDetails
+} from '@auth0/auth0-acul-js/reset-password-mfa-webauthn-roaming-challenge';
+
+const sdk = new ResetPasswordMfaWebAuthnRoamingChallenge();
+
+async function verifyWithSecurityKey(userWantsToRememberDevice: boolean) {
+  if (!sdk.screen.publicKey) {
+    alert("Security key challenge options are not available.");
+    return;
+  }
+
+  const options: UseSecurityKeyOptions = {};
+  if (sdk.screen.showRememberDevice) {
+    options.rememberDevice = userWantsToRememberDevice;
+  }
+
+  try {
+    await sdk.useSecurityKey(options);
+    // On success, Auth0 handles redirection to the next step (e.g., password reset form).
+  } catch (error: any) {
+    console.error('Security key verification process failed:', error.message);
+
+    // If it's a WebAuthn API error (e.g., user cancellation, timeout), report it to Auth0 server
+    if (error.name && error.message) { // Basic check for DOMException-like error
+      try {
+        const errorToReport: WebAuthnErrorDetails = { name: error.name, message: error.message };
+        // Add other properties if relevant, e.g., error.code
+        if (error.code) errorToReport.code = error.code;
+        await sdk.showError({ error: errorToReport, rememberDevice: sdk.screen.showRememberDevice && userWantsToRememberDevice });
+        // Auth0 may redirect or update UI based on the error report.
+        // The page might re-render with specific error messages from `sdk.transaction.errors`.
+      } catch (reportError: any) {
+        console.error("Failed to report the WebAuthn browser error to Auth0:", reportError.message);
+        // Display a fallback error message if reporting also fails.
+        alert(`Verification failed: ${error.message}. Reporting this error also failed.`);
+      }
+    } else {
+      // Handle other types of errors (e.g., network issues before WebAuthn call, SDK internal errors)
+      alert(`Verification process failed: ${error.message || 'Please try again.'}`);
+    }
+    // You might also want to check `sdk.transaction.errors` if the page reloads
+    // as Auth0 might return specific errors on the transaction object.
+  }
+}
+
+// Example usage, perhaps from a button click in your UI:
+// const rememberMeCheckbox = document.getElementById('remember-me') as HTMLInputElement;
+// verifyWithSecurityKey(rememberMeCheckbox?.checked || false);
+```
+
+### Report a Client-Side WebAuthn Error
+
+If you need to manually report a WebAuthn API error that occurred (perhaps from a custom `navigator.credentials.get()` call, though `sdk.useSecurityKey()` handles this), you can use `sdk.showError()`.
+
+```typescript
+import ResetPasswordMfaWebAuthnRoamingChallenge, {
+  type ShowErrorOptions,
+  type WebAuthnErrorDetails
+} from '@auth0/auth0-acul-js/reset-password-mfa-webauthn-roaming-challenge';
+
+const sdk = new ResetPasswordMfaWebAuthnRoamingChallenge();
+
+async function handleWebAuthnApiError(errorFromWebAuthnApi: DOMException, userWantsToRememberDevice: boolean) {
+  const errorDetails: WebAuthnErrorDetails = {
+    name: errorFromWebAuthnApi.name,
+    message: errorFromWebAuthnApi.message,
+  };
+  if ('code' in errorFromWebAuthnApi && errorFromWebAuthnApi.code !== undefined) {
+    errorDetails.code = errorFromWebAuthnApi.code;
+  }
+  // You can add other relevant properties from DOMException if your WebAuthnErrorDetails interface supports them.
+
+  const options: ShowErrorOptions = {
+    error: errorDetails
+  };
+  if (sdk.screen.showRememberDevice) {
+    options.rememberDevice = userWantsToRememberDevice;
+  }
+
+  try {
+    await sdk.showError(options);
+    // Auth0 will process this error. The page might re-render with specific error messages
+    // from `sdk.transaction.errors`, or redirect to an error screen.
+  } catch (submitError: any) {
+    console.error('Failed to submit the WebAuthn error report to Auth0:', submitError.message);
+    // Handle failure to report the error - display a generic error message to the user.
+  }
+}
+
+// Example: Catching an error from a manual navigator.credentials.get() call
+// async function manualSecurityKeyAttempt(userWantsToRemember: boolean) {
+//   try {
+//     const cred = await navigator.credentials.get({ publicKey: sdk.screen.publicKey });
+//     // ... process cred and submit manually ...
+//   } catch (e) {
+//     if (e instanceof DOMException) {
+//       handleWebAuthnApiError(e, userWantsToRemember);
+//     }
+//   }
+// }
+```
+
+### Try Another MFA Method
+
+If the user cannot use their security key or wishes to use a different MFA factor:
+
+```typescript
+import ResetPasswordMfaWebAuthnRoamingChallenge, { type TryAnotherMethodOptions } from '@auth0/auth0-acul-js/reset-password-mfa-webauthn-roaming-challenge';
+
+const sdk = new ResetPasswordMfaWebAuthnRoamingChallenge();
+
+async function tryDifferentMfaMethod(userWantsToRememberDevice: boolean) {
+  const options: TryAnotherMethodOptions = {};
+  if (sdk.screen.showRememberDevice) {
+    options.rememberDevice = userWantsToRememberDevice;
+  }
+
+  try {
+    await sdk.tryAnotherMethod(options);
+    // On success, Auth0 will redirect the user to the MFA factor selection screen.
+  } catch (error: any) {
+    console.error('Failed to switch to another MFA method:', error.message);
+    // Update UI to inform the user.
+  }
+}
+
+// Example usage from a "Try another way" button in your UI:
+// const rememberMeCheckbox = document.getElementById('remember-me') as HTMLInputElement;
+// tryDifferentMfaMethod(rememberMeCheckbox?.checked || false);
+```

--- a/packages/auth0-acul-js/interfaces/export/extended-types.ts
+++ b/packages/auth0-acul-js/interfaces/export/extended-types.ts
@@ -56,5 +56,6 @@ export type { ScreenMembersOnMfaWebAuthnRoamingChallenge } from '../screens/mfa-
 export type { ScreenMembersOnMfaWebAuthnPlatformChallenge } from '../screens/mfa-webauthn-platform-challenge';
 export type { ScreenMembersOnMfaWebAuthnEnrollmentSuccess } from '../screens/mfa-webauthn-enrollment-success';
 export type { ScreenMembersOnMfaWebAuthnChangeKeyNickname } from '../screens/mfa-webauthn-change-key-nickname';
-export type { ScreenMembersOnConsent } from '../screens/consent'; 
+export type { ScreenMembersOnConsent } from '../screens/consent';
 export type { ScreenMembersOnResetPasswordMfaWebAuthnPlatformChallenge } from '../screens/reset-password-mfa-webauthn-platform-challenge';
+export type { ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge } from '../screens/reset-password-mfa-webauthn-roaming-challenge';

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -70,3 +70,8 @@ export type {
   ReportBrowserErrorOptions as ResetPasswordMfaWebAuthnPlatformChallengeReportErrorOptions,
   TryAnotherMethodOptions as ResetPasswordMfaWebAuthnPlatformChallengeTryAnotherMethodOptions,
 } from '../screens/reset-password-mfa-webauthn-platform-challenge';
+export type {
+  UseSecurityKeyOptions as ResetPasswordMfaWebAuthnRoamingChallengeUseSecurityKeyOptions,
+  ShowErrorOptions as ResetPasswordMfaWebAuthnRoamingChallengeShowErrorOptions,
+  TryAnotherMethodOptions as ResetPasswordMfaWebAuthnRoamingChallengeTryAnotherMethodOptions
+} from '../screens/reset-password-mfa-webauthn-roaming-challenge';

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -73,3 +73,4 @@ export type { MfaWebAuthnEnrollmentSuccessMembers } from '../screens/mfa-webauth
 export type { MfaWebAuthnChangeKeyNicknameMembers } from '../screens/mfa-webauthn-change-key-nickname';
 // export type { ConsentMembers } from '../screens/consent';
 export type { ResetPasswordMfaWebAuthnPlatformChallengeMembers } from '../screens/reset-password-mfa-webauthn-platform-challenge';
+export type { ResetPasswordMfaWebAuthnRoamingChallengeMembers } from '../screens/reset-password-mfa-webauthn-roaming-challenge';

--- a/packages/auth0-acul-js/interfaces/screens/index.ts
+++ b/packages/auth0-acul-js/interfaces/screens/index.ts
@@ -59,3 +59,4 @@ export * as MfaWebAuthnEnrollmentSuccess from './mfa-webauthn-enrollment-success
 export * as MfaWebAuthnChangeKeyNickname from './mfa-webauthn-change-key-nickname';
 export * as Consent from './consent';
 export * as ResetPasswordMfaWebAuthnPlatformChallenge from './reset-password-mfa-webauthn-platform-challenge';
+export * as ResetPasswordMfaWebAuthnRoamingChallenge from './reset-password-mfa-webauthn-roaming-challenge';

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-webauthn-roaming-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-webauthn-roaming-challenge.ts
@@ -1,10 +1,6 @@
 import type { CustomOptions, WebAuthnErrorDetails } from '../common';
 import type { BaseMembers } from '../models/base-context';
-import type { ClientMembers } from '../models/client';
-import type { OrganizationMembers } from '../models/organization';
-import type { PromptMembers } from '../models/prompt';
 import type { ScreenMembers, PasskeyRead } from '../models/screen';
-import type { TransactionMembers } from '../models/transaction';
 
 /**
  * @interface ScreenDataOnResetPasswordMfaWebAuthnRoamingChallenge
@@ -147,37 +143,13 @@ export interface TryAnotherMethodOptions extends CustomOptions {
  * 3. Opt to use a different authentication method (`tryAnotherMethod`).
  */
 export interface ResetPasswordMfaWebAuthnRoamingChallengeMembers extends BaseMembers {
-  /**
-   * Provides access to client-specific information (e.g., client ID, name).
-   * @type {ClientMembers}
-   */
-  client: ClientMembers;
 
   /**
-   * Provides access to organization-specific information, if applicable to the current transaction.
-   * Will be `null` or have default values if no organization context is active.
-   * @type {OrganizationMembers}
-   */
-  organization: OrganizationMembers;
-
-  /**
-   * Provides access to prompt details (e.g., prompt name, settings).
-   * @type {PromptMembers}
-   */
-  prompt: PromptMembers;
-
-  /**
-   * Access to the specific properties and data of the `reset-password-mfa-webauthn-roaming-challenge` screen,
-   * including WebAuthn `publicKey` challenge options and the `showRememberDevice` flag.
-   * @type {ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge}
-   */
+ * Access to the specific properties and data of the `reset-password-mfa-webauthn-roaming-challenge` screen,
+ * including WebAuthn `publicKey` challenge options and the `showRememberDevice` flag.
+ * @type {ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge}
+ */
   screen: ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge;
-
-  /**
-   * Provides access to the current transaction details (e.g., state, errors, locale).
-   * @type {TransactionMembers}
-   */
-  transaction: TransactionMembers;
 
   /**
    * Initiates the WebAuthn assertion process (security key challenge).

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-webauthn-roaming-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-mfa-webauthn-roaming-challenge.ts
@@ -1,0 +1,226 @@
+import type { CustomOptions, WebAuthnErrorDetails } from '../common';
+import type { BaseMembers } from '../models/base-context';
+import type { ClientMembers } from '../models/client';
+import type { OrganizationMembers } from '../models/organization';
+import type { PromptMembers } from '../models/prompt';
+import type { ScreenMembers, PasskeyRead } from '../models/screen';
+import type { TransactionMembers } from '../models/transaction';
+
+/**
+ * @interface ScreenDataOnResetPasswordMfaWebAuthnRoamingChallenge
+ * description Specific data available on the `screen.data` object for the
+ * `reset-password-mfa-webauthn-roaming-challenge` screen.
+ *
+ * @property {PasskeyRead} passkey - The WebAuthn public key credential request options (Assertion).
+ * This object contains the challenge that needs to be passed to `navigator.credentials.get()`.
+ * @property {boolean} [show_remember_device] - Optional. Indicates if the "Remember this device"
+ * option should be displayed to the user.
+ */
+export interface ScreenDataOnResetPasswordMfaWebAuthnRoamingChallenge {
+  /**
+   * The WebAuthn public key credential request options, specifically the challenge (`publicKey`)
+   * to be used with `navigator.credentials.get()`.
+   * @type {PasskeyRead}
+   */
+  passkey: PasskeyRead;
+  /**
+   * Optional. If true, the UI should offer an option to remember the current device/browser,
+   * potentially skipping MFA for a defined period on subsequent logins from the same device.
+   * @type {boolean | undefined}
+   */
+  show_remember_device?: boolean;
+}
+
+/**
+ * @interface ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge
+ * @extends ScreenMembers
+ * description Defines the specific properties available on the `screen` object for the
+ * `reset-password-mfa-webauthn-roaming-challenge` screen.
+ *
+ * @property {ScreenDataOnResetPasswordMfaWebAuthnRoamingChallenge | null} data - Screen-specific data,
+ * including WebAuthn challenge options and the "show remember device" flag.
+ * @property {PasskeyRead['public_key'] | null} publicKey - A convenience accessor for `screen.data.passkey.public_key`.
+ * Provides the challenge and related options for `navigator.credentials.get()`.
+ * @property {boolean} showRememberDevice - A convenience accessor for `screen.data.show_remember_device`.
+ * Indicates if the "Remember this device" option should be displayed. Defaults to `false` if not present.
+ */
+export interface ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge extends ScreenMembers {
+  /**
+   * A direct accessor for the `passkey.public_key` data from `screen.data`.
+   * This object contains the challenge and other options necessary for the
+   * `navigator.credentials.get()` WebAuthn API call.
+   * It is `null` if `screen.data.passkey.public_key` is not available.
+   * @type {PasskeyRead['public_key'] | null}
+   * @public
+   */
+  publicKey: PasskeyRead['public_key'] | null;
+
+  /**
+   * A direct accessor for the `show_remember_device` flag from `screen.data`.
+   * Indicates whether the UI should present an option to the user to remember this device/browser
+   * to potentially bypass MFA on future logins. Defaults to `false` if not set in `screen.data`.
+   * @type {boolean}
+   * @public
+   */
+  showRememberDevice: boolean;
+}
+
+/**
+ * @interface UseSecurityKeyOptions
+ * @extends CustomOptions
+ * description Defines the options for the `useSecurityKey` method.
+ * This is the primary action where the user attempts to verify with their security key.
+ *
+ * @property {boolean} [rememberDevice] - Optional. If `true` and `screen.showRememberDevice` is also `true`,
+ * the SDK will include `rememberBrowser=true` in the form submission, indicating the user's
+ * choice to remember this device.
+ */
+export interface UseSecurityKeyOptions extends CustomOptions {
+  /**
+   * Optional. If `true`, and if the screen context (`screen.showRememberDevice`)
+   * indicates that remembering the device is an option, this signals the user's
+   * intent to remember this browser/device for future authentications.
+   * The SDK will submit `rememberBrowser=true` in this case.
+   * @type {boolean | undefined}
+   */
+  rememberDevice?: boolean;
+}
+
+/**
+ * @interface ShowErrorOptions
+ * @extends CustomOptions
+ * description Defines the options for the `showError` method.
+ * This method is used to report a client-side WebAuthn API error to the Auth0 server.
+ *
+ * @property {WebAuthnErrorDetails} error - The error object from the WebAuthn API (`navigator.credentials.get()`)
+ * containing `name` and `message` of the DOMException.
+ * @property {boolean} [rememberDevice] - Optional. If `true` and `screen.showRememberDevice` is also `true`,
+ * the SDK will include `rememberBrowser=true` in the form submission.
+ */
+export interface ShowErrorOptions {
+  /**
+   * The error object captured from a failed `navigator.credentials.get()` call.
+   * This should include at least `name` and `message` properties of the DOMException.
+   * @type {WebAuthnErrorDetails}
+   * @example { name: "NotAllowedError", message: "The operation was aborted by the user." }
+   */
+  error: WebAuthnErrorDetails;
+
+  /**
+   * Optional. If `true`, and if the screen context (`screen.showRememberDevice`)
+   * indicates that remembering the device is an option, this signals the user's
+   * intent to remember this browser/device.
+   * @type {boolean | undefined}
+   */
+  rememberDevice?: boolean;
+}
+
+/**
+ * @interface TryAnotherMethodOptions
+ * @extends CustomOptions
+ * description Defines the options for the `tryAnotherMethod` method.
+ * Allows the user to select a different MFA method.
+ *
+ * @property {boolean} [rememberDevice] - Optional. If `true` and `screen.showRememberDevice` is also `true`,
+ * the SDK will include `rememberBrowser=true` in the form submission.
+ */
+export interface TryAnotherMethodOptions extends CustomOptions {
+  /**
+   * Optional. If `true`, and if the screen context (`screen.showRememberDevice`)
+   * indicates that remembering the device is an option, this signals the user's
+   * intent to remember this browser/device.
+   * @type {boolean | undefined}
+   */
+  rememberDevice?: boolean;
+}
+
+/**
+ * @interface ResetPasswordMfaWebAuthnRoamingChallengeMembers
+ * @extends BaseMembers
+ * description Defines all accessible members (properties and methods) for the
+ * `reset-password-mfa-webauthn-roaming-challenge` screen.
+ *
+ * This screen is part of the password reset flow requiring MFA with a WebAuthn roaming authenticator.
+ * It allows the user to:
+ * 1. Verify their identity using their security key (`useSecurityKey`).
+ * 2. Report a client-side error encountered during the WebAuthn process (`showError`).
+ * 3. Opt to use a different authentication method (`tryAnotherMethod`).
+ */
+export interface ResetPasswordMfaWebAuthnRoamingChallengeMembers extends BaseMembers {
+  /**
+   * Provides access to client-specific information (e.g., client ID, name).
+   * @type {ClientMembers}
+   */
+  client: ClientMembers;
+
+  /**
+   * Provides access to organization-specific information, if applicable to the current transaction.
+   * Will be `null` or have default values if no organization context is active.
+   * @type {OrganizationMembers}
+   */
+  organization: OrganizationMembers;
+
+  /**
+   * Provides access to prompt details (e.g., prompt name, settings).
+   * @type {PromptMembers}
+   */
+  prompt: PromptMembers;
+
+  /**
+   * Access to the specific properties and data of the `reset-password-mfa-webauthn-roaming-challenge` screen,
+   * including WebAuthn `publicKey` challenge options and the `showRememberDevice` flag.
+   * @type {ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge}
+   */
+  screen: ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge;
+
+  /**
+   * Provides access to the current transaction details (e.g., state, errors, locale).
+   * @type {TransactionMembers}
+   */
+  transaction: TransactionMembers;
+
+  /**
+   * Initiates the WebAuthn assertion process (security key challenge).
+   * This method will internally call `navigator.credentials.get()` using the challenge
+   * provided in `screen.publicKey`.
+   * On successful interaction with the security key, it submits the resulting
+   * `PublicKeyCredential` to Auth0 with `action: "default"`.
+   *
+   * @param {UseSecurityKeyOptions} [options] - Optional. Parameters for the operation,
+   * such as `rememberDevice` (if `screen.showRememberDevice` is true) and other custom options.
+   * The `response` field (the WebAuthn credential) is handled internally by the SDK.
+   * @returns {Promise<void>} A promise that resolves when the verification attempt is submitted.
+   * A successful operation typically results in a redirect by Auth0.
+   * @throws {Error} Throws an error if `screen.publicKey` is missing, if `navigator.credentials.get()`
+   * fails (e.g., user cancellation, no authenticator found), or if the form submission to Auth0 fails.
+   * It's recommended to catch these errors and potentially use `showError()` to report WebAuthn API specific issues.
+   */
+  useSecurityKey(options?: UseSecurityKeyOptions): Promise<void>;
+
+  /**
+   * Reports a client-side WebAuthn API error (from `navigator.credentials.get()`) to Auth0.
+   * This method should be used when `useSecurityKey()` (or a manual `navigator.credentials.get()` call)
+   * fails due to a browser-side WebAuthn issue (e.g., `NotAllowedError` if the user cancels the prompt,
+   * `NotFoundError` if no matching authenticator is found, or a timeout).
+   * It submits the error details with `action: "showError::{errorDetailsJsonString}"` and an empty `response`.
+   *
+   * @param {ShowErrorOptions} options - Contains the `error` object (with `name` and `message`
+   * from the WebAuthn API DOMException), an optional `rememberDevice` flag, and any other custom options.
+   * @returns {Promise<void>} A promise that resolves when the error report is submitted.
+   * Auth0 may re-render the page with error information or redirect.
+   * @throws {Error} Throws an error if the form submission fails (e.g., network error, invalid state).
+   */
+  showError(options: ShowErrorOptions): Promise<void>;
+
+  /**
+   * Allows the user to opt-out of the WebAuthn roaming challenge and select a different MFA method.
+   * This action submits `action: "pick-authenticator"` to Auth0, which should navigate
+   * the user to an MFA factor selection screen.
+   *
+   * @param {TryAnotherMethodOptions} [options] - Optional. Parameters for the operation,
+   * such as `rememberDevice` (if `screen.showRememberDevice` is true) and other custom options.
+   * @returns {Promise<void>} A promise that resolves when the 'pick-authenticator' action is submitted.
+   * @throws {Error} Throws an error if the form submission fails.
+   */
+  tryAnotherMethod(options?: TryAnotherMethodOptions): Promise<void>;
+}

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -291,6 +291,10 @@
     "./reset-password-mfa-webauthn-platform-challenge": {
       "import": "./dist/screens/reset-password-mfa-webauthn-platform-challenge/index.js",
       "types": "./dist/types/src/screens/reset-password-mfa-webauthn-platform-challenge/index.d.ts"
+    },
+    "./reset-password-mfa-webauthn-roaming-challenge": {
+      "import": "./dist/screens/reset-password-mfa-webauthn-roaming-challenge/index.js",
+      "types": "./dist/types/src/screens/reset-password-mfa-webauthn-roaming-challenge/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/auth0-acul-js/src/constants/enums.ts
+++ b/packages/auth0-acul-js/src/constants/enums.ts
@@ -73,4 +73,5 @@ export const ScreenIds = {
   MFA_WEBAUTHN_CHANGE_KEY_NICKNAME: 'mfa-webauthn-change-key-nickname',
   CONSENT: 'consent',
   RESET_PASSWORD_MFA_WEBAUTHN_PLATFORM_CHALLENGE: 'reset-password-mfa-webauthn-platform-challenge',
+  RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE: 'reset-password-mfa-webauthn-roaming-challenge', 
 };

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -73,3 +73,4 @@ export { default as MfaWebAuthnEnrollmentSuccess } from './mfa-webauthn-enrollme
 export { default as MfaWebAuthnChangeKeyNickname } from './mfa-webauthn-change-key-nickname';
 // export { default as Consent } from './consent';
 export { default as ResetPasswordMfaWebAuthnPlatformChallenge } from './reset-password-mfa-webauthn-platform-challenge';
+export { default as ResetPasswordMfaWebAuthnRoamingChallenge } from './reset-password-mfa-webauthn-roaming-challenge';

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-webauthn-roaming-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-webauthn-roaming-challenge/index.ts
@@ -1,0 +1,249 @@
+import { ScreenIds, FormActions, Errors } from '../../constants';
+import { BaseContext } from '../../models/base-context';
+import { FormHandler } from '../../utils/form-handler';
+import { getPasskeyCredentials } from '../../utils/passkeys';
+
+import { ScreenOverride } from './screen-override';
+
+import type {CustomOptions, WebAuthnErrorDetails } from '../../../interfaces/common';
+import type { ScreenContext } from '../../../interfaces/models/screen';
+import type {
+  ResetPasswordMfaWebAuthnRoamingChallengeMembers,
+  ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge as ScreenContextScreenOptions,
+  UseSecurityKeyOptions,
+  ShowErrorOptions,
+  TryAnotherMethodOptions,
+} from '../../../interfaces/screens/reset-password-mfa-webauthn-roaming-challenge';
+import type { FormOptions as SDKFormOptions } from '../../../interfaces/utils/form-handler';
+import type { PasskeyCredentialResponse } from '../../../interfaces/utils/passkeys';
+
+/**
+ * @class ResetPasswordMfaWebAuthnRoamingChallenge
+ * @extends BaseContext
+ * implements ResetPasswordMfaWebAuthnRoamingChallengeMembers
+ * description Manages interactions for the 'reset-password-mfa-webauthn-roaming-challenge' screen.
+ * This screen prompts the user to use their WebAuthn roaming authenticator (e.g., a security key)
+ * as a second factor during the password reset process. It handles:
+ * - Initiating the security key challenge via the WebAuthn API.
+ * - Submitting the successful credential assertion to Auth0.
+ * - Reporting client-side WebAuthn API errors to Auth0.
+ * - Allowing the user to try a different MFA method.
+ */
+export default class ResetPasswordMfaWebAuthnRoamingChallenge
+  extends BaseContext
+  implements ResetPasswordMfaWebAuthnRoamingChallengeMembers {
+  /**
+   * The unique identifier for this screen, used for internal SDK logic and telemetry.
+   * @type {string}
+   * static
+   * @readonly
+   */
+  static screenIdentifier: string = ScreenIds.RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE;
+
+  /**
+   * Holds the specific screen data and properties for this screen,
+   
+   * (for the WebAuthn challenge) and `showRememberDevice`.
+   * @type {ScreenContextScreenOptions}
+   * @public
+   */
+  public screen: ScreenContextScreenOptions;
+
+  /**
+   * Initializes a new instance of the `ResetPasswordMfaWebAuthnRoamingChallenge` class.
+   * It retrieves the necessary context (screen, transaction, etc.) from the global
+   * @throws {Error} If the Universal Login Context is not available or if the screen name
+   * in the context does not match `ResetPasswordMfaWebAuthnRoamingChallenge.screenIdentifier`.
+   */
+  constructor() {
+    super();
+    const screenContext = this.getContext('screen') as ScreenContext;
+    this.screen = new ScreenOverride(screenContext);
+  }
+
+  /**
+   * Initiates the WebAuthn security key challenge.
+   * This method internally calls `navigator.credentials.get()` using the challenge
+   * options provided in `this.screen.publicKey`.
+   * If the user successfully authenticates with their security key, the resulting
+   * `PublicKeyCredential` is stringified and submitted to Auth0 with `action: "default"`.
+   *
+   * @param {UseSecurityKeyOptions} [options] - Optional parameters for the operation.
+   * This can include `rememberDevice` (if `this.screen.showRememberDevice` is true) and
+   * any other custom key-value pairs to be sent in the form submission.
+   * The `response` field (the WebAuthn credential) is handled internally by this method.
+   * @returns {Promise<void>} A promise that resolves when the verification attempt is submitted.
+   * A successful operation usually results in Auth0 redirecting the user.
+   * @throws {Error} Throws an error if `this.screen.publicKey` is missing (indicating missing challenge options),
+   * if `getPasskeyCredentials` (which wraps `navigator.credentials.get()`) fails (e.g., user cancellation,
+   * no authenticator found, hardware error), or if the final form submission to Auth0 fails.
+   * It is crucial to catch errors from this method. WebAuthn API errors (like `NotAllowedError`)
+   * should be reported using {@link showError}.
+   *
+   * @example
+   * ```typescript
+   * // In your UI component for the reset-password-mfa-webauthn-roaming-challenge screen:
+   * const sdk = new ResetPasswordMfaWebAuthnRoamingChallenge();
+   *
+   * async function handleSecurityKeyAuth() {
+   *   try {
+   *     const userWantsToRemember = document.getElementById('remember-device-checkbox')?.checked || false;
+   *     await sdk.useSecurityKey({ rememberDevice: sdk.screen.showRememberDevice && userWantsToRemember });
+   *     // On success, Auth0 typically handles redirection.
+   *   } catch (err) {
+   *     console.error("Security key authentication failed:", err);
+   *     // If it's a WebAuthn API error, report it to Auth0
+   *     if (err.name && err.message) { // Basic check for DOMException-like error
+   *       try {
+   *         await sdk.showError({ error: { name: err.name, message: err.message } });
+   *       } catch (reportError) {
+   *         console.error("Failed to report WebAuthn error:", reportError);
+   *       }
+   *     }
+   *     // Update UI to inform the user, e.g., "Security key verification failed. Please try again."
+   *     // Also check `sdk.transaction.errors` if the page might have reloaded with an error message from the server.
+   *   }
+   * }
+   * ```
+   */
+  public async useSecurityKey(options?: UseSecurityKeyOptions): Promise<void> {
+    const publicKeyOpts = this.screen.publicKey;
+    
+    if (!publicKeyOpts) {
+      throw new Error(Errors.PASSKEY_PUBLIC_KEY_UNAVAILABLE);
+    }
+
+    // `getPasskeyCredentials` calls `navigator.credentials.get()` and processes the response.
+    // It will throw if `navigator.credentials.get()` fails or returns null.
+
+    const credential = (await getPasskeyCredentials(publicKeyOpts)) as PasskeyCredentialResponse | null;
+
+    if (!credential) {
+      // This case should ideally be caught by getPasskeyCredentials throwing an error
+      throw new Error(Errors.PASSKEY_CREDENTIALS_UNAVAILABLE);
+    }
+
+    const formOptions: SDKFormOptions = {
+      state: this.transaction.state,
+      telemetry: [ResetPasswordMfaWebAuthnRoamingChallenge.screenIdentifier, 'useSecurityKey'],
+      route: '/u/mfa-webauthn-challenge', // As per OpenAPI spec
+    };
+
+    const { rememberDevice, ...customSubmissionOptions } = options || {};
+    const payloadToSubmit: CustomOptions = {
+      ...customSubmissionOptions,
+      action: FormActions.DEFAULT,
+      response: JSON.stringify(credential),
+    };
+
+    if (this.screen.showRememberDevice && rememberDevice) {
+      payloadToSubmit.rememberBrowser = true;
+    }
+
+    await new FormHandler(formOptions).submitData(payloadToSubmit);
+  }
+
+  /**
+   * Reports a client-side WebAuthn API error (from `navigator.credentials.get()`) to Auth0.
+   * This method is intended to be called when {@link useSecurityKey} (or a direct call to
+   * `navigator.credentials.get()`) fails due to a standard WebAuthn API error
+   * (e.g., `NotAllowedError` if the user cancels, `NotFoundError`, `SecurityError`, timeout).
+   * It submits the error details with `action: "showError::{errorDetailsJsonString}"` and an empty `response`.
+   *
+   * @param {ShowErrorOptions} options - Contains the `error` object (with `name` and `message`
+   * from the WebAuthn API DOMException), an optional `rememberDevice` flag, and any other custom options.
+   * @returns {Promise<void>} A promise that resolves when the error report is successfully submitted.
+   * Auth0 may re-render the page with specific error messages in `this.transaction.errors` or redirect.
+   * @throws {Error} Throws an error if the form submission itself fails (e.g., network error, invalid state).
+   *
+   * @example
+   * ```typescript
+   * // In your UI, after catching an error from `sdk.useSecurityKey()` or `navigator.credentials.get()`:
+   * if (webAuthnError instanceof DOMException) {
+   *   await sdk.showError({
+   *     error: { name: webAuthnError.name, message: webAuthnError.message },
+   *     rememberDevice: userWantsToRemember // if applicable
+   *   });
+   * }
+   * ```
+   */
+  public async showError(options: ShowErrorOptions): Promise<void> {
+    const { error, rememberDevice, ...customPayload } = options;
+
+    const formOptions: SDKFormOptions = {
+      state: this.transaction.state,
+      telemetry: [ResetPasswordMfaWebAuthnRoamingChallenge.screenIdentifier, 'showError'],
+      route: '/u/mfa-webauthn-challenge', // As per OpenAPI spec
+    };
+
+    // Sanitize errorDetails for payload, including only defined properties
+    const errorDetailsForPayload: Partial<WebAuthnErrorDetails> = { name: error.name, message: error.message };
+    if (error.code !== undefined) errorDetailsForPayload.code = error.code;
+    // Add other common DOMException properties if needed and part of WebAuthnErrorDetails
+    // if (error.type !== undefined) errorDetailsForPayload.type = error.type; // Example if 'type' was added
+
+    const errorDetailsString = JSON.stringify(errorDetailsForPayload);
+
+    const payloadToSubmit: { action: string; response: string; rememberBrowser?: boolean;[key: string]: unknown } = {
+      ...customPayload,
+      action: `${FormActions.SHOW_ERROR_ACTION_PREFIX}${errorDetailsString}`,
+      response: '', // Response is empty for showError actions
+    };
+
+    if (this.screen.showRememberDevice && rememberDevice) {
+      payloadToSubmit.rememberBrowser = true;
+    }
+
+    await new FormHandler(formOptions).submitData(payloadToSubmit);
+  }
+
+  /**
+   * Allows the user to opt-out of the WebAuthn roaming authenticator challenge and select a different MFA method.
+   * This action submits `action: "pick-authenticator"` to Auth0, which should navigate
+   * the user to an MFA factor selection screen.
+   *
+   * @param {TryAnotherMethodOptions} [options] - Optional. Parameters for the operation,
+   * such as `rememberDevice` (if `this.screen.showRememberDevice` is true) and other custom options.
+   * @returns {Promise<void>} A promise that resolves when the 'pick-authenticator' action is submitted.
+   * @throws {Error} Throws an error if the form submission fails (e.g., network error, invalid state).
+   *
+   * @example
+   * ```typescript
+   * // When the user clicks a "Try Another Way" button:
+   * await sdk.tryAnotherMethod({ rememberDevice: userWantsToRemember });
+   * // Auth0 handles redirection to the MFA selection screen.
+   * ```
+   */
+  public async tryAnotherMethod(options?: TryAnotherMethodOptions): Promise<void> {
+    const formOptions: SDKFormOptions = {
+      state: this.transaction.state,
+      telemetry: [ResetPasswordMfaWebAuthnRoamingChallenge.screenIdentifier, 'tryAnotherMethod'],
+      route: '/u/mfa-webauthn-challenge', // As per OpenAPI spec
+    };
+
+    const { rememberDevice, ...customPayload } = options || {};
+    const payloadToSubmit: { action: string; rememberBrowser?: boolean;[key: string]: unknown } = {
+      ...customPayload,
+      action: FormActions.PICK_AUTHENTICATOR,
+    };
+
+    if (this.screen.showRememberDevice && rememberDevice) {
+      payloadToSubmit.rememberBrowser = true;
+    }
+
+    await new FormHandler(formOptions).submitData(payloadToSubmit);
+  }
+}
+
+// Export all necessary types and members for this screen
+export {
+  ResetPasswordMfaWebAuthnRoamingChallengeMembers,
+  ScreenContextScreenOptions as ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge,
+  UseSecurityKeyOptions,
+  ShowErrorOptions,
+  TryAnotherMethodOptions,
+  WebAuthnErrorDetails,
+  PasskeyCredentialResponse,
+};
+export * from '../../../interfaces/export/common';
+export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-webauthn-roaming-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-webauthn-roaming-challenge/index.ts
@@ -9,7 +9,7 @@ import type {CustomOptions, WebAuthnErrorDetails } from '../../../interfaces/com
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   ResetPasswordMfaWebAuthnRoamingChallengeMembers,
-  ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge as ScreenContextScreenOptions,
+  ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge as ScreenOptions,
   UseSecurityKeyOptions,
   ShowErrorOptions,
   TryAnotherMethodOptions,
@@ -44,10 +44,10 @@ export default class ResetPasswordMfaWebAuthnRoamingChallenge
    * Holds the specific screen data and properties for this screen,
    
    * (for the WebAuthn challenge) and `showRememberDevice`.
-   * @type {ScreenContextScreenOptions}
+   * @type {ScreenOptions}
    * @public
    */
-  public screen: ScreenContextScreenOptions;
+  public screen: ScreenOptions;
 
   /**
    * Initializes a new instance of the `ResetPasswordMfaWebAuthnRoamingChallenge` class.
@@ -238,7 +238,7 @@ export default class ResetPasswordMfaWebAuthnRoamingChallenge
 // Export all necessary types and members for this screen
 export {
   ResetPasswordMfaWebAuthnRoamingChallengeMembers,
-  ScreenContextScreenOptions as ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge,
+  ScreenOptions as ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge,
   UseSecurityKeyOptions,
   ShowErrorOptions,
   TryAnotherMethodOptions,

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-webauthn-roaming-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-webauthn-roaming-challenge/screen-override.ts
@@ -1,0 +1,57 @@
+import { Screen } from '../../models/screen';
+import { getPublicKey, getShowRememberDevice } from '../../shared/screen';
+
+import type { PasskeyRead, ScreenContext } from '../../../interfaces/models/screen';
+import type {
+  ScreenMembersOnResetPasswordMfaWebAuthnRoamingChallenge as OverrideOptions,
+} from '../../../interfaces/screens/reset-password-mfa-webauthn-roaming-challenge';
+
+/**
+ * @class ScreenOverride
+ * @extends Screen
+ * @implements OverrideOptions
+ * @description Provides specific data accessors for the 'reset-password-mfa-webauthn-roaming-challenge' screen context.
+ * It ensures that `passkey` (containing WebAuthn challenge options) and `show_remember_device`
+ * are correctly typed and easily accessible.
+ */
+export class ScreenOverride extends Screen implements OverrideOptions {
+
+  /**
+   * A convenience accessor for `this.data.passkey.public_key`.
+   * Provides the challenge and related options for `navigator.credentials.get()`.
+   * It is `null` if the `passkey.public_key` data is not available in the screen context.
+   * @type {PasskeyRead['public_key'] | null}
+   * @public
+   */
+  public publicKey: PasskeyRead['public_key'] | null;
+
+  /**
+   * A convenience accessor for `this.data.show_remember_device`.
+   * Indicates if the "Remember this device" option should be displayed to the user.
+   * Defaults to `false` if not present in the screen context data.
+   * @type {boolean}
+   * @public
+   */
+  public showRememberDevice: boolean;
+
+  /**
+   * Initializes a new instance of the `ScreenOverride` class for the 'reset-password-mfa-webauthn-roaming-challenge' screen.
+   * Parses the screen context to extract `passkey` data and the `show_remember_device` flag.
+   *
+   * @param {ScreenContext} screenContext - The screen context object provided by Universal Login
+   * for the 'reset-password-mfa-webauthn-roaming-challenge' screen.
+   */
+  constructor(screenContext: ScreenContext) {
+    super(screenContext); // Initialize the base Screen class
+    this.publicKey = ScreenOverride.getPublicKey(screenContext);
+    this.showRememberDevice = ScreenOverride.getShowRememberDevice(screenContext)
+  }
+
+  static getPublicKey = (screenContext: ScreenContext): OverrideOptions['publicKey'] => {
+    return getPublicKey(screenContext) as OverrideOptions['publicKey'];
+  };
+
+  static getShowRememberDevice = (screenContext: ScreenContext): boolean => {
+    return getShowRememberDevice(screenContext)
+  }
+}

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-webauthn-roaming-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-webauthn-roaming-challenge/index.test.ts
@@ -1,0 +1,166 @@
+import { ScreenIds, FormActions, Errors } from '../../../../src/constants';
+import ResetPasswordMfaWebAuthnRoamingChallenge from '../../../../src/screens/reset-password-mfa-webauthn-roaming-challenge';
+import { ScreenOverride } from '../../../../src/screens/reset-password-mfa-webauthn-roaming-challenge/screen-override';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { getPasskeyCredentials } from '../../../../src/utils/passkeys';
+import { baseContextData } from '../../../data/test-data';
+
+import type { PasskeyRead } from '../../../../interfaces/models/screen';
+import type {
+  UseSecurityKeyOptions,
+  TryAnotherMethodOptions,
+} from '../../../../interfaces/screens/reset-password-mfa-webauthn-roaming-challenge';
+import type { PasskeyCredentialResponse } from '../../../../interfaces/utils/passkeys';
+
+// Mock dependencies
+jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/passkeys');
+jest.mock('../../../../src/screens/reset-password-mfa-webauthn-roaming-challenge/screen-override');
+
+describe('ResetPasswordMfaWebAuthnRoamingChallenge SDK', () => {
+  let sdkInstance: ResetPasswordMfaWebAuthnRoamingChallenge;
+  let mockFormHandlerInstance: { submitData: jest.Mock };
+  let mockScreenOverrideInstance: Partial<ScreenOverride>;
+
+  const mockTransactionState = 'test-tx-state-rp-mfa-webauthn-roaming';
+  const mockPublicKeyChallenge: PasskeyRead['public_key'] = {
+    challenge: 'mockChallengeBase64UrlEncodedStringForPasswordResetMfa',
+    // Other potential properties like rpId, allowCredentials if part of PasskeyRead.public_key
+  };
+  const mockSuccessfulCredentialResponse: PasskeyCredentialResponse = {
+    id: 'credIdRpMfa',
+    rawId: 'rawCredIdRpMfa',
+    type: 'public-key',
+    authenticatorAttachment: 'cross-platform',
+    response: {
+      clientDataJSON: 'clientDataJSONStringRpMfa',
+      authenticatorData: 'authenticatorDataStringRpMfa',
+      signature: 'signatureStringRpMfa',
+      userHandle: 'userHandleStringRpMfa',
+    },
+    isUserVerifyingPlatformAuthenticatorAvailable: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup mock for ScreenOverride
+    mockScreenOverrideInstance = {
+      name: ScreenIds.RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE,
+      publicKey: mockPublicKeyChallenge,
+      showRememberDevice: true, // Default to true for testing rememberDevice logic
+      links: null,
+      texts: null,
+      captcha: null,
+      captchaImage: null,
+      captchaProvider: null,
+      captchaSiteKey: null,
+      isCaptchaAvailable: false,
+    };
+    (ScreenOverride as unknown as jest.Mock).mockImplementation(() => mockScreenOverrideInstance);
+
+    // Mock global context
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'universal_login_context', {
+      value: {
+        ...baseContextData,
+        screen: {
+          name: ScreenIds.RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE,
+          data: {
+            passkey: { public_key: mockPublicKeyChallenge },
+            show_remember_device: true,
+          },
+        },
+        transaction: { ...baseContextData.transaction, state: mockTransactionState },
+      },
+      writable: true,
+    });
+
+    sdkInstance = new ResetPasswordMfaWebAuthnRoamingChallenge();
+
+    // Mock FormHandler
+    mockFormHandlerInstance = { submitData: jest.fn().mockResolvedValue(undefined) };
+    (FormHandler as jest.Mock).mockImplementation(() => mockFormHandlerInstance);
+
+    // Mock getPasskeyCredentials
+    (getPasskeyCredentials as jest.Mock).mockResolvedValue(mockSuccessfulCredentialResponse);
+  });
+
+  it('should initialize correctly, setting up screen override', () => {
+    expect(sdkInstance).toBeInstanceOf(ResetPasswordMfaWebAuthnRoamingChallenge);
+    expect(sdkInstance.screen).toBe(mockScreenOverrideInstance);
+    expect(ScreenOverride).toHaveBeenCalledWith(window.universal_login_context.screen);
+  });
+
+  describe('useSecurityKey method', () => {
+    it('should call getPasskeyCredentials and submit with default action', async () => {
+      await sdkInstance.useSecurityKey();
+      expect(getPasskeyCredentials).toHaveBeenCalledWith(mockPublicKeyChallenge);
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        action: FormActions.DEFAULT,
+        response: JSON.stringify(mockSuccessfulCredentialResponse),
+        // rememberBrowser should not be included by default if options.rememberDevice is not explicitly true
+      });
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: mockTransactionState,
+        telemetry: [ScreenIds.RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE, 'useSecurityKey'],
+        route: '/u/mfa-webauthn-challenge',
+      });
+    });
+
+    it('should include rememberBrowser if options.rememberDevice is true and screen.showRememberDevice is true', async () => {
+      const options: UseSecurityKeyOptions = { rememberDevice: true };
+      await sdkInstance.useSecurityKey(options);
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rememberBrowser: true,
+        }),
+      );
+    });
+
+    it('should NOT include rememberBrowser if options.rememberDevice is true BUT screen.showRememberDevice is false', async () => {
+      mockScreenOverrideInstance.showRememberDevice = false;
+      sdkInstance = new ResetPasswordMfaWebAuthnRoamingChallenge(); // Re-initialize
+      const options: UseSecurityKeyOptions = { rememberDevice: true };
+      await sdkInstance.useSecurityKey(options);
+      expect(mockFormHandlerInstance.submitData).not.toHaveBeenCalledWith(
+        expect.objectContaining({ rememberBrowser: true }),
+      );
+    });
+
+    it('should throw an error if publicKey is missing from screen', async () => {
+      mockScreenOverrideInstance.publicKey = null;
+      sdkInstance = new ResetPasswordMfaWebAuthnRoamingChallenge(); // Re-initialize
+      await expect(sdkInstance.useSecurityKey()).rejects.toThrow(Errors.PASSKEY_PUBLIC_KEY_UNAVAILABLE);
+    });
+
+    it('should re-throw errors from getPasskeyCredentials', async () => {
+      const webauthnApiError = new DOMException('User cancelled WebAuthn', 'NotAllowedError');
+      (getPasskeyCredentials as jest.Mock).mockRejectedValueOnce(webauthnApiError);
+      await expect(sdkInstance.useSecurityKey()).rejects.toThrow(webauthnApiError);
+    });
+  });
+
+  describe('tryAnotherMethod method', () => {
+    it('should submit with pick-authenticator action', async () => {
+      await sdkInstance.tryAnotherMethod();
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        action: FormActions.PICK_AUTHENTICATOR,
+      });
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: mockTransactionState,
+        telemetry: [ScreenIds.RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE, 'tryAnotherMethod'],
+        route: '/u/mfa-webauthn-challenge',
+      });
+    });
+
+    it('should include rememberBrowser if options.rememberDevice is true and screen.showRememberDevice is true', async () => {
+      const options: TryAnotherMethodOptions = { rememberDevice: true };
+      await sdkInstance.tryAnotherMethod(options);
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ rememberBrowser: true }),
+      );
+    });
+  });
+});

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-webauthn-roaming-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-webauthn-roaming-challenge/screen-override.test.ts
@@ -1,0 +1,149 @@
+import { Screen } from '../../../../src/models/screen';
+import { ScreenOverride } from '../../../../src/screens/reset-password-mfa-webauthn-roaming-challenge/screen-override';
+import * as sharedScreen from '../../../../src/shared/screen';
+
+import type { ScreenContext, PasskeyRead } from '../../../../interfaces/models/screen';
+
+// Mock the shared utility functions
+jest.mock('../../../../src/shared/screen', () => ({
+  getPublicKey: jest.fn(),
+  getShowRememberDevice: jest.fn(),
+}));
+
+describe('ResetPasswordMfaWebAuthnRoamingChallenge ScreenOverride', () => {
+  const mockPublicKeyData: PasskeyRead['public_key'] = {
+    challenge: 'mockChallengeDataForPasswordResetMfa',
+    // Other properties if defined in PasskeyRead.public_key
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should correctly initialize with valid screen context data', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-webauthn-roaming-challenge',
+      data: {
+        passkey: { public_key: mockPublicKeyData },
+        show_remember_device: true,
+      },
+    } as ScreenContext; // Cast for test purposes
+
+    // Setup mocks for shared utility functions
+    (sharedScreen.getPublicKey as jest.Mock).mockReturnValue(mockPublicKeyData);
+    (sharedScreen.getShowRememberDevice as jest.Mock).mockReturnValue(true);
+
+    const screenOverride = new ScreenOverride(screenContext);
+
+    expect(screenOverride).toBeInstanceOf(Screen); // Check inheritance
+    expect(sharedScreen.getPublicKey).toHaveBeenCalledWith(screenContext);
+    expect(sharedScreen.getShowRememberDevice).toHaveBeenCalledWith(screenContext);
+    expect(screenOverride.publicKey).toEqual(mockPublicKeyData);
+    expect(screenOverride.showRememberDevice).toBe(true);
+  });
+
+  it('should handle show_remember_device being false', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-webauthn-roaming-challenge',
+      data: {
+        passkey: { public_key: mockPublicKeyData },
+        show_remember_device: false,
+      },
+    } as ScreenContext;
+
+    // Setup mocks
+    (sharedScreen.getPublicKey as jest.Mock).mockReturnValue(mockPublicKeyData);
+    (sharedScreen.getShowRememberDevice as jest.Mock).mockReturnValue(false);
+
+    const screenOverride = new ScreenOverride(screenContext);
+    expect(screenOverride.showRememberDevice).toBe(false);
+  });
+
+  it('should default showRememberDevice to false if show_remember_device is undefined in context', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-webauthn-roaming-challenge',
+      data: {
+        passkey: { public_key: mockPublicKeyData },
+        // show_remember_device is omitted
+      },
+    } as ScreenContext;
+
+    // Setup mocks
+    (sharedScreen.getPublicKey as jest.Mock).mockReturnValue(mockPublicKeyData);
+    (sharedScreen.getShowRememberDevice as jest.Mock).mockReturnValue(false); // Default behavior
+
+    const screenOverride = new ScreenOverride(screenContext);
+    expect(screenOverride.showRememberDevice).toBe(false);
+  });
+
+  it('should set publicKey to null if passkey data is missing', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-webauthn-roaming-challenge',
+      data: {
+        show_remember_device: true,
+        // passkey property is missing
+      },
+    } as ScreenContext;
+
+    // Setup mocks
+    (sharedScreen.getPublicKey as jest.Mock).mockReturnValue(null);
+    (sharedScreen.getShowRememberDevice as jest.Mock).mockReturnValue(true);
+
+    const screenOverride = new ScreenOverride(screenContext);
+    expect(screenOverride.publicKey).toBeNull();
+  });
+
+  it('should set publicKey to null if passkey.public_key is missing', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-webauthn-roaming-challenge',
+      data: {
+        show_remember_device: true,
+        passkey: {} as PasskeyRead, // public_key is missing inside passkey
+      },
+    } as ScreenContext;
+
+    // Setup mocks
+    (sharedScreen.getPublicKey as jest.Mock).mockReturnValue(null);
+    (sharedScreen.getShowRememberDevice as jest.Mock).mockReturnValue(true);
+
+    const screenOverride = new ScreenOverride(screenContext);
+    expect(screenOverride.publicKey).toBeNull();
+  });
+
+  it('should handle when screenContext.data is undefined', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-webauthn-roaming-challenge',
+      data: undefined,
+    } as ScreenContext;
+
+    // Setup mocks
+    (sharedScreen.getPublicKey as jest.Mock).mockReturnValue(null);
+    (sharedScreen.getShowRememberDevice as jest.Mock).mockReturnValue(false);
+
+    const screenOverride = new ScreenOverride(screenContext);
+    expect(screenOverride.publicKey).toBeNull();
+    expect(screenOverride.showRememberDevice).toBe(false);
+  });
+
+  describe('static methods', () => {
+    it('should call getPublicKey from shared/screen', () => {
+      const screenContext: ScreenContext = {
+        name: 'test-screen',
+        data: { passkey: { public_key: mockPublicKeyData } },
+      } as ScreenContext;
+
+      ScreenOverride.getPublicKey(screenContext);
+      expect(sharedScreen.getPublicKey).toHaveBeenCalledWith(screenContext);
+    });
+
+    it('should call getShowRememberDevice from shared/screen', () => {
+      const screenContext: ScreenContext = {
+        name: 'test-screen',
+        data: { show_remember_device: true },
+      } as ScreenContext;
+
+      ScreenOverride.getShowRememberDevice(screenContext);
+      expect(sharedScreen.getShowRememberDevice).toHaveBeenCalledWith(screenContext);
+    });
+  });
+});


### PR DESCRIPTION
- implements ResetPasswordMfaWebAuthnPlatformChallengeMembers
- description Manages interactions for the 'reset-password-mfa-webauthn-platform-challenge' screen.
- This screen is part of the password reset flow and requires the user to verify their identity
- using a WebAuthn platform authenticator (e.g., Touch ID, Windows Hello) as a second factor.