### PR TITLE
Refactor: rename SocialSignup to FederatedSignup and update related m…

### DIFF
--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -37,7 +37,7 @@ It allows to signup new users via different identifiers
      connection : socialConnection[0].name, // "google-oauth2"
     };
     
-    signupIdManager.socialSignup(signupParams);
+    signupIdManager.federatedSignup(signupParams);
    
 ```
 

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -7,7 +7,7 @@ export type { AbortEnrollmentOptions } from '../screens/passkey-enrollment-local
 export type { EmailChallengeOptions } from '../screens/email-identifier-challenge';
 export type { PhoneChallengeOptions } from '../screens/phone-identifier-challenge';
 export type { PhoneEnrollmentOptions } from '../screens/phone-identifier-enrollment';
-export type { SignupOptions, SocialSignupOptions } from '../screens/signup-id';
+export type { SignupOptions, FederatedSignupOptions } from '../screens/signup-id';
 export type { SignupPasswordOptions } from '../screens/signup-password';
 export type { LoginOptions as LoginPayloadOptions, SocialLoginOptions as SocialLoginPayloadOptions } from '../screens/login';
 export type { SignupOptions as SignupPayloadOptions, SocialSignupOptions as SocialSignupPayloadOptions } from '../screens/signup';

--- a/packages/auth0-acul-js/interfaces/screens/signup-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-id.ts
@@ -35,7 +35,7 @@ export interface SignupId extends BaseContext {
   untrusted_data?: ExtendedUntrustedDataContext;
 }
 
-export interface SocialSignupOptions {
+export interface FederatedSignupOptions {
   connection: string;
   [key: string]: string | number | boolean;
 }
@@ -52,5 +52,5 @@ export interface SignupIdMembers {
   screen: ScreenMembersOnSignupId;
   transaction: TransactionMembersOnSignupId;
   signup(payload: SignupOptions): Promise<void>;
-  socialSignup(payload: SocialSignupOptions): Promise<void>;
+  federatedSignup(payload: FederatedSignupOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -12,7 +12,7 @@ import type {
   ScreenMembersOnSignupId as ScreenOptions,
   TransactionMembersOnSignupId as TransactionOptions,
   SignupOptions,
-  SocialSignupOptions,
+  FederatedSignupOptions,
 } from '../../../interfaces/screens/signup-id';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
@@ -91,21 +91,21 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
    *  connection : socialConnection[0].name, // "google-oauth2"
    * };
    *
-   * signupIdManager.socialSignup(signupParams);
+   * signupIdManager.federatedSignup(signupParams);
    */
-  async socialSignup(payload: SocialSignupOptions): Promise<void> {
+  async federatedSignup(payload: FederatedSignupOptions): Promise<void> {
     const options: FormOptions = {
       state: this.transaction.state,
       telemetry: [SignupId.screenIdentifier, 'socialSignup'],
     };
-    await new FormHandler(options).submitData<SocialSignupOptions>(payload);
+    await new FormHandler(options).submitData<FederatedSignupOptions>(payload);
   }
 }
 
 export {
   SignupIdMembers,
   SignupOptions,
-  SocialSignupOptions,
+  FederatedSignupOptions,
   ScreenOptions as ScreenMembersOnSignupId,
   TransactionOptions as TransactionMembersOnSignupId,
 };

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
@@ -4,7 +4,7 @@ import { FormHandler } from '../../../../src/utils/form-handler';
 import { ScreenIds } from '../../../../src/constants';
 import {
   SignupOptions,
-  SocialSignupOptions,
+  FederatedSignupOptions,
 } from 'interfaces/screens/signup-id';
 
 jest.mock('../../../../src/utils/form-handler');
@@ -98,10 +98,10 @@ describe('SignupId', () => {
 
   describe('Social Signup method', () => {
     it('should handle social signup with valid credentials correctly', async () => {
-      const payload: SocialSignupOptions = {
+      const payload: FederatedSignupOptions = {
         connection: 'testConnection',
       };
-      await signupId.socialSignup(payload);
+      await signupId.federatedSignup(payload);
 
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
@@ -111,10 +111,10 @@ describe('SignupId', () => {
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      const payload: SocialSignupOptions = {
+      const payload: FederatedSignupOptions = {
         connection: 'testConnection',
       };
-      await expect(signupId.socialSignup(payload)).rejects.toThrow(
+      await expect(signupId.federatedSignup(payload)).rejects.toThrow(
         'Mocked reject'
       );
     });


### PR DESCRIPTION
### Summary  
This PR renames the `socialSignup` type and related methods to `federatedSignup` across the codebase for improved clarity and consistency. It also renames the `SocialLogin` component to `FederatedLogin`.

---

### What’s Changed  
- Rename `socialSignup` type to `federatedSignup`  
- Update all method names related to `socialSignup` accordingly  
- Rename `SocialLogin` component to `FederatedLogin`

---

### Why  
Explain the reasoning behind this change.  
Example:  
The term “federated signup” better reflects the authentication flow and aligns terminology across the project.

---

### Impact  
Describe any effects this change has on the codebase or functionality.  
Example:  
- No functional or behavioral changes  
- Purely refactoring/renaming for clarity

---

### Testing  
Describe how this change was tested or validated.  
Example:  
- Verified all tests pass successfully 
---