### PR TITLE
New: Added support for email-otp-challenge screen

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -203,6 +203,7 @@ Get up and running quickly with our boilerplate starter template: [Link](https:/
 | 71     |reset-password                    | reset-password-mfa-webauthn-platform-challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordMfaWebAuthnPlatformChallenge.html)                |
 | 72     |reset-password                    | reset-password-mfa-webauthn-roaming-challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.ResetPasswordMfaWebAuthnRoamingChallenge.html)   |
 | 73     |consent                   | consent | [Link](https://auth0.github.io/universal-login/classes/Classes.consent.html)   |
+| 74     |email-otp-challenge                   | email-otp-challenge | [Link](https://auth0.github.io/universal-login/classes/Classes.EmailOTPChallenge.html)   |
 </details>
 
 

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -61,7 +61,7 @@ export type { LogoutMembers } from '../screens/logout';
 export type { LogoutAbortedMembers } from '../screens/logout-aborted';
 export type { LogoutCompleteMembers } from '../screens/logout-complete';
 export type { EmailVerificationResultMembers } from '../screens/email-verification-result';
-// export type { EmailOTPChallengeMembers } from '../screens/email-otp-challenge';
+export type { EmailOTPChallengeMembers } from '../screens/email-otp-challenge';
 export type { LoginEmailVerificationMembers } from '../screens/login-email-verification'
 export type { MfaWebAuthnPlatformEnrollmentMembers } from '../screens/mfa-webauthn-platform-enrollment';
 export type { MfaWebAuthnErrorMembers } from '../screens/mfa-webauthn-error';

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -168,6 +168,10 @@
       "import": "./dist/screens/mfa-otp-enrollment-code/index.js",
       "types": "./dist/types/src/screens/mfa-otp-enrollment-code/index.d.ts"
     },
+    "./email-otp-challenge": {
+      "import": "./dist/screens/email-otp-challenge/index.js",
+      "types": "./dist/types/src/screens/email-otp-challenge/index.d.ts"
+    },
     "./organization-selection": {
       "import": "./dist/screens/organization-selection/index.js",
       "types": "./dist/types/src/screens/organization-selection/index.d.ts"

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -60,7 +60,7 @@ export { default as MfaRecoveryCodeChallengeNewCode } from './mfa-recovery-code-
 export { default as Logout } from './logout';
 export { default as LogoutAborted } from './logout-aborted';
 export { default as LogoutComplete } from './logout-complete';
-// export { default as EmailOTPChallenge } from './email-otp-challenge'
+export { default as EmailOTPChallenge } from './email-otp-challenge'
 export { default as EmailVerificationResult } from './email-verification-result';
 export { default as LoginEmailVerification } from './login-email-verification';
 export { default as MfaWebAuthnPlatformEnrollment } from './mfa-webauthn-platform-enrollment';


### PR DESCRIPTION
### Description
As part of this PR, we verified the generated screen code for `email-otp-challenge` screen , added required changes and necessary exports, verified unit test cases, screen documentation with examples of events required for the email-otp-challenge screen, and also revised the main README for the universal-login project.

### Testing
- Verified the generated docs for **email-otp-challenge** screen.
- Performed manual testing for all the required events and tested end to end workflow.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
