### PR TITLE
Release config setup update

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,10 +11,10 @@ runs:
   using: composite
 
   steps:
-    - name: Setup Node
+    - name: Setup Node.js 22.x
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ inputs.node }}
+        node-version: 22
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -28,6 +28,10 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Debug Node.js version
+      shell: bash
+      run: node --version
+
     - name: Install dependencies
       shell: bash
       working-directory: packages/${{ inputs.package }}

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -28,6 +28,13 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Debug working directory
+      shell: bash
+      working-directory: packages/${{ inputs.package }}
+      run: |
+        pwd
+        ls -la
+
     - name: Install dependencies
       shell: bash
       working-directory: packages/${{ inputs.package }}

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -21,16 +21,12 @@ runs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup Node.js 22.x
+    - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: ${{ inputs.node-version }}
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
-
-    - name: Debug Node.js version
-      shell: bash
-      run: node --version
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -20,15 +20,11 @@ runs:
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
-    - name: Node version before setup
-      shell: bash
-      run: node --version || echo "Node not installed"
 
-    - name: Setup Node
+    - name: Setup Node.js 22.x
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version: 22
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -20,6 +20,10 @@ runs:
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
+    
+    - name: Node version before setup
+      shell: bash
+      run: node --version || echo "Node not installed"
 
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -50,7 +50,7 @@ runs:
         else
           TAG="latest"
         fi
-        npm publish --provenance --access public --tag $TAG 
+        npm whoami
       env:
         NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -8,9 +8,9 @@ inputs:
   version:
     required: true
   require-build:
-    default: true
+    required: true
   package:
-    default: true
+    required: true
   release-directory:
     default: './'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     types:
       - [opened, closed]
   workflow_dispatch:
-
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Monorepo Release
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - '*'
+  workflow_dispatch:
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,11 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/actions/npm-publish
         with:
