### PR TITLE
Refactor: rename SocialLogin to FederatedLogin and update related

### DIFF
--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -14,7 +14,7 @@ loginIdManager.login({
 ```
 
 
-## socialLogin
+## federatedLogin
 If there is an associated social connection, below snippet can help login with selected social connection
 
 ```typescript
@@ -33,7 +33,7 @@ const selectedConnection = alternateConnections[0];
 console.log(`Selected connection: ${selectedConnection.name}`);
 
 // Proceed with federated login using the selected connection
-loginIdManager.socialLogin({
+loginIdManager.federatedLogin({
   connection: selectedConnection.name,
 })
 

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -1,4 +1,4 @@
-export type { LoginOptions, SocialLoginOptions } from '../screens/login-id';
+export type { LoginOptions, FederatedLoginOptions } from '../screens/login-id';
 export type { LoginPasswordOptions } from '../screens/login-password';
 export type { SubmitCodeOptions } from '../screens/login-passwordless-email-code';
 export type { SubmitOTPOptions } from '../screens/login-passwordless-sms-otp';

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -49,7 +49,7 @@ export interface LoginOptions {
   [key: string]: string | number | boolean | undefined;
 }
 
-export interface SocialLoginOptions {
+export interface FederatedLoginOptions {
   connection: string;
   [key: string]: string | number | boolean;
 }
@@ -57,7 +57,7 @@ export interface SocialLoginOptions {
 export interface LoginIdMembers extends BaseMembers {
   screen: ScreenMembersOnLoginId;
   login(payload: LoginOptions): Promise<void>;
-  socialLogin(payload: SocialLoginOptions): Promise<void>;
+  federatedLogin(payload: FederatedLoginOptions): Promise<void>;
   passkeyLogin(payload?: CustomOptions): Promise<void>;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -14,7 +14,7 @@ import type {
   TransactionMembersOnLoginId as TransactionOptions,
   LoginIdMembers,
   LoginOptions,
-  SocialLoginOptions,
+  FederatedLoginOptions,
 } from '../../../interfaces/screens/login-id';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
@@ -74,17 +74,17 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * console.log(`Selected connection: ${selectedConnection.name}`);
    *
    * // Proceed with federated login using the selected connection
-   * loginIdManager.socialLogin({
+   * loginIdManager.federatedLogin({
    *   connection: selectedConnection.name,
    * });
    */
-  async socialLogin(payload: SocialLoginOptions): Promise<void> {
+  async federatedLogin(payload: FederatedLoginOptions): Promise<void> {
     const options: FormOptions = {
       state: this.transaction.state,
       telemetry: [LoginId.screenIdentifier, 'socialLogin'],
     };
 
-    await new FormHandler(options).submitData<SocialLoginOptions>(payload);
+    await new FormHandler(options).submitData<FederatedLoginOptions>(payload);
   }
 
   /**
@@ -134,7 +134,7 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
 export {
   LoginIdMembers,
   LoginOptions,
-  SocialLoginOptions,
+  FederatedLoginOptions,
   ScreenOptions as ScreenMembersOnLoginId,
   TransactionOptions as TransactionMembersOnLoginId,
 };

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
@@ -7,7 +7,7 @@ import { Errors } from '../../../../src/constants';
 import { BaseContext } from '../../../../src/models/base-context';
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../../interfaces/models/transaction';
-import type { LoginOptions, SocialLoginOptions } from '../../../../interfaces/screens/login-id';
+import type { LoginOptions, FederatedLoginOptions } from '../../../../interfaces/screens/login-id';
 import { ScreenIds } from '../../../../src//constants';
 import { FormActions } from '../../../../src/constants';
 
@@ -57,10 +57,10 @@ describe('LoginId', () => {
     });
   });
 
-  describe('socialLogin', () => {
+  describe('federatedLogin', () => {
     it('should submit social login form data correctly', async () => {
-      const payload: SocialLoginOptions = { connection: 'google' };
-      await loginId.socialLogin(payload);
+      const payload: FederatedLoginOptions = { connection: 'google' };
+      await loginId.federatedLogin(payload);
       expect(FormHandler).toHaveBeenCalledWith(expect.objectContaining({ state: 'mockState' }));
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(payload);
     });


### PR DESCRIPTION
### Summary

This PR renames the `SocialLoginOptions` type to `FederatedLoginOptions` throughout the codebase for better clarity and consistency. The changes cover:

- Interface and type name updates
- Method signature updates
- Corresponding test updates

### Changes Included

- Renamed `SocialLoginOptions` to `FederatedLoginOptions`
- Updated all related method names and interface definitions
- Updated affected unit tests accordingly

### Note

No functional logic changes are introduced in this PR — only renaming and refactoring.

---

Let me know if you'd like to include screenshots, test output, or link to a JIRA ticket or task ID (if applicable)!
