### PR TITLE
New: Added support for customized-consent screen

### DIFF
--- a/packages/auth0-acul-js/examples/consent.md
+++ b/packages/auth0-acul-js/examples/consent.md
@@ -64,15 +64,13 @@ const ConsentScreen: React.FC = () => {
             </h2>
             <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
               {screen.scopes.map((scope: Scope) => (
-                <li key={scope.name} className="flex items-start">
+                <li key={scope.value} className="flex items-start">
                   <svg className="flex-shrink-0 h-5 w-5 text-green-500 mt-0.5 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                     <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                   </svg>
                   <div>
-                    <p className="text-sm font-medium text-gray-700">{scope.description || scope.name}</p>
-                    {scope.values && scope.values.length > 0 && (
-                      <p className="text-xs text-gray-500 pl-1">Details: {scope.values.join(', ')}</p>
-                    )}
+                    <p className="text-sm font-medium text-gray-700">{scope.value}</p>
+                    <p className="text-sm font-small text-gray-700">{scope.description}</p>
                   </div>
                 </li>
               ))}
@@ -144,7 +142,7 @@ if (shouldHideScopes) {
 } else if (requestedScopes) {
   console.log("Requested permissions:");
   requestedScopes.forEach(scope => {
-    console.log(`- ${scope.description} (${scope.name})`);
+    console.log(`- ${scope.description} (${scope.value})`);
   });
 }
 

--- a/packages/auth0-acul-js/examples/customized-consent.md
+++ b/packages/auth0-acul-js/examples/customized-consent.md
@@ -66,15 +66,13 @@ const CustomizedConsentScreen: React.FC = () => {
             </h2>
             <ul className="space-y-3 max-h-48 overflow-y-auto pr-2">
               {screenData.scopes.map((scope: Scope) => (
-                <li key={scope.name} className="flex items-start p-3 bg-gray-50 rounded-lg shadow-sm">
+                <li key={scope.value} className="flex items-start p-3 bg-gray-50 rounded-lg shadow-sm">
                   <svg className="flex-shrink-0 h-6 w-6 text-blue-500 mt-0.5 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   <div>
-                    <p className="text-md font-medium text-gray-800">{scope.description || scope.name}</p>
-                    {scope.values && scope.values.length > 0 && (
-                      <p className="text-xs text-gray-500 pl-1">Details: {scope.values.join(', ')}</p>
-                    )}
+                    <p className="text-sm font-medium text-gray-700">{scope.value}</p>
+                    <p className="text-sm font-small text-gray-700">{scope.description}</p>
                   </div>
                 </li>
               ))}

--- a/packages/auth0-acul-js/examples/customized-consent.md
+++ b/packages/auth0-acul-js/examples/customized-consent.md
@@ -145,7 +145,7 @@ export default CustomizedConsentScreen;
 
 ## Usage Examples
 
-### Initialize the SDK Class
+### Initialize the SDK Class and get screen related properties
 
 First, import and instantiate the class for the Customized Consent screen:
 

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -75,5 +75,5 @@ export type { ConsentMembers } from '../screens/consent';
 export type { ResetPasswordMfaWebAuthnPlatformChallengeMembers } from '../screens/reset-password-mfa-webauthn-platform-challenge';
 export type { ResetPasswordMfaWebAuthnRoamingChallengeMembers } from '../screens/reset-password-mfa-webauthn-roaming-challenge';
 export type { BruteForceProtectionUnblockMembers } from '../screens/brute-force-protection-unblock';
-export type { BruteForceProtectionUnblockFailureMembers } from '../screens/brute-force-protection-unblock-failure';
-export type { BruteForceProtectionUnblockSuccessMembers } from '../screens/brute-force-protection-unblock-success';
+export type { BruteForceProtectionUnblockFailureMembers, ScreenMembersOnBruteForceProtectionUnblockFailure } from '../screens/brute-force-protection-unblock-failure';
+export type { BruteForceProtectionUnblockSuccessMembers, ScreenMembersOnBruteForceProtectionUnblockSuccess } from '../screens/brute-force-protection-unblock-success';

--- a/packages/auth0-acul-js/interfaces/models/screen.ts
+++ b/packages/auth0-acul-js/interfaces/models/screen.ts
@@ -45,9 +45,8 @@ export interface PhonePrefix {
 }
 
 export interface Scope {
-  name: string;
-  description: string;
-  values: string[];
+  value: string;
+  description?: string;
 }
 
 export interface AuthorizationDetail {

--- a/packages/auth0-acul-js/package.json
+++ b/packages/auth0-acul-js/package.json
@@ -184,6 +184,10 @@
       "import": "./dist/screens/consent/index.js",
       "types": "./dist/types/src/screens/consent/index.d.ts"
     },
+    "./customized-consent": {
+      "import": "./dist/screens/customized-consent/index.js",
+      "types": "./dist/types/src/screens/customized-consent/index.d.ts"
+    },
     "./brute-force-protection-unblock": {
       "import": "./dist/screens/brute-force-protection-unblock/index.js",
       "types": "./dist/types/src/screens/brute-force-protection-unblock/index.d.ts"

--- a/packages/auth0-acul-js/src/screens/brute-force-protection-unblock-failure/index.ts
+++ b/packages/auth0-acul-js/src/screens/brute-force-protection-unblock-failure/index.ts
@@ -19,7 +19,6 @@ export default class BruteForceProtectionUnblockFailure extends BaseContext impl
   
   /**
    * Creates an instance of the BruteForceProtectionUnblockFailure screen.
-   * @constructor
    */
   constructor() {
     super();

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -41,7 +41,7 @@ export { default as ResetPasswordMfaOtpChallenge } from './reset-password-mfa-ot
 export { default as OrganizationSelection } from './organization-selection';
 export { default as OrganizationPicker } from './organization-picker';
 export { default as AcceptInvitation } from './accept-invitation';
-// export { default as CustomizedConsent } from './customized-consent';
+export { default as CustomizedConsent } from './customized-consent';
 export { default as MfaPhoneEnrollment } from './mfa-phone-enrollment';
 export { default as MfaVoiceEnrollment } from './mfa-voice-enrollment';
 export { default as MfaRecoveryCodeChallenge } from './mfa-recovery-code-challenge';

--- a/packages/auth0-acul-js/src/shared/screen.ts
+++ b/packages/auth0-acul-js/src/shared/screen.ts
@@ -111,17 +111,12 @@ export function getWebAuthnType(screen: ScreenContext): string | null {
 export function getScopes(screen: ScreenContext): Scope[] {
   return Array.isArray(screen.data?.scopes)
         ? (screen.data?.scopes as Scope[])
-            .map((scope: Scope): Scope | null => {
+            .map((scope: Scope): Scope => {
               return {
-                name: scope.name,
+                value: scope.value,
                 // Provide defaults for optional fields
-                description: typeof scope.description === 'string' ? scope.description : '',
-                // Ensure values is always an array of strings
-                values: Array.isArray(scope.values)
-                  ? scope.values.filter((v): v is string => typeof v === 'string')
-                  : typeof scope.name === 'string' ? [scope.name] : [], // Default values to name if valid
+                description: typeof scope.description === 'string' ? scope.description : ''
               };
             })
-            .filter((scope): scope is Scope => scope !== null) // Remove nulls from invalid entries
         : [];
 }

--- a/packages/auth0-acul-js/tests/unit/screens/consent/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/consent/index.test.ts
@@ -22,9 +22,9 @@ describe('Consent Screen SDK', () => {
 
   const mockTransactionState = 'consent-tx-state-123';
   const mockScopes: Scope[] = [
-    { name: 'openid', description: 'Sign in', values: [] },
-    { name: 'profile', description: 'View your profile information', values: [] },
-    { name: 'email', description: 'View your email address', values: [] },
+    { value: 'openid', description: 'Sign in' },
+    { value: 'profile', description: 'View your profile information' },
+    { value: 'email', description: 'View your email address' },
   ];
 
   beforeEach(() => {

--- a/packages/auth0-acul-js/tests/unit/screens/consent/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/consent/screen-override.test.ts
@@ -13,9 +13,9 @@ jest.mock('../../../../src/shared/screen');
  */
 describe('Consent ScreenOverride', () => {
   const validScopes: Scope[] = [
-    { name: 'openid', description: 'Sign in', values: [] },
-    { name: 'profile', description: 'View your profile information', values: ['name', 'picture'] },
-    { name: 'email', description: 'View your email address', values: [] },
+    { value: 'openid', description: 'Sign in' },
+    { value: 'profile', description: 'View your profile information' },
+    { value: 'email', description: 'View your email address' },
   ];
 
   beforeEach(() => {

--- a/packages/auth0-acul-js/tests/unit/screens/customized-consent/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/customized-consent/index.test.ts
@@ -18,7 +18,7 @@ describe('CustomizedConsent Screen SDK', () => {
 
   const mockTransactionState = 'customized-consent-tx-state-456';
   const mockScopes: Scope[] = [
-    { name: 'read:data', description: 'Read your data', values: [] },
+    { value: 'read:data', description: 'Read your data' },
   ];
   const mockAuthDetails: AuthorizationDetail[] = [
     { type: 'transaction', amount: '100', currency: 'USD' },

--- a/packages/auth0-acul-js/tests/unit/screens/customized-consent/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/customized-consent/screen-override.test.ts
@@ -12,8 +12,8 @@ jest.mock('../../../../src/shared/screen', () => ({
 
 describe('CustomizedConsent ScreenOverride', () => {
   const mockValidScopes: Scope[] = [
-    { name: 'openid', description: 'Sign in', values: [] },
-    { name: 'profile', description: 'View your profile information', values: ['name', 'picture'] },
+    { value: 'openid', description: 'Sign in' },
+    { value: 'profile', description: 'View your profile information' },
   ];
 
   const mockValidAuthorizationDetails: AuthorizationDetail[] = [


### PR DESCRIPTION
### Description

1. As part of this PR, we verified the generated screen code for `customized-consent` screen , added required changes and necessary exports, verified unit test cases, screen documentation with examples of events required for the customized-consent screen, and also revised the main README for the universal-login project.
2. Fixed build warnings related to `brute-force-protection-unblock` and `email-otp-challenge` screens.

### Testing
- Verified the generated docs for **customized-consent** screen.
- Performed manual testing for all the required events and tested end to end workflow.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
