### PR TITLE
Refactor: Update variable names in mfa-push-enrollment-qr to camelCas…

### DIFF
--- a/packages/auth0-acul-js/examples/mfa-push-enrollment-qr.md
+++ b/packages/auth0-acul-js/examples/mfa-push-enrollment-qr.md
@@ -13,7 +13,7 @@ import MfaPushEnrollmentQr from '@auth0/auth0-acul-js/mfa-push-enrollment-qr';
 const MfaPushEnrollmentQrScreen: React.FC = () => {
   const mfaPushEnrollmentQr = new MfaPushEnrollmentQr();
   const { screen } = mfaPushEnrollmentQr;
-  const { qr_code, qr_uri, show_code_copy } = screen.data || {};
+  const { qrCode, qrUri, showCodeCopy } = screen.data || {};
 
   const handlePickAuthenticator = async () => {
     try {
@@ -24,8 +24,8 @@ const MfaPushEnrollmentQrScreen: React.FC = () => {
   };
 
   const handleCopyCode = () => {
-    if (qr_uri) {
-      navigator.clipboard.writeText(qr_uri)
+    if (qrUri) {
+      navigator.clipboard.writeText(qrUri)
         .then(() => {
           alert('Code copied to clipboard');
         })
@@ -41,16 +41,16 @@ const MfaPushEnrollmentQrScreen: React.FC = () => {
         <h2 className="text-2xl font-bold">{ screen.texts?.title ?? 'Enroll with Push Notification' }</h2>
         <p className="mb-4">{ screen.texts?.description ?? '' }</p>
         {
-          qr_code ? (
+          qrCode ? (
             <div className="mb-4">
-              <img src={qr_code} alt="QR Code" className="mb-4 mx-auto" />
+              <img src={qrCode} alt="QR Code" className="mb-4 mx-auto" />
               
-              {show_code_copy && qr_uri && (
+              {showCodeCopy && qrUri && (
                 <div className="text-center mb-4">
                   <p className="text-sm text-gray-600 mb-2">Or copy this code to your authenticator app:</p>
                   <div className="flex items-center justify-center">
                     <code className="bg-gray-100 p-2 rounded mr-2 text-xs overflow-hidden text-ellipsis max-w-xs">
-                      {qr_uri}
+                      {qrUri}
                     </code>
                     <button
                       onClick={handleCopyCode}

--- a/packages/auth0-acul-js/interfaces/screens/mfa-push-enrollment-qr.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-push-enrollment-qr.ts
@@ -7,9 +7,9 @@ import type { ScreenMembers } from '../models/screen';
  */
 export interface ScreenMembersOnMfaPushEnrollmentQr extends ScreenMembers {
   data: {
-    qr_code: string;
-    qr_uri: string;
-    show_code_copy: boolean;
+    qrCode: string;
+    qrUri: string;
+    showCodeCopy: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -6,7 +6,7 @@ import type { TransactionMembers, UsernamePolicy, PasswordPolicy } from '../mode
 export interface SignupOptions {
   email?: string;
   username?: string;
-  phone_number?: string;
+  phoneNumber?: string;
   password?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/screen-override.ts
@@ -26,9 +26,9 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     }
 
     return {
-      qr_code: typeof data.qr_code === 'string' ? data.qr_code : '',
-      qr_uri: typeof data.qr_uri === 'string' ? data.qr_uri : '',
-      show_code_copy: !!data.show_code_copy
+      qrCode: typeof data.qr_code === 'string' ? data.qr_code : '',
+      qrUri: typeof data.qr_uri === 'string' ? data.qr_uri : '',
+      showCodeCopy: !!data.show_code_copy
     };
   };
 }

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-push-enrollment-qr/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-push-enrollment-qr/screen-override.test.ts
@@ -1,5 +1,6 @@
-import { ScreenOverride } from '../../../../src/screens/mfa-push-enrollment-qr/screen-override';
 import { Screen } from '../../../../src/models/screen';
+import { ScreenOverride } from '../../../../src/screens/mfa-push-enrollment-qr/screen-override';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 describe('ScreenOverride', () => {
@@ -21,9 +22,9 @@ describe('ScreenOverride', () => {
 
   it('should initialize data correctly', () => {
     expect(screenOverride.data).toEqual({
-      qr_code: 'base64-encoded-qr-code',
-      qr_uri: 'qr-uri',
-      show_code_copy: true
+      qrCode: 'base64-encoded-qr-code',
+      qrUri: 'qr-uri',
+      showCodeCopy: true
     });
   });
 
@@ -36,9 +37,9 @@ describe('ScreenOverride', () => {
   it('should return a copy of screenContext.data when available', () => {
     const result = ScreenOverride.getScreenData(screenContext);
     expect(result).toEqual({
-      qr_code: 'base64-encoded-qr-code',
-      qr_uri: 'qr-uri',
-      show_code_copy: true
+      qrCode: 'base64-encoded-qr-code',
+      qrUri: 'qr-uri',
+      showCodeCopy: true
     });
   });
 


### PR DESCRIPTION

### 📋 Summary

This PR updates multiple MFA-related screens and interfaces in the `auth0-acul-js` package to replace all `snake_case` field names with `camelCase`. This change improves consistency with JavaScript/TypeScript conventions and ensures a more modern, predictable codebase.

### ✅ Changes Made

### 🧾 Interface Updates


- **`mfa-push-enrollment-qr.ts`**
  - `qr_code` → `qrCode`
  - `qr_uri` → `qrUri`
  - `show_code_copy` → `showCodeCopy`

- **`signup.ts`**
  - `phone_number` → `phoneNumber`

### 🧩 Example & Component Updates

- Updated destructuring and usage in:
  - `MfaPushEnrollmentQrScreen`

- Replaced all references to snake_case fields in the examples under:

  - `examples/mfa-push-enrollment-qr.md`