-          working-directory: packages/${{ steps.meta.outputs.name }}
+           node-version: 22
+           npm-token: ${{ secrets.NPM_TOKEN }}
+           version: ${{ steps.meta.outputs.version }}
+           require-build: true
+           package: ${{ steps.meta.outputs.name }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: Monorepo Release
 on:
   pull_request:
     types: [opened, reopened]
-  push:
-    branches:
-      - 'release-config'
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: 22
           cache: 'npm'
 
+      - name: Check Node.js version
+        run: node --version
       - name: Install deps
         run: npm install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Monorepo Release
 on:
   pull_request:
     branches:
-      - 'release/*/v*'
+      - 'release/auth0-acul-js/v*'
     types:
       - [opened, closed]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Monorepo Release
 
 on:
-  pull_request:
-    types:
-      - [opened, closed]
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       
+      - name: Debug meta outputs
+        run: |
+          echo "Parsed package name: ${{ steps.meta.outputs.name }}"
+          echo "Parsed version: ${{ steps.meta.outputs.version }}"
       - name: Build
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/actions/npm-publish
         with:
+          node-version: 22
           working-directory: packages/${{ steps.meta.outputs.name }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,7 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/actions/npm-publish
         with:
-           node-version: 22
-           npm-token: ${{ secrets.NPM_TOKEN }}
-           version: ${{ steps.meta.outputs.version }}
-           require-build: true
-           package: ${{ steps.meta.outputs.name }}
+           working-directory: packages/${{ steps.meta.outputs.name }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,7 @@
 name: Monorepo Release
 
 on:
-  # Tag-based release (for direct tag pushes, e.g. auth0-acul-js@1.2.3)
-  push:
-    tags:
-      - 'auth0-acul-*@*'
-
-  # PR-based release (for merging release branches, e.g. release/auth0-acul-js/v1.2.3)
+  # PR-based release
   pull_request:
     branches:
       - 'release/*/v*'
@@ -38,22 +33,6 @@ jobs:
 
       - name: Install deps
         run: npm install
-
-      # Parse package name and version from tag or branch
-      - name: Parse version and package
-        id: meta
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            TAG=${GITHUB_REF#refs/tags/}
-            NAME=$(echo $TAG | cut -d@ -f1)
-            VERSION=$(echo $TAG | cut -d@ -f2)
-          else
-            BRANCH="${{ github.event.pull_request.base.ref }}"
-            NAME=$(echo $BRANCH | cut -d'/' -f2)
-            VERSION=$(echo $BRANCH | cut -d'/' -f3 | sed 's/^v//')
-          fi
-          echo "name=$NAME" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Check tag exists (tag-based only)
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
           version: ${{ steps.meta.outputs.version }}
           require-build: true
           package: ${{ steps.meta.outputs.name }}
-          working-directory: packages/${{ steps.meta.outputs.name }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,32 @@
-# .github/workflows/release.yml
 name: Monorepo Release
 
 on:
+  # Tag-based release (for direct tag pushes, e.g. auth0-acul-js@1.2.3)
   push:
     tags:
       - 'auth0-acul-*@*'
 
+  # PR-based release (for merging release branches, e.g. release/auth0-acul-js/v1.2.3)
+  pull_request:
+    branches:
+      - 'release/*/v*'
+    types:
+      - closed
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
-    name: Release from Tag
+    # For PR-based: only run if PR was merged
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -22,16 +39,24 @@ jobs:
       - name: Install deps
         run: npm install
 
+      # Parse package name and version from tag or branch
       - name: Parse version and package
         id: meta
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          NAME=$(echo $TAG | cut -d@ -f1)
-          VERSION=$(echo $TAG | cut -d@ -f2)
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG=${GITHUB_REF#refs/tags/}
+            NAME=$(echo $TAG | cut -d@ -f1)
+            VERSION=$(echo $TAG | cut -d@ -f2)
+          else
+            BRANCH="${{ github.event.pull_request.base.ref }}"
+            NAME=$(echo $BRANCH | cut -d'/' -f2)
+            VERSION=$(echo $BRANCH | cut -d'/' -f3 | sed 's/^v//')
+          fi
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Check tag exists
+      - name: Check tag exists (tag-based only)
+        if: startsWith(github.ref, 'refs/tags/')
         uses: ./.github/actions/tag-exists
         with:
           tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
           VERSION=$(echo $BRANCH | cut -d'/' -f3 | sed 's/^v//')
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Show parsed package name
+        run: echo "Parsed package name: ${{ steps.meta.outputs.name }}"
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: Monorepo Release
 
 on:
-  # PR-based release
   pull_request:
     branches:
       - 'release/*/v*'
     types:
-      - [closed]
+      - [closed, opened]
   workflow_dispatch:
 
 permissions:
@@ -15,7 +14,6 @@ permissions:
 
 jobs:
   release:
-    # For PR-based: only run if PR was merged
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Monorepo Release
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
         uses: ./.github/actions/npm-publish
         with:
           node-version: 22
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          version: ${{ steps.meta.outputs.version }}
+          require-build: true
+          package: ${{ steps.meta.outputs.name }}
           working-directory: packages/${{ steps.meta.outputs.name }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'release/*/v*'
     types:
-      - opened
+      - [closed, opened]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Monorepo Release
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
   push:
     branches:
       - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened]
   push:
     branches:
-      - '*'
+      - 'release-config'
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Monorepo Release
 on:
   pull_request:
     branches:
-      - 'release/auth0-acul-js/v*'
+      - 'release/*/v*'
     types:
       - [opened, closed]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - 'release/*/v*'
     types:
-      - [closed, opened]
+      - closed
+      - opened
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Monorepo Release
 on:
   pull_request:
     branches:
-      - 'release/*/v*'
+      - '*'
     types:
       - [opened, closed]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - 'release/*/v*'
     types:
-      - [closed, opened]
+      - [closed]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,6 @@ jobs:
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       
-      - name: Show parsed package name
-        run: echo "Parsed package name ${{ steps.meta.outputs.name }}"
-
       - name: Build
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,11 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/actions/npm-publish
         with:
-           working-directory: packages/${{ steps.meta.outputs.name }}
+           node-version: 22
+           npm-token: ${{ secrets.NPM_TOKEN }}
+           version: ${{ steps.meta.outputs.version }}
+           require-build: true
+           package: ${{ steps.meta.outputs.name }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - '*'
     types:
-      - [opened, closed]
+      - opened
+      - closed
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Monorepo Release
 
 on:
   pull_request:
-    branches:
-      - '*'
     types:
       - [opened, closed]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
       - 'release/*/v*'
     types:
       - closed
-
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - '*'
     types:
-      - opened
-      - closed
+      - [opened, closed]
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'release/*/v*'
     types:
-      - opened
+      - [opened, closed]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'release/*/v*'
     types:
-      - closed
       - opened
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - 'release/*/v*'
     types:
-      - [closed, opened]
+      - closed
+      - opened
   workflow_dispatch:
 
 permissions:
@@ -14,9 +15,7 @@ permissions:
 
 jobs:
   release:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -31,11 +30,15 @@ jobs:
       - name: Install deps
         run: npm install
 
-      - name: Check tag exists (tag-based only)
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: ./.github/actions/tag-exists
-        with:
-          tag: ${{ github.ref_name }}
+      # Parse package name and version from branch
+      - name: Parse version and package
+        id: meta
+        run: |
+          BRANCH="${{ github.event.pull_request.base.ref }}"
+          NAME=$(echo $BRANCH | cut -d'/' -f2)
+          VERSION=$(echo $BRANCH | cut -d'/' -f3 | sed 's/^v//')
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build
         uses: ./.github/actions/build
@@ -52,6 +55,6 @@ jobs:
       - name: Create GitHub Release
         uses: ./.github/actions/release-create
         with:
-          tag: ${{ github.ref_name }}
+          tag: ${{ steps.meta.outputs.name }}@${{ steps.meta.outputs.version }}
           name: ${{ steps.meta.outputs.name }}
           version: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - 'release/*/v*'
     types:
-      - closed
+      - [closed, opened]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       
       - name: Show parsed package name
-        run: echo "Parsed package name: ${{ steps.meta.outputs.name }}"
+        run: echo "Parsed package name ${{ steps.meta.outputs.name }}"
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Monorepo Release
 on:
   pull_request:
     types: [opened, reopened]
+  push:
+    branches:
+      - 'release-config'
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,7 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/actions/npm-publish
         with:
-          node-version: 22
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          version: ${{ steps.meta.outputs.version }}
-          require-build: true
-          package: ${{ steps.meta.outputs.name }}
+          working-directory: packages/${{ steps.meta.outputs.name }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
### Description
This PR updates the release workflow and npm publish action to support a generic, monorepo-friendly release process. The workflow now triggers on PR merges to release branches (e.g., release/{package}/v*), extracts the package name and version, and builds, publishes, and creates a GitHub release for the appropriate package.

### Impact

- Enables automated, package-specific releases for any package in the monorepo via standardized branch naming.
- Simplifies and unifies the release process—no need for separate workflows or manual steps per package.
- Ensures correct npm tagging based on version