### PR TITLE
Add federatedLogin and federatedSignup to LoginPassword and SignupPassword screens

### DIFF
--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -8,7 +8,7 @@ export type { EmailChallengeOptions } from '../screens/email-identifier-challeng
 export type { PhoneChallengeOptions } from '../screens/phone-identifier-challenge';
 export type { PhoneEnrollmentOptions } from '../screens/phone-identifier-enrollment';
 export type { SignupOptions, FederatedSignupOptions } from '../screens/signup-id';
-export type { SignupPasswordOptions } from '../screens/signup-password';
+export type { SignupPasswordOptions, FederatedSignupOptions as FederatedSignupPasswordPayloadOptions } from '../screens/signup-password';
 export type { LoginOptions as LoginPayloadOptions, FederatedLoginOptions as FederatedLoginPayloadOptions } from '../screens/login';
 export type { SignupOptions as SignupPayloadOptions, FederatedSignupOptions as FederatedSignupPayloadOptions } from '../screens/signup';
 export type { ResetPasswordEmailOptions } from '../screens/reset-password-email';

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -1,5 +1,5 @@
 export type { LoginOptions, FederatedLoginOptions } from '../screens/login-id';
-export type { LoginPasswordOptions } from '../screens/login-password';
+export type { LoginPasswordOptions, FederatedLoginOptions as FederatedLoginPasswordOptions } from '../screens/login-password';
 export type { SubmitCodeOptions } from '../screens/login-passwordless-email-code';
 export type { SubmitOTPOptions } from '../screens/login-passwordless-sms-otp';
 export type { SubmitCaptchaOptions } from '../screens/interstitial-captcha';

--- a/packages/auth0-acul-js/interfaces/screens/login-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-password.ts
@@ -45,7 +45,13 @@ export interface LoginPasswordOptions {
   [key: string]: string | number | boolean | undefined;
 }
 
+export interface FederatedLoginOptions {
+  connection: string;
+  [key: string]: string | number | boolean;
+}
+
 export interface LoginPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnLoginPassword;
   login(payload: LoginPasswordOptions): Promise<void>;
+  federatedLogin(payload: FederatedLoginOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/signup-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-password.ts
@@ -20,6 +20,11 @@ export interface SignupPassword extends BaseContext {
   screen: ScreenContextOnSignupPassword;
 }
 
+export interface FederatedSignupOptions {
+  connection: string;
+  [key: string]: string | number | boolean;
+}
+
 export interface ScreenMembersOnSignupPassword extends ScreenMembers {
   loginLink: string | null;
   editLink: string | null;
@@ -50,4 +55,5 @@ export interface SignupPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnSignupPassword;
   transaction: TransactionMembersOnSignupPassword;
   signup(payload: SignupPasswordOptions): Promise<void>;
+  federatedSignup(payload: FederatedSignupOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/login-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/index.ts
@@ -11,6 +11,7 @@ import type {
   ScreenMembersOnLoginPassword as ScreenOptions,
   LoginPasswordOptions,
   LoginPasswordMembers,
+  FederatedLoginOptions,
   TransactionMembersOnLoginPassword as TransactionOptions,
 } from '../../../interfaces/screens/login-password';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
@@ -45,11 +46,42 @@ export default class LoginPassword extends BaseContext implements LoginPasswordM
     const options: FormOptions = { state: this.transaction.state, telemetry: [LoginPassword.screenIdentifier, 'login'] };
     await new FormHandler(options).submitData<LoginPasswordOptions>(payload);
   }
+
+  /**
+     * @example
+     * import LoginPassword from "@auth0/auth0-acul-js/login-id";
+     * const loginIdManager = new LoginPassword();
+     *
+     * // Check if alternateConnections is available and has at least one item
+     * if (!loginIdManager.transaction.alternateConnections) {
+     *   console.error('No alternate connections available.');
+     * }
+     *
+     * // Select the first available connection (users can select any available connection)
+     * const selectedConnection = alternateConnections[0];
+     *
+     * // Log the chosen connection for debugging or informational purposes
+     * console.log(`Selected connection: ${selectedConnection.name}`);
+     *
+     * // Proceed with federated login using the selected connection
+     * loginIdManager.federatedLogin({
+     *   connection: selectedConnection.name,
+     * });
+     */
+  async federatedLogin(payload: FederatedLoginOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [LoginPassword.screenIdentifier, 'federatedLogin'],
+    };
+
+    await new FormHandler(options).submitData<FederatedLoginOptions>(payload);
+  }
 }
 
 export {
   LoginPasswordMembers,
   LoginPasswordOptions,
+  FederatedLoginOptions,
   ScreenOptions as ScreenMembersOnLoginPassword,
   TransactionOptions as TransactionMembersOnLoginPassword,
 };

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -12,6 +12,7 @@ import type {
   ScreenMembersOnSignupPassword as ScreenOptions,
   TransactionMembersOnSignupPassword as TransactionOptions,
   SignupPasswordOptions,
+  FederatedSignupOptions
 } from '../../../interfaces/screens/signup-password';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
@@ -69,11 +70,41 @@ export default class SignupPassword extends BaseContext implements SignupPasswor
 
     await new FormHandler(options).submitData<SignupPasswordOptions>(payload);
   }
