### PR TITLE
Refactor: Introduce Branding interface and update UserMembers to use

### DIFF
--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -5,3 +5,4 @@ export type { CustomOptions, WebAuthnErrorDetails } from '../common/index';
 export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../models/user';
 export type { IdentifierType } from '../../src/constants';
 export type { PasskeyCreateResponse, CredentialResponse } from '../utils/passkeys';
+export type { Branding } from '../models/organization';

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -6,3 +6,4 @@ export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../mode
 export type { IdentifierType } from '../../src/constants';
 export type { PasskeyCreateResponse, CredentialResponse } from '../utils/passkeys';
 export type { Branding } from '../models/organization';
+export type { Organizations } from '../models/user'

--- a/packages/auth0-acul-js/interfaces/models/organization.ts
+++ b/packages/auth0-acul-js/interfaces/models/organization.ts
@@ -15,17 +15,19 @@ export interface OrganizationContext {
   };
 }
 
+export interface Branding {
+  logoUrl?: string;
+  colors?: {
+    primary?: string;
+    pageBackground?: string;
+  };
+}
+
 export interface OrganizationMembers {
   id: string | null;
   name: string | null;
   usage: string | null;
   displayName: string | null;
-  branding: {
-    logoUrl?: string | undefined;
-    colors?: {
-      primary?: string | undefined;
-      pageBackground?: string;
-    };
-  } | null;
+  branding: Branding | null;
   metadata: { [key: string]: string } | null;
 }

--- a/packages/auth0-acul-js/interfaces/models/user.ts
+++ b/packages/auth0-acul-js/interfaces/models/user.ts
@@ -28,6 +28,14 @@ export interface UserContext {
   user_metadata?: Record<string, string>;
   app_metadata?: Record<string, string>;
 }
+
+export interface Organizations {
+  organizationId: string | undefined;
+  organizationName: string | undefined;
+  displayName: string | undefined;
+  branding: Branding;
+}
+
 export interface UserMembers {
   id: string | null;
   email: string | null;
@@ -38,14 +46,7 @@ export interface UserMembers {
   enrolledEmails: Array<EnrolledEmail> | null;
   enrolledPhoneNumbers: Array<EnrolledPhoneNumber> | null;
   enrolledDevices: Array<EnrolledDevice> | null;
-  organizations:
-  | {
-    organizationId: string | undefined;
-    organizationName: string | undefined;
-    displayName: string | undefined;
-    branding: Branding | undefined
-  }[]
-  | null;
+  organizations: Organizations[] | null;
   userMetadata: { [key: string]: string } | null;
   appMetadata: { [key: string]: string } | null;
 }

--- a/packages/auth0-acul-js/interfaces/models/user.ts
+++ b/packages/auth0-acul-js/interfaces/models/user.ts
@@ -1,5 +1,4 @@
-import type { OrganizationContext } from './organization';
-
+import type { OrganizationContext, Branding } from './organization';
 export interface EnrolledEmail {
   id: number;
   email: string;
@@ -29,7 +28,6 @@ export interface UserContext {
   user_metadata?: Record<string, string>;
   app_metadata?: Record<string, string>;
 }
-
 export interface UserMembers {
   id: string | null;
   email: string | null;
@@ -41,17 +39,13 @@ export interface UserMembers {
   enrolledPhoneNumbers: Array<EnrolledPhoneNumber> | null;
   enrolledDevices: Array<EnrolledDevice> | null;
   organizations:
-    | {
-        organizationId: string | undefined;
-        organizationName: string | undefined;
-        displayName: string | undefined;
-        branding:
-          | {
-              logoUrl: string | undefined;
-            }
-          | undefined;
-      }[]
-    | null;
+  | {
+    organizationId: string | undefined;
+    organizationName: string | undefined;
+    displayName: string | undefined;
+    branding: Branding | undefined
+  }[]
+  | null;
   userMetadata: { [key: string]: string } | null;
   appMetadata: { [key: string]: string } | null;
 }


### PR DESCRIPTION
### Summary

This PR centralizes and reuses the `Branding` type across the codebase by exporting it and replacing redundant inline definitions.

### Changes

- Added the `Branding` interface in `models/organization.ts`:
  ```ts
  export interface Branding {
    logoUrl?: string;
    colors?: {
      primary?: string;
      pageBackground?: string;
    };
  }


### Changes

- Exported the `Branding` type from `models/organization.ts` via `interfaces/export/common.ts`:
  ```ts
  export type { Branding } from '../models/organization';

### Impact

- Type-only change; no runtime logic affected.
- No breaking changes introduced.
- Improves maintainability and reduces potential for type drift.

### Checklist

- Exported shared Branding type  
- Refactored related interfaces to use shared type  
- Verified type consistency across affected files
