### PR TITLE
fix(login-id): Send browser capabilities to enable passwordless flow

### DIFF
--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -1,5 +1,6 @@
 import { ScreenIds, FormActions, Errors } from '../../constants';
 import { BaseContext } from '../../models/base-context';
+import { isJsAvailable, isBrave, isWebAuthAvailable, isWebAuthPlatformAvailable } from '../../utils/browser-capabilities';
 import { FormHandler } from '../../utils/form-handler';
 import { getPasskeyCredentials } from '../../utils/passkeys';
 
@@ -54,7 +55,13 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
       telemetry: [LoginId.screenIdentifier, 'login'],
     };
 
-    await new FormHandler(options).submitData<LoginOptions>(payload);
+    await new FormHandler(options).submitData<LoginOptions>({
+      ...payload,
+      'js-available': isJsAvailable(),
+      'is-brave': await isBrave(),
+      'webauthn-available': isWebAuthAvailable(),
+      'webauthn-platform-available': await isWebAuthPlatformAvailable(),
+    });
   }
 
   /**

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
@@ -1,15 +1,17 @@
+import { ScreenIds } from '../../../../src//constants';
+import { Errors } from '../../../../src/constants';
+import { FormActions } from '../../../../src/constants';
+import { BaseContext } from '../../../../src/models/base-context';
 import LoginId from '../../../../src/screens/login-id';
 import { ScreenOverride } from '../../../../src/screens/login-id/screen-override';
 import { TransactionOverride } from '../../../../src/screens/login-id/transaction-override';
 import { FormHandler } from '../../../../src/utils/form-handler';
 import { getPasskeyCredentials } from '../../../../src/utils/passkeys';
-import { Errors } from '../../../../src/constants';
-import { BaseContext } from '../../../../src/models/base-context';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../../interfaces/models/transaction';
 import type { LoginOptions, SocialLoginOptions } from '../../../../interfaces/screens/login-id';
-import { ScreenIds } from '../../../../src//constants';
-import { FormActions } from '../../../../src/constants';
+
 
 jest.mock('../../../../src/screens/login-id/screen-override');
 jest.mock('../../../../src/screens/login-id/transaction-override');
@@ -53,7 +55,13 @@ describe('LoginId', () => {
       const payload: LoginOptions = { username: 'testuser' };
       await loginId.login(payload);
       expect(FormHandler).toHaveBeenCalledWith(expect.objectContaining({ state: 'mockState' }));
-      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(payload);
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
+        ...payload,
+        'js-available': expect.any(Boolean) as unknown,
+        'is-brave': expect.any(Boolean) as unknown,
+        'webauthn-available': expect.any(Boolean) as unknown,
+        'webauthn-platform-available': expect.any(Boolean) as unknown,
+      });
     });
   });
 


### PR DESCRIPTION
## 🐛 Problem
Currently, when a user attempts to log in with their identifier (username/email) with the intent to use passkey/biometric authentication, the system incorrectly prompts for a password before initiating the biometric prompt. The expected and correct behavior is for the biometric challenge to be presented immediately after the identifier is submitted.

## 🛠️ Solution
This change enhances the initial identifier-first login submission by including crucial browser capability flags. Specifically, we now send the following information to the backend:

- `js-available`: Indicates if JavaScript is enabled in the browser.
- `is-brave`: Detects if the user is on Brave, which may have unique handling for security features.
- `webauthn-available`: Checks if the WebAuthn API is available in the browser.
- `webauthn-platform-available`: Determines if a platform authenticator (like Touch ID, Windows Hello, or Android biometrics) is available.

By providing this context upfront, the backend can now intelligently determine whether to initiate a passwordless (WebAuthn/passkey) flow or fall back to requiring a password. This ensures a smoother user experience and directly triggers the expected biometric prompt.

The unit tests for the login-id screen have been updated to reflect these new payload parameters.