### PR TITLE
Refactor: rename SocialLogin to FederatedLogin and update related met…

### DIFF
--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -32,7 +32,7 @@ const loginManager = new Login();
 // Handle social login
 const handleSocialLogin = async (connection: string) => {
   try {
-    await loginManager.socialLogin({
+    await loginManager.federatedLogin({
       connection: connection // e.g. 'google-oauth2'
     });
   } catch (error) {
@@ -71,7 +71,7 @@ const LoginScreen: React.FC = () => {
   
   const handleSocialLogin = async (connection: string) => {
     try {
-      await loginManager.socialLogin({ connection });
+      await loginManager.federatedLogin({ connection });
     } catch (error) {
       setError('Social login failed. Please try again.');
     }

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -9,7 +9,7 @@ export type { PhoneChallengeOptions } from '../screens/phone-identifier-challeng
 export type { PhoneEnrollmentOptions } from '../screens/phone-identifier-enrollment';
 export type { SignupOptions, FederatedSignupOptions } from '../screens/signup-id';
 export type { SignupPasswordOptions } from '../screens/signup-password';
-export type { LoginOptions as LoginPayloadOptions, SocialLoginOptions as SocialLoginPayloadOptions } from '../screens/login';
+export type { LoginOptions as LoginPayloadOptions, FederatedLoginOptions as FederatedLoginPayloadOptions } from '../screens/login';
 export type { SignupOptions as SignupPayloadOptions, FederatedSignupOptions as FederatedSignupPayloadOptions } from '../screens/signup';
 export type { ResetPasswordEmailOptions } from '../screens/reset-password-email';
 export type { ResetPasswordRequestOptions } from '../screens/reset-password-request';

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -67,7 +67,7 @@ export interface LoginOptions {
 /**
  * Options for performing social login operations
  */
-export interface SocialLoginOptions {
+export interface FederatedLoginOptions {
   /** The social connection name to use */
   connection: string;
   /** Any additional custom options */
@@ -89,5 +89,5 @@ export interface LoginMembers extends BaseMembers {
    * Performs login with social provider
    * @param payload The social login options
    */
-  socialLogin(payload: SocialLoginOptions): Promise<void>;
+  federatedLogin(payload: FederatedLoginOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -81,7 +81,7 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
   async federatedLogin(payload: FederatedLoginOptions): Promise<void> {
     const options: FormOptions = {
       state: this.transaction.state,
-      telemetry: [LoginId.screenIdentifier, 'socialLogin'],
+      telemetry: [LoginId.screenIdentifier, 'federatedLogin'],
     };
 
     await new FormHandler(options).submitData<FederatedLoginOptions>(payload);

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -12,7 +12,7 @@ import type {
   LoginOptions,
   LoginMembers,
   TransactionMembersOnLogin as TransactionOptions,
-  SocialLoginOptions,
+  FederatedLoginOptions,
 } from '../../../interfaces/screens/login';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
@@ -60,17 +60,17 @@ export default class Login extends BaseContext implements LoginMembers {
    * ```typescript
    * import Login from "@auth0/auth0-acul-js/login";
    * const loginManager = new Login();
-   * loginManager.socialLogin({
+   * loginManager.federatedLogin({
    *   connection: "google-oauth2"
    * });
    * ```
    */
-  async socialLogin(payload: SocialLoginOptions): Promise<void> {
-    const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'login'] };
-    await new FormHandler(options).submitData<SocialLoginOptions>(payload);
+  async federatedLogin(payload: FederatedLoginOptions): Promise<void> {
+    const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'federatedLogin'] };
+    await new FormHandler(options).submitData<FederatedLoginOptions>(payload);
   }
 }
 
-export { LoginMembers, LoginOptions, SocialLoginOptions, ScreenOptions as ScreenMembersOnLogin, TransactionOptions as TransactionMembersOnLogin };
+export { LoginMembers, LoginOptions, FederatedLoginOptions, ScreenOptions as ScreenMembersOnLogin, TransactionOptions as TransactionMembersOnLogin };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -96,7 +96,7 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
   async federatedSignup(payload: FederatedSignupOptions): Promise<void> {
     const options: FormOptions = {
       state: this.transaction.state,
-      telemetry: [SignupId.screenIdentifier, 'socialSignup'],
+      telemetry: [SignupId.screenIdentifier, 'federatedSignup'],
     };
     await new FormHandler(options).submitData<FederatedSignupOptions>(payload);
   }

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -1,7 +1,7 @@
 import Login from '../../../../src/screens/login';
 import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
-import { LoginOptions, SocialLoginOptions } from '../../../../interfaces/screens/login';
+import { LoginOptions, FederatedLoginOptions } from '../../../../interfaces/screens/login';
 import { ScreenIds } from '../../../../src//constants';
 
 jest.mock('../../../../src/utils/form-handler');
@@ -78,10 +78,10 @@ describe('Login', () => {
 
   describe('Social Login method', () => {
     it('should handle social login correctly', async () => {
-      const payload: SocialLoginOptions = {
+      const payload: FederatedLoginOptions = {
         connection: 'google-oauth2',
       };
-      await login.socialLogin(payload);
+      await login.federatedLogin(payload);
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.objectContaining(payload)
@@ -90,10 +90,10 @@ describe('Login', () => {
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      const payload: SocialLoginOptions = {
+      const payload: FederatedLoginOptions = {
         connection: 'google-oauth2',
       };
-      await expect(login.socialLogin(payload)).rejects.toThrow('Mocked reject');
+      await expect(login.federatedLogin(payload)).rejects.toThrow('Mocked reject');
     });
   });
 });


### PR DESCRIPTION
### Summary

This PR renames the `SocialLoginOptions` type to `FederatedLoginOptions` throughout the codebase for better clarity and consistency. The changes cover:

- Interface and type name updates
- Method signature updates
- Corresponding test updates

### Changes Included

- Renamed `SocialLoginOptions` to `FederatedLoginOptions`
- Updated all related method names and interface definitions
- Updated affected unit tests accordingly

### Note

No functional logic changes are introduced in this PR — only renaming and refactoring.

---

Let me know if you'd like to include screenshots, test output, or link to a JIRA ticket or task ID (if applicable)!
