### PR TITLE
Update: Add support for consent screen

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -201,7 +201,8 @@ Get up and running quickly with our boilerplate starter template: [Link](https:/
 | 69     |mfa-webauthn                    | mfa-webauthn-enrollment-success          | [Link](https://auth0.github.io/universal-login/classes/Classes.MfaWebAuthnEnrollmentSuccess.html)   |
 | 70     |mfa-webauthn                    | mfa-webauthn-change-key-nickname          | [Link](https://auth0.github.io/universal-login/classes/Classes.MfaWebAuthnChangeKeyNickname.html)   |
 | 71     |reset-password                    | reset-password-mfa-webauthn-platform-challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordMfaWebAuthnPlatformChallenge.html)                |
-| 72     |reset-password                    | Reset Password MFA WebAuthn Roaming Challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordMfaWebAuthnRoamingChallenge.html)   |
+| 72     |reset-password                    | reset-password-mfa-webauthn-roaming-challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordMfaWebAuthnRoamingChallenge.html)   |
+| 73     |consent                   | consent | [Link](https://auth0.github.io/universal-login/classes/Classes.consent.html)   |
 </details>
 
 

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -41,7 +41,7 @@ export type { ResetPasswordMfaOtpChallengeMembers } from '../screens/reset-passw
 export type { OrganizationSelectionMembers } from '../screens/organization-selection';
 export type { OrganizationPickerMembers } from '../screens/organization-picker';
 export type { AcceptInvitationMembers } from '../screens/accept-invitation';
-// export type { CustomizedConsentMembers } from '../screens/customized-consent';
+export type { CustomizedConsentMembers } from '../screens/customized-consent';
 export type { MfaPhoneEnrollmentMembers } from '../screens/mfa-phone-enrollment';
 export type { MfaVoiceEnrollmentMembers } from '../screens/mfa-voice-enrollment';
 export type { MfaRecoveryCodeChallengeMembers } from '../screens/mfa-recovery-code-challenge';
@@ -71,6 +71,6 @@ export type { MfaWebAuthnRoamingChallengeMembers } from '../screens/mfa-webauthn
 export type { MfaWebAuthnPlatformChallengeMembers } from '../screens/mfa-webauthn-platform-challenge';
 export type { MfaWebAuthnEnrollmentSuccessMembers } from '../screens/mfa-webauthn-enrollment-success';
 export type { MfaWebAuthnChangeKeyNicknameMembers } from '../screens/mfa-webauthn-change-key-nickname';
-// export type { ConsentMembers } from '../screens/consent';
+export type { ConsentMembers } from '../screens/consent';
 export type { ResetPasswordMfaWebAuthnPlatformChallengeMembers } from '../screens/reset-password-mfa-webauthn-platform-challenge';
 export type { ResetPasswordMfaWebAuthnRoamingChallengeMembers } from '../screens/reset-password-mfa-webauthn-roaming-challenge';

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -176,6 +176,10 @@
       "import": "./dist/screens/organization-picker/index.js",
       "types": "./dist/types/src/screens/organization-picker/index.d.ts"
     },
+    "./consent": {
+      "import": "./dist/screens/consent/index.js",
+      "types": "./dist/types/src/screens/consent/index.d.ts"
+    },
     "./accept-invitation": {
       "import": "./dist/screens/accept-invitation/index.js",
       "types": "./dist/types/src/screens/accept-invitation/index.d.ts"

--- a/packages/auth0-acul-js/src/screens/consent/index.ts
+++ b/packages/auth0-acul-js/src/screens/consent/index.ts
@@ -50,6 +50,19 @@ export default class Consent extends BaseContext implements ConsentMembers {
    *                 during submission (e.g., network error). Server-side validation errors
    *                 from Auth0 (like "invalid_request") are not thrown as JavaScript errors
    *                 but are made available in `this.transaction.errors` after the operation.
+   * @example
+   * ```typescript
+   * import Consent from '@auth0/auth0-acul-js/consent';
+   * const consentManager = new Consent();
+   * const handleAccept = async () => {
+   *  try {
+   *    await consentManager.accept();
+   *    console.log('Consent accepted successfully.');
+   *  } catch (err) {
+   *    console.error('Error accepting consent:', err);
+   *  }
+   * };
+   * ```
    */
   async accept(payload?: CustomOptions): Promise<void> {
     const formOptions: SDKFormOptions = {
@@ -78,6 +91,18 @@ export default class Consent extends BaseContext implements ConsentMembers {
    *                          A successful submission usually results in a server-side redirect.
    * @throws {Error} Throws an error if `FormHandler` encounters an issue (e.g., network error).
    *                 Server-side validation errors are reflected in `this.transaction.errors`.
+   * @example
+   * ```typescript
+   * import Consent from '@auth0/auth0-acul-js/consent';
+   * const consentManager = new Consent();
+   * const handleDeny = async () => {
+   *  try {
+   *    await consentManager.deny();
+   *    console.log('Form denied successfully.');
+   *  } catch (err) {
+   *    console.error('Failed to deny form:', error);
+   *  }
+   * };
    */
   async deny(payload?: CustomOptions): Promise<void> {
     const formOptions: SDKFormOptions = {

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -71,6 +71,6 @@ export { default as MfaWebAuthnRoamingChallenge } from './mfa-webauthn-roaming-c
 export { default as MfaWebAuthnPlatformChallenge } from './mfa-webauthn-platform-challenge';
 export { default as MfaWebAuthnEnrollmentSuccess } from './mfa-webauthn-enrollment-success';
 export { default as MfaWebAuthnChangeKeyNickname } from './mfa-webauthn-change-key-nickname';
-// export { default as Consent } from './consent';
+export { default as Consent } from './consent';
 export { default as ResetPasswordMfaWebAuthnPlatformChallenge } from './reset-password-mfa-webauthn-platform-challenge';
 export { default as ResetPasswordMfaWebAuthnRoamingChallenge } from './reset-password-mfa-webauthn-roaming-challenge';


### PR DESCRIPTION
### Description
As part of this PR, we verified the generated consent screen code, added the necessary exports, updated the screen documentation with examples of events required for the consent screen, and also revised the main README for the universal-login project.

### Testing
- Verified the generated docs for consent screen.
- Performed manual testing for both the required events - deny and accept for consent screen and testes end to end workflow.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
