### PR TITLE
Fix: Update branch references from 'release/*/v*' to 'master' in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - 'release/*/v*'
+      - 'master'
   workflow_dispatch:
 permissions:
   contents: write
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * *' # daily
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## 📝 Pull Request Description

### 🔄 Changes
- The release workflow's branch references were updated from `release/*/v*` to `master`.
- The security workflow's branch reference was changed from `main` to `master`.
- The release workflow's trigger condition was updated to include workflow dispatch and merged pull requests from `release/*` branches.


### 💥 Impact
- This change simplifies the release process by using a single branch for releases.
- This change ensures that the security scans run on the correct branch.
- There is no performance impact expected from these changes.

### 📋 Checklist
- [ ] Code follows the project's coding standards
- [ ] Tests have been added/updated
- [ ] Documentation has been updated
- [ ] All tests are passing