### PR TITLE
Enhance MFA Screens & Standardize Form Submissions

### DIFF
--- a/packages/auth0-acul-js/examples/mfa-enroll-result.md
+++ b/packages/auth0-acul-js/examples/mfa-enroll-result.md
@@ -11,40 +11,144 @@ import MfaEnrollResult from '@auth0/auth0-acul-js/mfa-enroll-result';
 const MfaEnrollResultScreen: React.FC = () => {
   const mfaEnrollResult = new MfaEnrollResult();
   const { screen } = mfaEnrollResult;
+  
+  // Determine message and styling based on enrollment status
+  let title = screen.texts?.title ?? 'MFA Enrollment';
+  console.log(screen)
+  let description = screen.texts?.description ?? 'Your multi-factor authentication status.';
+  let iconComponent = null;
+  let textColorClass = 'text-gray-900';
+  let iconColorClass = 'text-gray-500';
+  
+  // Use data.status to determine the enrollment result
+  const enrollmentStatus = screen.data?.status;
+  
+  if (enrollmentStatus === 'success') {
+    title = screen.texts?.titleSuccess ?? 'MFA Enrollment Complete';
+    description = screen.texts?.descriptionSuccess ?? 'Your multi-factor authentication has been successfully set up.';
+    textColorClass = 'text-green-700';
+    iconColorClass = 'text-green-500';
+    iconComponent = (
+      <svg
+        className={`h-12 w-12 ${iconColorClass}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 13l4 4L19 7"
+        />
+      </svg>
+    );
+  } else if (enrollmentStatus === 'failure') {
+    title = screen.texts?.titleFailure ?? 'MFA Enrollment Failed';
+    description = screen.texts?.descriptionFailure ?? 'There was a problem setting up your multi-factor authentication.';
+    textColorClass = 'text-red-700';
+    iconColorClass = 'text-red-500';
+    iconComponent = (
+      <svg
+        className={`h-12 w-12 ${iconColorClass}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    );
+  } else if (enrollmentStatus === 'already-enrolled') {
+    title = screen.texts?.titleAlreadyEnrolled ?? 'Already Enrolled';
+    description = screen.texts?.alreadyEnrolledDescription ?? 'Two-factor Verification has Already Been Enabled.';
+    textColorClass = 'text-blue-700';
+    iconColorClass = 'text-blue-500';
+    iconComponent = (
+      <svg
+        className={`h-12 w-12 ${iconColorClass}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    );
+  } else if (enrollmentStatus === 'already-used') {
+    title = screen.texts?.alreadyUsedTitle ?? 'Already Used';
+    description = screen.texts?.alreadyUsedDescription ?? 'This link has already been used. Please get a new link to enroll with Multi-factor Authentication.';
+    textColorClass = 'text-orange-700';
+    iconColorClass = 'text-orange-500';
+    iconComponent = (
+      <svg
+        className={`h-12 w-12 ${iconColorClass}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    );
+  } else {
+    // Default or unknown status
+    iconComponent = (
+      <svg
+        className={`h-12 w-12 ${iconColorClass}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-          { screen.texts?.title ?? 'MFA Enrollment Complete' }
+        <h2 className={`mt-6 text-center text-3xl font-extrabold ${textColorClass}`}>
+          {title}
         </h2>
         <p className="mt-2 text-center text-sm text-gray-600">
-          { screen.texts?.description ?? 'Your multi-factor authentication has been successfully set up.' }
+          {description}
         </p>
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <div className="flex items-center justify-center">
-            <svg
-              className="h-12 w-12 text-green-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
+            {iconComponent}
           </div>
           
           <div className="mt-6 text-center">
             <p className="text-sm text-gray-500">
-              { screen.texts?.enrolledDescription ?? 'You have successfully enrolled in multi-factor authentication.' }
+              {screen.texts?.badgeAltText && (
+                <span className="block mt-2">{screen.texts.badgeAltText}</span>
+              )}
             </p>
           </div>
         </div>
@@ -54,4 +158,4 @@ const MfaEnrollResultScreen: React.FC = () => {
 };
 
 export default MfaEnrollResultScreen;
-```
+````

--- a/packages/auth0-acul-js/examples/mfa-push-enrollment-qr.md
+++ b/packages/auth0-acul-js/examples/mfa-push-enrollment-qr.md
@@ -13,13 +13,25 @@ import MfaPushEnrollmentQr from '@auth0/auth0-acul-js/mfa-push-enrollment-qr';
 const MfaPushEnrollmentQrScreen: React.FC = () => {
   const mfaPushEnrollmentQr = new MfaPushEnrollmentQr();
   const { screen } = mfaPushEnrollmentQr;
-  const { qr_code } = screen.data || {};
+  const { qr_code, qr_uri, show_code_copy } = screen.data || {};
 
   const handlePickAuthenticator = async () => {
     try {
       await mfaPushEnrollmentQr.pickAuthenticator();
     } catch (error) {
       console.error('Failed to pick authenticator:', error);
+    }
+  };
+
+  const handleCopyCode = () => {
+    if (qr_uri) {
+      navigator.clipboard.writeText(qr_uri)
+        .then(() => {
+          alert('Code copied to clipboard');
+        })
+        .catch((error) => {
+          console.error('Failed to copy code:', error);
+        });
     }
   };
 
@@ -32,6 +44,24 @@ const MfaPushEnrollmentQrScreen: React.FC = () => {
           qr_code ? (
             <div className="mb-4">
               <img src={qr_code} alt="QR Code" className="mb-4 mx-auto" />
+              
+              {show_code_copy && qr_uri && (
+                <div className="text-center mb-4">
+                  <p className="text-sm text-gray-600 mb-2">Or copy this code to your authenticator app:</p>
+                  <div className="flex items-center justify-center">
+                    <code className="bg-gray-100 p-2 rounded mr-2 text-xs overflow-hidden text-ellipsis max-w-xs">
+                      {qr_uri}
+                    </code>
+                    <button
+                      onClick={handleCopyCode}
+                      className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm py-1 px-2 rounded"
+                      aria-label="Copy code"
+                    >
+                      Copy
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           ) : (
             <p>Loading QR Code...</p>

--- a/packages/auth0-acul-js/examples/mfa-webauthn-change-key-nickname.md
+++ b/packages/auth0-acul-js/examples/mfa-webauthn-change-key-nickname.md
@@ -27,6 +27,7 @@ const MfaWebAuthnChangeKeyNicknameComponent: React.FC = () => {
   const sdk = useMemo(() => new MfaWebAuthnChangeKeyNickname(), []);
 
   const { client, screen, transaction } = sdk;
+
   const currentNickname = screen.data?.nickname ?? 'Unknown Key';
   const texts = screen.texts ?? {};
 
@@ -58,7 +59,7 @@ const MfaWebAuthnChangeKeyNicknameComponent: React.FC = () => {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-6">
           <div>
             <label htmlFor="current-nickname" className="block text-sm font-medium text-gray-700">
               {texts.currentNicknameLabel ?? 'Current Nickname'}
@@ -107,7 +108,7 @@ const MfaWebAuthnChangeKeyNicknameComponent: React.FC = () => {
           )}
 
           <button
-            type="submit"
+            onClick={handleSubmit}
             className="w-full flex justify-center items-center px-4 py-2.5 border border-transparent 
                        rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 
                        focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 
@@ -115,7 +116,7 @@ const MfaWebAuthnChangeKeyNicknameComponent: React.FC = () => {
           >
             Save Nickname
           </button>
-        </form>
+        </div>
       </div>
     </div>
   );

--- a/packages/auth0-acul-js/interfaces/export/extended-types.ts
+++ b/packages/auth0-acul-js/interfaces/export/extended-types.ts
@@ -22,6 +22,7 @@ export type { ScreenMembersOnLogin, TransactionMembersOnLogin } from '../screens
 export type { ScreenMembersOnMfaPushEnrollmentQr } from '../screens/mfa-push-enrollment-qr';
 export type { SelectMfaPushDeviceOptions } from '../screens/mfa-push-list';
 export type { ScreenMembersOnMfaPushWelcome } from '../screens/mfa-push-welcome';
+export type { ScreenMembersOnMfaEnrollResult } from '../screens/mfa-enroll-result';
 export type { ScreenMembersOnMfaSmsEnrollment } from '../screens/mfa-sms-enrollment';
 export type { ScreenMembersOnMfaSmsChallenge, UntrustedDataMembersOnMfaSmsChallenge } from '../screens/mfa-sms-challenge';
 export type { ScreenMembersOnMfaCountryCodes } from '../screens/mfa-country-codes';

--- a/packages/auth0-acul-js/interfaces/screens/mfa-enroll-result.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-enroll-result.ts
@@ -1,12 +1,56 @@
-import type { BaseContext, BaseMembers } from '../models/base-context';
+import type { BaseMembers } from '../models/base-context';
+import type { ScreenMembers } from '../models/screen';
 
 /**
- * Interface representing the MFA enrollment result screen.
- * This screen is shown after a successful MFA enrollment process.
+ * @interface ScreenMembersOnMfaEnrollResult
+ * @extends ScreenMembers
+ * description Defines the specific properties available on the `screen` object for the
+ * 'mfa-enroll-result' screen. This screen is typically shown after an MFA enrollment process.
+ *
+ * @property {object | null} data - Screen-specific data.
+ * @property {string} data.status - The status of the MFA enrollment attempt (e.g., "success", "failure").
  */
-export interface MfaEnrollResult extends BaseContext {}
+export interface ScreenMembersOnMfaEnrollResult extends ScreenMembers {
+  /**
+   * Screen-specific data containing the status of the MFA enrollment.
+   * @type {{ status: string; } | null}
+   */
+  data: {
+    /**
+     * The status of the MFA enrollment process.
+     * Possible values might include "success", "failure", or other specific status codes.
+     * This status can be used to display an appropriate message to the user.
+     * @type {string}
+     */
+    status: string;
+  } | null;
+}
 
 /**
- * Interface defining the available methods and properties for the MFA enrollment result screen.
+ * @interface MfaEnrollResultMembers
+ * @extends BaseMembers
+ * description Defines all accessible members (properties and methods) for the MFA Enroll Result screen.
+ * This screen is informational and typically confirms the outcome of an MFA enrollment.
+ *
+ * The `universal_login_context` for this screen will include:
+ * - `client`: Information about the Auth0 application.
+ * - `organization` (optional): Details if the enrollment is for a specific organization.
+ * - `prompt`: Context of the current authentication prompt.
+ * - `screen`: UI texts, and screen-specific data such as `status` (in `screen.data.status`).
+ * - `transaction`: Details of the ongoing transaction.
+ * - `user`: Information about the user.
+ *
+ * @property {ScreenMembersOnMfaEnrollResult} screen - Screen-specific data, including enrollment status.
  */
-export interface MfaEnrollResultMembers extends BaseMembers {}
+export interface MfaEnrollResultMembers extends BaseMembers {
+  /**
+   * Provides access to the specific properties and data of the MFA Enroll Result screen,
+   * including the enrollment `status` (via `screen.data.status`).
+   * @type {ScreenMembersOnMfaEnrollResult}
+   */
+  screen: ScreenMembersOnMfaEnrollResult;
+
+  // No specific operations (methods) are typically defined for this screen as it's informational.
+  // The user might be automatically redirected or provided a button to continue,
+  // which would usually be a simple navigation handled by the page template or a default action.
+}

--- a/packages/auth0-acul-js/interfaces/screens/mfa-push-enrollment-qr.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-push-enrollment-qr.ts
@@ -8,6 +8,8 @@ import type { ScreenMembers } from '../models/screen';
 export interface ScreenMembersOnMfaPushEnrollmentQr extends ScreenMembers {
   data: {
     qr_code: string;
+    qr_uri: string;
+    show_code_copy: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/src/screens/consent/index.ts
+++ b/packages/auth0-acul-js/src/screens/consent/index.ts
@@ -52,11 +52,9 @@ export default class Consent extends BaseContext implements ConsentMembers {
    *                 but are made available in `this.transaction.errors` after the operation.
    */
   async accept(payload?: CustomOptions): Promise<void> {
-    const route = `/u/consent?state=${this.transaction.state}`;
     const formOptions: SDKFormOptions = {
       state: this.transaction.state, // For form body
-      telemetry: [Consent.screenIdentifier, 'accept'],
-      route: route, // For form action URL
+      telemetry: [Consent.screenIdentifier, 'accept']
     };
 
     const submitPayload = {
@@ -82,11 +80,9 @@ export default class Consent extends BaseContext implements ConsentMembers {
    *                 Server-side validation errors are reflected in `this.transaction.errors`.
    */
   async deny(payload?: CustomOptions): Promise<void> {
-    const route = `/u/consent?state=${this.transaction.state}`;
     const formOptions: SDKFormOptions = {
       state: this.transaction.state, // For form body
-      telemetry: [Consent.screenIdentifier, 'deny'],
-      route: route, // For form action URL
+      telemetry: [Consent.screenIdentifier, 'deny']
     };
 
     const submitPayload = {

--- a/packages/auth0-acul-js/src/screens/login-email-verification/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-email-verification/index.ts
@@ -127,8 +127,7 @@ export default class LoginEmailVerification extends BaseContext implements Login
 
     const formOptions: InternalFormOptions = {
       state: this.transaction.state,
-      telemetry: [LoginEmailVerification.screenIdentifier, 'continueWithCode'],
-      route: '/u/login-email-verification', // As per OpenAPI specification
+      telemetry: [LoginEmailVerification.screenIdentifier, 'continueWithCode']
     };
 
     // Prepare the data to be submitted.
@@ -176,8 +175,7 @@ export default class LoginEmailVerification extends BaseContext implements Login
   async resendCode(payload?: ResendCodeOptions): Promise<void> {
     const formOptions: InternalFormOptions = {
       state: this.transaction.state,
-      telemetry: [LoginEmailVerification.screenIdentifier, 'resendCode'],
-      route: '/u/login-email-verification', // As per OpenAPI specification
+      telemetry: [LoginEmailVerification.screenIdentifier, 'resendCode']
     };
 
     // Prepare the data for resending the code.

--- a/packages/auth0-acul-js/src/screens/mfa-enroll-result/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-enroll-result/index.ts
@@ -1,23 +1,80 @@
 import { ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 
-import type { MfaEnrollResultMembers } from '../../../interfaces/screens/mfa-enroll-result';
+import { ScreenOverride } from './screen-override';
+
+import type { ScreenContext } from '../../../interfaces/models/screen';
+import type {
+  MfaEnrollResultMembers,
+  ScreenMembersOnMfaEnrollResult as ScreenOptions,
+} from '../../../interfaces/screens/mfa-enroll-result';
 
 /**
- * Class implementing the MFA enrollment result screen functionality.
- * This screen is displayed after successful MFA enrollment to show the result.
+ * @class MfaEnrollResult
+ * @extends BaseContext
+ * implements MfaEnrollResultMembers
+ * description Manages the interactions and data for the MFA Enroll Result screen.
+ * This screen displays the outcome of an MFA enrollment process.
+ * It is primarily informational.
+ *
+ * @example
+ * ```typescript
+ * import MfaEnrollResult from '@auth0/auth0-acul-js/mfa-enroll-result';
+ *
+ * const mfaEnrollResultScreen = new MfaEnrollResult();
+ *
+ * // Access screen data
+ * const enrollmentStatus = mfaEnrollResultScreen.screen.data?.status;
+ * const pageTitle = mfaEnrollResultScreen.screen.texts?.title;
+ *
+ * console.log(`MFA Enrollment Status: ${enrollmentStatus}`);
+ * console.log(`Page Title: ${pageTitle}`);
+ * ```
  */
 export default class MfaEnrollResult extends BaseContext implements MfaEnrollResultMembers {
+  /**
+   * static
+   * @property {string} screenIdentifier - The unique identifier for the MFA Enroll Result screen.
+   */
   static screenIdentifier: string = ScreenIds.MFA_ENROLL_RESULT;
 
   /**
+   * @property {ScreenOptions} screen - Holds the specific screen data and properties for the
+   * MFA Enroll Result screen, including the enrollment `status`.
+   * @public
+   */
+  public screen: ScreenOptions;
+
+  /**
    * Creates an instance of MfaEnrollResult screen manager.
+   * It initializes the `BaseContext` and sets up the `screen` property
+   * with an instance of `ScreenOverride` tailored for this screen.
+   * @throws {Error} If the Universal Login Context is not available or if the
+   * current screen name in the context does not match `MfaEnrollResult.screenIdentifier`.
    */
   constructor() {
-    super();
+    super(); // Calls BaseContext constructor for global context initialization and validation.
+    const screenContext = this.getContext('screen') as ScreenContext;
+    this.screen = new ScreenOverride(screenContext);
   }
+
+  // This screen is typically informational.
+  // If there's a "Continue" button, it would likely be a default action.
+  // For example, if a `continue()` method was needed:
+  /*
+  async continue(payload?: CustomOptions): Promise<void> {
+    const formOptions: SDKFormOptions = {
+      state: this.transaction.state,
+      telemetry: [MfaEnrollResult.screenIdentifier, 'continue'],
+      route: '/u/mfa-enroll-result', // Assuming this is the endpoint
+    };
+    await new FormHandler(formOptions).submitData({ ...payload, action: FormActions.DEFAULT });
+  }
+  */
 }
 
-export { MfaEnrollResultMembers };
+// Export the primary class and its relevant member and options interfaces.
+export { MfaEnrollResultMembers, ScreenOptions as ScreenMembersOnMfaEnrollResult };
+// Re-export common interfaces and base properties for convenience.
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-enroll-result/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-enroll-result/screen-override.ts
@@ -1,0 +1,55 @@
+import { Screen } from '../../models/screen';
+
+import type { ScreenContext } from '../../../interfaces/models/screen';
+import type { ScreenMembersOnMfaEnrollResult as OverrideOptions } from '../../../interfaces/screens/mfa-enroll-result';
+
+/**
+ * @class ScreenOverride
+ * @extends Screen
+ * @implements OverrideOptions
+ * @description Screen-specific override for the MFA Enroll Result screen ('mfa-enroll-result').
+ * This class ensures that the `screen.data.status` property is correctly parsed and typed
+ * according to the {@link ScreenMembersOnMfaEnrollResult} interface.
+ */
+export class ScreenOverride extends Screen implements OverrideOptions {
+  /**
+   * Screen-specific data containing the status of the MFA enrollment.
+   * @type {{ status: string; } | null}
+   * @public
+   */
+  public data: OverrideOptions['data'];
+
+  /**
+   * Creates an instance of ScreenOverride for the MFA Enroll Result screen.
+   * It initializes the `data` (specifically `status`) by parsing the provided `screenContext`.
+   *
+   * @param {ScreenContext} screenContext - The screen context object from the Universal Login global context,
+   * specific to the 'mfa-enroll-result' screen.
+   */
+  constructor(screenContext: ScreenContext) {
+    super(screenContext); // Call the base Screen constructor
+    this.data = ScreenOverride.getScreenData(screenContext);
+  }
+
+  /**
+   * @static
+   * @method getScreenData
+   * @description Extracts and transforms the screen-specific data from the provided screen context.
+   * Specifically, it retrieves the `status` of the MFA enrollment.
+   *
+   * @param {ScreenContext} screenContext - The screen context containing the raw data for the screen.
+   * @returns {OverrideOptions['data']} The structured screen data containing the `status`,
+   * or `null` if the `status` is not present or not a string in the context data.
+   */
+  static getScreenData = (screenContext: ScreenContext): OverrideOptions['data'] => {
+    const data = screenContext.data; // Access the raw data object
+    // Check if data exists and contains the 'status' property as a string
+    if (!data || typeof data.status !== 'string') {
+      return null; // Return null if essential data is missing or not a string
+    }
+    // Return the structured data object
+    return {
+      status: data.status,
+    };
+  };
+}

--- a/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/screen-override.ts
@@ -27,6 +27,8 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       qr_code: typeof data.qr_code === 'string' ? data.qr_code : '',
+      qr_uri: typeof data.qr_uri === 'string' ? data.qr_uri : '',
+      show_code_copy: !!data.show_code_copy
     };
   };
 }

--- a/packages/auth0-acul-js/src/screens/mfa-recovery-code-challenge-new-code/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-recovery-code-challenge-new-code/index.ts
@@ -73,8 +73,7 @@ export default class MfaRecoveryCodeChallengeNewCode extends BaseContext impleme
     // Prepare options for the FormHandler, including state and telemetry
     const formHandlerOptions: FormOptions = {
       state: this.transaction.state,
-      telemetry: [MfaRecoveryCodeChallengeNewCode.screenIdentifier, 'continue'],
-      route: '/u/mfa-recovery-code-challenge-new-code', // Explicitly set the route
+      telemetry: [MfaRecoveryCodeChallengeNewCode.screenIdentifier, 'continue']
     };
 
     // Construct the data payload for the form submission

--- a/packages/auth0-acul-js/src/screens/mfa-webauthn-change-key-nickname/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-webauthn-change-key-nickname/index.ts
@@ -62,8 +62,7 @@ export default class MfaWebAuthnChangeKeyNickname extends BaseContext implements
 
     const formOptions: SDKFormOptions = {
       state: this.transaction.state,
-      telemetry: [MfaWebAuthnChangeKeyNickname.screenIdentifier, 'continueWithNewNickname'],
-      route: '/u/mfa-webauthn-change-key-nickname',
+      telemetry: [MfaWebAuthnChangeKeyNickname.screenIdentifier, 'continueWithNewNickname']
     };
 
     // Prepare the data to be submitted.

--- a/packages/auth0-acul-js/src/screens/mfa-webauthn-enrollment-success/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-webauthn-enrollment-success/index.ts
@@ -82,8 +82,7 @@ export default class MfaWebAuthnEnrollmentSuccess extends BaseContext implements
   async continue(payload?: ContinueOptions): Promise<void> {
     const formOptions: SDKFormOptions = {
       state: this.transaction.state,
-      telemetry: [MfaWebAuthnEnrollmentSuccess.screenIdentifier, 'continue'],
-      route: '/u/mfa-webauthn-enrollment-success', // Endpoint for this screen
+      telemetry: [MfaWebAuthnEnrollmentSuccess.screenIdentifier, 'continue']
     };
 
     // The payload for this action is simple, primarily just the action itself.

--- a/packages/auth0-acul-js/src/screens/mfa-webauthn-not-available-error/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-webauthn-not-available-error/index.ts
@@ -59,12 +59,6 @@ export default class MfaWebAuthnNotAvailableError extends BaseContext implements
     const formOptions: SDKFormOptions = {
       state: this.transaction.state,
       telemetry: [MfaWebAuthnNotAvailableError.screenIdentifier, 'tryAnotherMethod'],
-      // The OpenAPI spec path is /u/mfa-webauthn-enrollment.
-      // If this is a common endpoint for multiple WebAuthn related POSTs, we set it.
-      // Otherwise, FormHandler's default behavior of using window.location.pathname is usually correct for UL.
-      // Given the title "Mfa-webauthn-not-available-error screen API", if the path is specific for this screen,
-      // it should ideally be /u/mfa-webauthn-not-available-error.
-      // For now, we'll assume the provided OpenAPI path is correct for this action.
       route: '/u/mfa-webauthn-enrollment', // As per provided OpenAPI spec
     };
     await new FormHandler(formOptions).submitData<CustomOptions>({

--- a/packages/auth0-acul-js/src/screens/mfa-webauthn-platform-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-webauthn-platform-challenge/index.ts
@@ -89,8 +89,7 @@ export default class MfaWebAuthnPlatformChallenge extends BaseContext implements
 
     const formOptions: SDKFormOptions = {
       state: this.transaction.state,
-      telemetry: [MfaWebAuthnPlatformChallenge.screenIdentifier, 'verify'],
-      route: '/u/mfa-webauthn-platform-challenge', // Endpoint for this screen
+      telemetry: [MfaWebAuthnPlatformChallenge.screenIdentifier, 'verify']
     };
 
     const { rememberDevice, ...customSubmissionOptions } = options || {};
@@ -123,8 +122,7 @@ export default class MfaWebAuthnPlatformChallenge extends BaseContext implements
 
     const formOptions: SDKFormOptions = {
       state: this.transaction.state,
-      telemetry: [MfaWebAuthnPlatformChallenge.screenIdentifier, 'reportBrowserError'],
-      route: '/u/mfa-webauthn-platform-challenge',
+      telemetry: [MfaWebAuthnPlatformChallenge.screenIdentifier, 'reportBrowserError']
     };
 
     // Sanitize errorDetails to include only known and safe properties if necessary,
@@ -150,8 +148,7 @@ export default class MfaWebAuthnPlatformChallenge extends BaseContext implements
   async tryAnotherMethod(options?: TryAnotherMethodOptions): Promise<void> {
     const formOptions: SDKFormOptions = {
       state: this.transaction.state,
-      telemetry: [MfaWebAuthnPlatformChallenge.screenIdentifier, 'tryAnotherMethod'],
-      route: '/u/mfa-webauthn-platform-challenge',
+      telemetry: [MfaWebAuthnPlatformChallenge.screenIdentifier, 'tryAnotherMethod']
     };
 
     await new FormHandler(formOptions).submitData({

--- a/packages/auth0-acul-js/tests/unit/screens/consent/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/consent/index.test.ts
@@ -79,15 +79,12 @@ describe('Consent Screen SDK', () => {
   });
 
   describe('accept method', () => {
-    const route = `/u/consent?state=${mockTransactionState}`;
-
     it('should call FormHandler with "accept" action, correct route, and transaction state', async () => {
       await consentInstance.accept();
 
       expect(FormHandler).toHaveBeenCalledWith({
         state: mockTransactionState,
-        telemetry: [ScreenIds.CONSENT, 'accept'],
-        route: route,
+        telemetry: [ScreenIds.CONSENT, 'accept']
       });
       expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
         action: FormActions.ACCEPT,
@@ -113,15 +110,12 @@ describe('Consent Screen SDK', () => {
   });
 
   describe('deny method', () => {
-    const route = `/u/consent?state=${mockTransactionState}`;
-
     it('should call FormHandler with "deny" action, correct route, and transaction state', async () => {
       await consentInstance.deny();
 
       expect(FormHandler).toHaveBeenCalledWith({
         state: mockTransactionState,
-        telemetry: [ScreenIds.CONSENT, 'deny'],
-        route: route,
+        telemetry: [ScreenIds.CONSENT, 'deny']
       });
       expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
         action: FormActions.DENY,

--- a/packages/auth0-acul-js/tests/unit/screens/login-email-verification/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-email-verification/index.test.ts
@@ -76,8 +76,7 @@ describe('LoginEmailVerification Screen SDK', () => {
 
       expect(FormHandler).toHaveBeenCalledWith({
         state: testTransactionState,
-        telemetry: [screenName, 'continueWithCode'],
-        route: endpoint,
+        telemetry: [screenName, 'continueWithCode']
       });
       expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
         code: '123456',
@@ -131,8 +130,7 @@ describe('LoginEmailVerification Screen SDK', () => {
 
       expect(FormHandler).toHaveBeenCalledWith({
         state: testTransactionState,
-        telemetry: [screenName, 'resendCode'],
-        route: endpoint,
+        telemetry: [screenName, 'resendCode']
       });
       expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
         action: FormActions.RESEND_CODE,

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-push-enrollment-qr/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-push-enrollment-qr/screen-override.test.ts
@@ -11,6 +11,8 @@ describe('ScreenOverride', () => {
       name: 'mfa-push-enrollment-qr',
       data: {
         qr_code: 'base64-encoded-qr-code',
+        qr_uri: 'qr-uri',
+        show_code_copy: true
       },
     } as ScreenContext;
 
@@ -20,6 +22,8 @@ describe('ScreenOverride', () => {
   it('should initialize data correctly', () => {
     expect(screenOverride.data).toEqual({
       qr_code: 'base64-encoded-qr-code',
+      qr_uri: 'qr-uri',
+      show_code_copy: true
     });
   });
 
@@ -33,6 +37,8 @@ describe('ScreenOverride', () => {
     const result = ScreenOverride.getScreenData(screenContext);
     expect(result).toEqual({
       qr_code: 'base64-encoded-qr-code',
+      qr_uri: 'qr-uri',
+      show_code_copy: true
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-recovery-code-challenge-new-code/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-recovery-code-challenge-new-code/index.test.ts
@@ -61,8 +61,7 @@ describe('MfaRecoveryCodeChallengeNewCode', () => {
       // Verify FormHandler constructor options
       expect(FormHandler).toHaveBeenCalledWith({
         state: testState,
-        telemetry: [screenName, 'continue'],
-        route: '/u/mfa-recovery-code-challenge-new-code',
+        telemetry: [screenName, 'continue']
       });
 
       // Verify submitData payload
@@ -80,8 +79,7 @@ describe('MfaRecoveryCodeChallengeNewCode', () => {
       // Verify FormHandler constructor options
       expect(FormHandler).toHaveBeenCalledWith({
         state: testState,
-        telemetry: [screenName, 'continue'],
-        route: '/u/mfa-recovery-code-challenge-new-code',
+        telemetry: [screenName, 'continue']
       });
 
       // Verify submitData payload

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-change-key-nickname/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-change-key-nickname/index.test.ts
@@ -72,8 +72,7 @@ describe('MfaWebAuthnChangeKeyNickname SDK', () => {
 
       expect(FormHandler).toHaveBeenCalledWith({
         state: mockTransactionState,
-        telemetry: [ScreenIds.MFA_WEBAUTHN_CHANGE_KEY_NICKNAME, 'continueWithNewNickname'],
-        route: '/u/mfa-webauthn-change-key-nickname',
+        telemetry: [ScreenIds.MFA_WEBAUTHN_CHANGE_KEY_NICKNAME, 'continueWithNewNickname']
       });
       expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
         nickname: validNewNickname,

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-enrollment-success/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-enrollment-success/index.test.ts
@@ -76,8 +76,7 @@ describe('MfaWebAuthnEnrollmentSuccess SDK', () => {
 
       expect(FormHandler).toHaveBeenCalledWith({
         state: mockTransactionState,
-        telemetry: [ScreenIds.MFA_WEBAUTHN_ENROLLMENT_SUCCESS, 'continue'],
-        route: '/u/mfa-webauthn-enrollment-success',
+        telemetry: [ScreenIds.MFA_WEBAUTHN_ENROLLMENT_SUCCESS, 'continue']
       });
       expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
         action: FormActions.DEFAULT,

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-platform-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-platform-challenge/index.test.ts
@@ -119,8 +119,7 @@ describe('MfaWebAuthnPlatformChallenge SDK', () => {
       });
       expect(FormHandler).toHaveBeenCalledWith({
         state: mockTransactionState,
-        telemetry: [ScreenIds.MFA_WEBAUTHN_PLATFORM_CHALLENGE, 'verify'],
-        route: '/u/mfa-webauthn-platform-challenge',
+        telemetry: [ScreenIds.MFA_WEBAUTHN_PLATFORM_CHALLENGE, 'verify']
       });
     });
 
@@ -177,8 +176,7 @@ describe('MfaWebAuthnPlatformChallenge SDK', () => {
       });
       expect(FormHandler).toHaveBeenCalledWith({
         state: mockTransactionState,
-        telemetry: [ScreenIds.MFA_WEBAUTHN_PLATFORM_CHALLENGE, 'reportBrowserError'],
-        route: '/u/mfa-webauthn-platform-challenge',
+        telemetry: [ScreenIds.MFA_WEBAUTHN_PLATFORM_CHALLENGE, 'reportBrowserError']
       });
     });
   });
@@ -193,8 +191,7 @@ describe('MfaWebAuthnPlatformChallenge SDK', () => {
       });
       expect(FormHandler).toHaveBeenCalledWith({
         state: mockTransactionState,
-        telemetry: [ScreenIds.MFA_WEBAUTHN_PLATFORM_CHALLENGE, 'tryAnotherMethod'],
-        route: '/u/mfa-webauthn-platform-challenge',
+        telemetry: [ScreenIds.MFA_WEBAUTHN_PLATFORM_CHALLENGE, 'tryAnotherMethod']
       });
     });
 


### PR DESCRIPTION
This PR improves the MFA enrollment result and push QR screens, and standardizes form submission logic across several SDK screen classes.

**Key Changes:**

1.  **`mfa-enroll-result` Screen:**
    *   Example (`.md`) now dynamically shows status-specific titles, descriptions, icons, and colors (success, failure, already-enrolled, already-used).
    *   New `MfaEnrollResult` SDK class and interfaces provide structured access to `screen.data.status`.

2.  **`mfa-push-enrollment-qr` Screen:**
    *   Example (`.md`) now optionally displays `qr_uri` with a "Copy" button if `show_code_copy` is true.
    *   Interface and `ScreenOverride` updated for `qr_uri` and `show_code_copy`.

3.  **Standardized SDK Form Submission:**
    *   Removed explicit `route` property from `FormHandler` calls in various SDK screen classes (e.g., `Consent`, `LoginEmailVerification`, `MfaWebAuthn...`).
    *   Forms now rely on `FormHandler`'s default URL determination (typically `window.location.pathname`), aligning with Universal Login behavior.

4.  **Minor UI Tweak:** `mfa-webauthn-change-key-nickname.md` example uses a `div` and `onClick` instead of a form for submission.

**Testing:**
*   Unit tests updated for `FormHandler` changes and new screen data properties.
*   Example pages serve as visual/functional tests.