### PR TITLE
update shiprc for version update check

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,7 +1,10 @@
 {
     "files": {
         "packages/auth0-acul-js/CHANGELOG.md": [],
-        "packages/auth0-acul-js/.version": []
+        "packages/acul-js/.version": [
+            "v{MAJOR}.{MINOR}.{PATCH}",
+            "v{MAJOR}.{MINOR}.{PATCH}-{PRERELEASE_LABEL}.{PRERELEASE_COUNTER}"
+        ]
     },
     "prefixVersion": false,
     "packageLabel": "auth0-acul-js",


### PR DESCRIPTION
### Description
This PR updates the `shiprc` so it updates the  `.version` file for new release. The changes ensure that versioning and changelog updates are handled correctly during releases, and the version format is explicitly defined for both standard and prerelease version

### Test
Will be doing after merging into master as ship commands only runs on master.