+
+  /**
+     * @remarks
+     * This methods handles allows signup via different social identifiers.
+     * Eg: Google, Facebook etc.
+     *
+     * @example
+     * import SignupPassword from "@auth0/auth0-acul-js/signup-id";
+     *
+     * const signupIdManager = new SignupPassword();
+     * const { transaction } = signupIdManager;
+     *
+     * //get social connections
+     * const socialConnection = transaction.getAlternateConnections(); //eg: "google-oauth2"
+     *
+     * const signupParams = {
+     *  connection : socialConnection[0].name, // "google-oauth2"
+     * };
+     *
+     * signupIdManager.federatedSignup(signupParams);
+     */
+  async federatedSignup(payload: FederatedSignupOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [SignupPassword.screenIdentifier, 'federatedSignup'],
+    };
+
+    await new FormHandler(options).submitData<FederatedSignupOptions>(payload);
+  }
 }
 
 export {
   SignupPasswordMembers,
   SignupPasswordOptions,
+  FederatedSignupOptions,
   ScreenOptions as ScreenMembersOnSignupPassword,
   TransactionOptions as TransactionMembersOnSignupPassword,
 };

--- a/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
@@ -1,8 +1,9 @@
-import LoginPassword from '../../../../src/screens/login-password';
-import { baseContextData } from '../../../data/test-data';
-import { FormHandler } from '../../../../src/utils/form-handler';
-import type { LoginPasswordOptions } from '../../../../interfaces/screens/login-password';
 import { ScreenIds } from '../../../../src//constants';
+import LoginPassword from '../../../../src/screens/login-password';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
+import type { LoginPasswordOptions, FederatedLoginOptions } from '../../../../interfaces/screens/login-password';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -83,6 +84,59 @@ describe('LoginPassword', () => {
 
       await expect(loginPassword.login(payload)).rejects.toThrow(
         'Invalid password'
+      );
+    });
+  });
+
+  describe('federatedLogin method', () => {
+    it('should handle federated login correctly', async () => {
+      const payload: FederatedLoginOptions = {
+        connection: 'google-oauth2'
+      };
+      await loginPassword.federatedLogin(payload);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining(payload)
+      );
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: loginPassword.transaction.state,
+        telemetry: [ScreenIds.LOGIN_PASSWORD, 'federatedLogin']
+      });
+    });
+
+    it('should handle federated login with additional parameters', async () => {
+      const payload: FederatedLoginOptions = {
+        connection: 'facebook',
+        login_hint: 'user@example.com'
+      };
+      await loginPassword.federatedLogin(payload);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining(payload)
+      );
+    });
+
+    it('should throw error when federated login promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Federated login failed'));
+      const payload: FederatedLoginOptions = {
+        connection: 'github'
+      };
+
+      await expect(loginPassword.federatedLogin(payload)).rejects.toThrow(
+        'Federated login failed'
+      );
+    });
+
+    it('should throw error when connection is empty', async () => {
+      mockFormHandler.submitData.mockRejectedValueOnce(
+        new Error('Connection is required')
+      );
+      const payload = { connection: '' };
+
+      await expect(loginPassword.federatedLogin(payload)).rejects.toThrow(
+        'Connection is required'
       );
     });
   });

--- a/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
@@ -1,8 +1,9 @@
-import SignupPassword from '../../../../src/screens/signup-password';
-import { baseContextData } from '../../../data/test-data';
-import { FormHandler } from '../../../../src/utils/form-handler';
 import { ScreenIds } from '../../../../src//constants';
-import { SignupPasswordOptions } from 'interfaces/screens/signup-password';
+import SignupPassword from '../../../../src/screens/signup-password';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
+import type { SignupPasswordOptions, FederatedSignupOptions } from 'interfaces/screens/signup-password';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -121,6 +122,65 @@ describe('SignupPassword', () => {
 
       await expect(signupPassword.signup(payload)).rejects.toThrow(
         'Invalid phone number format'
+      );
+    });
+  });
+
+  describe('FederatedSignup method', () => {
+    it('should handle federated signup with valid connection correctly', async () => {
+      const payload: FederatedSignupOptions = {
+        connection: 'google-oauth2',
+      };
+      await signupPassword.federatedSignup(payload);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(payload);
+      expect(FormHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: signupPassword.transaction.state,
+          telemetry: [ScreenIds.SIGNUP_PASSWORD, 'federatedSignup'],
+        })
+      );
+    });
+
+    it('should throw error when promise is rejected during federated signup', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Connection failed'));
+      const payload: FederatedSignupOptions = {
+        connection: 'google-oauth2',
+      };
+
+      await expect(signupPassword.federatedSignup(payload)).rejects.toThrow(
+        'Connection failed'
+      );
+    });
+
+    it('should handle various social connections', async () => {
+      const connections = ['google-oauth2', 'facebook', 'github', 'apple'];
+
+      for (const connection of connections) {
+        mockFormHandler.submitData.mockClear();
+        const payload: FederatedSignupOptions = { connection };
+
+        await signupPassword.federatedSignup(payload);
+
+        expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+        expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+          expect.objectContaining({ connection })
+        );
+      }
+    });
+
+    it('should use correct screen identifier in telemetry', async () => {
+      const payload: FederatedSignupOptions = {
+        connection: 'google-oauth2',
+      };
+
+      await signupPassword.federatedSignup(payload);
+
+      expect(FormHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          telemetry: [ScreenIds.SIGNUP_PASSWORD, 'federatedSignup'],
+        })
       );
     });
   });


### PR DESCRIPTION

### 📌 Summary
This PR adds new methods to support federated authentication via external identity providers (e.g., Google, Facebook):

- `federatedLogin` method in `LoginPassword` screen for federated login.
- `federatedSignup` method in `SignupPassword` screen for federated signup.

Both methods use the `FormHandler` to submit federated authentication payloads and include telemetry tagging for better tracking.

### ✅ Changes

#### LoginPassword screen (`src/screens/login-password/index.ts`)
- Added `federatedLogin(payload: FederatedLoginOptions): Promise<void>` method.
- Telemetry event tagged as `"federatedLogin"`.
- JSDoc documentation and usage example added.
- Updated `FederatedLoginOptions` interface to:
  ```ts
  connection: string;
  [key: string]: string | number | boolean;
