### PR TITLE
Refactor: Update MFA-related interfaces and exports for consistency

### DIFF
--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -51,7 +51,7 @@ export type {
   PickAuthenticatorOptions as MfaPhoneChallengePickAuthenticatorOptions,
 } from '../screens/mfa-phone-challenge';
 export type { MfaVoiceChallengeContinueOptions } from '../screens/mfa-voice-challenge';
-export type { ContinueOptions as MfaRecoveryCodeEnrollmentContinueOptions } from '../screens/mfa-recovery-code-enrollment';
+export type { MfaRecoveryCodeEnrollmentContinueOptions } from '../screens/mfa-recovery-code-enrollment';
 export type {
   ContinueOptions as ResetPasswordMfaPhoneChallengeContinueOptions,
   TryAnotherMethodOptions as ResetPasswordMfaPhoneChallengeTryAnotherMethodOptions,

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -50,7 +50,7 @@ export type {
   PickPhoneOptions as MfaPhoneChallengePickPhoneOptions,
   PickAuthenticatorOptions as MfaPhoneChallengePickAuthenticatorOptions,
 } from '../screens/mfa-phone-challenge';
-export type { ContinueOptions as MfaVoiceChallengeContinueOptions } from '../screens/mfa-voice-challenge';
+export type { MfaVoiceChallengeContinueOptions } from '../screens/mfa-voice-challenge';
 export type { ContinueOptions as MfaRecoveryCodeEnrollmentContinueOptions } from '../screens/mfa-recovery-code-enrollment';
 export type {
   ContinueOptions as ResetPasswordMfaPhoneChallengeContinueOptions,

--- a/packages/auth0-acul-js/interfaces/screens/mfa-recovery-code-enrollment.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-recovery-code-enrollment.ts
@@ -14,7 +14,7 @@ export interface ScreenMembersOnMfaRecoveryCodeEnrollment extends ScreenMembers 
   } | null;
 }
 
-export interface ContinueOptions extends CustomOptions {
+export interface MfaRecoveryCodeEnrollmentContinueOptions extends CustomOptions {
   isCodeCopied: boolean;
 }
 
@@ -34,5 +34,5 @@ export interface MfaRecoveryCodeEnrollmentMembers extends BaseMembers {
    * @returns {Promise<void>} A promise that resolves when the action is successfully submitted.
    * Rejects with an error if the submission fails.
    */
-  continue(payload: ContinueOptions): Promise<void>;
+  continue(payload: MfaRecoveryCodeEnrollmentContinueOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-voice-challenge.ts
@@ -6,7 +6,7 @@ import type { UntrustedDataMembers } from '../models/untrusted-data';
 /**
  * Options for submitting the voice challenge code.
  */
-export interface ContinueOptions {
+export interface MfaVoiceChallengeContinueOptions {
   /**
    * The verification code received via voice call.
    */
@@ -74,7 +74,7 @@ export interface MfaVoiceChallengeMembers extends BaseMembers {
    * });
    * ```
    */
-  continue(payload: ContinueOptions): Promise<void>;
+  continue(payload: MfaVoiceChallengeContinueOptions): Promise<void>;
 
   /**
    * Navigates to the screen for selecting a different phone number.

--- a/packages/auth0-acul-js/src/screens/device-code-confirmation/index.ts
+++ b/packages/auth0-acul-js/src/screens/device-code-confirmation/index.ts
@@ -68,6 +68,6 @@ export default class DeviceCodeConfirmation extends BaseContext implements Devic
   }
 }
 
-export { DeviceCodeConfirmationMembers };
+export { DeviceCodeConfirmationMembers, screenOptions as ScreenMembersOnDeviceCodeConfirmation };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-country-codes/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-country-codes/index.ts
@@ -86,6 +86,6 @@ export default class MfaCountryCodes extends BaseContext implements MfaCountryCo
   }
 }
 
-export { MfaCountryCodesMembers, ScreenOptions as ScreenMembersOnMfaCountryCodes };
+export { MfaCountryCodesMembers, ScreenOptions as ScreenMembersOnMfaCountryCodes, SelectCountryCodeOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-email-list/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-email-list/index.ts
@@ -75,6 +75,6 @@ export default class MfaEmailList extends BaseContext implements MfaEmailListMem
   }
 }
 
-export { MfaEmailListMembers, ScreenOptions as ScreenMembersOnMfaEmailList };
+export { MfaEmailListMembers, ScreenOptions as ScreenMembersOnMfaEmailList, SelectMfaEmailOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-login-options/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-login-options/index.ts
@@ -2,7 +2,7 @@ import { type MfaLoginFactorType, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
-import type { MfaLoginOptionsMembers, LoginEnrollOptions } from '../../../interfaces/screens/mfa-login-options';
+import type { MfaLoginOptionsMembers, LoginEnrollOptions, ScreenMembersOnMfaLoginOptions } from '../../../interfaces/screens/mfa-login-options';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 
 /**
@@ -38,6 +38,6 @@ export default class MfaLoginOptions extends BaseContext implements MfaLoginOpti
   }
 }
 
-export { MfaLoginOptionsMembers, LoginEnrollOptions, MfaLoginFactorType };
+export { MfaLoginOptionsMembers, LoginEnrollOptions, MfaLoginFactorType, ScreenMembersOnMfaLoginOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-push-list/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-list/index.ts
@@ -66,7 +66,7 @@ export default class MfaPushList extends BaseContext implements MfaPushListMembe
   }
 }
 
-export { MfaPushListMembers };
+export { MfaPushListMembers, SelectMfaPushDeviceOptions };
 
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-recovery-code-enrollment/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-recovery-code-enrollment/index.ts
@@ -68,6 +68,6 @@ export default class MfaRecoveryCodeEnrollment extends BaseContext implements Mf
   }
 }
 
-export { MfaRecoveryCodeEnrollmentMembers, ScreenMembersOnMfaRecoveryCodeEnrollment };
+export { MfaRecoveryCodeEnrollmentMembers, ScreenMembersOnMfaRecoveryCodeEnrollment, ContinueOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-recovery-code-enrollment/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-recovery-code-enrollment/index.ts
@@ -6,7 +6,7 @@ import { ScreenOverride } from './screen-override';
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
-  ContinueOptions,
+  MfaRecoveryCodeEnrollmentContinueOptions,
   MfaRecoveryCodeEnrollmentMembers,
   ScreenMembersOnMfaRecoveryCodeEnrollment,
 } from '../../../interfaces/screens/mfa-recovery-code-enrollment';
@@ -51,7 +51,7 @@ export default class MfaRecoveryCodeEnrollment extends BaseContext implements Mf
    * ```
    * Rejects with an error if the submission fails.
    */
-  async continue(payload: ContinueOptions): Promise<void> {
+  async continue(payload: MfaRecoveryCodeEnrollmentContinueOptions): Promise<void> {
     const formOptions = {
       state: this.transaction.state,
       telemetry: [MfaRecoveryCodeEnrollment.screenIdentifier, FormActions.CONTINUE],
@@ -59,15 +59,15 @@ export default class MfaRecoveryCodeEnrollment extends BaseContext implements Mf
 
     const { isCodeCopied, ...rest } = payload;
 
-    const options: Omit<ContinueOptions, 'isCodeCopied'> = {
+    const options: Omit<MfaRecoveryCodeEnrollmentContinueOptions, 'isCodeCopied'> = {
       ...rest,
       ...(isCodeCopied === true ? { saved: 'on' as unknown as boolean } : {}),
     };
 
-    await new FormHandler(formOptions).submitData<Omit<ContinueOptions, 'isCodeCopied'> & { saved?: 'string' }>(options);
+    await new FormHandler(formOptions).submitData<Omit<MfaRecoveryCodeEnrollmentContinueOptions, 'isCodeCopied'> & { saved?: 'string' }>(options);
   }
 }
 
-export { MfaRecoveryCodeEnrollmentMembers, ScreenMembersOnMfaRecoveryCodeEnrollment, ContinueOptions };
+export { MfaRecoveryCodeEnrollmentMembers, ScreenMembersOnMfaRecoveryCodeEnrollment, MfaRecoveryCodeEnrollmentContinueOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/mfa-voice-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-voice-challenge/index.ts
@@ -11,7 +11,7 @@ import type { UntrustedDataContext } from '../../../interfaces/models/untrusted-
 import type {
   MfaVoiceChallengeMembers,
   ScreenMembersOnMfaVoiceChallenge as ScreenOptions,
-  ContinueOptions as MfaVoiceChallengeContinueOptions,
+  MfaVoiceChallengeContinueOptions,
   UntrustedDataMembersOnMfaVoiceChallenge as UntrustedDataOptions,
 } from '../../../interfaces/screens/mfa-voice-challenge';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -99,6 +99,6 @@ export default class Signup extends BaseContext implements SignupMembers {
   }
 }
 
-export { SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup };
+export { SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
@@ -1,9 +1,10 @@
-import MfaVoiceChallenge from '../../../../src/screens/mfa-voice-challenge';
-import { baseContextData } from '../../../data/test-data';
-import { FormHandler } from '../../../../src/utils/form-handler';
-import { ContinueOptions } from '../../../../interfaces/screens/mfa-voice-challenge';
-import { CustomOptions } from '../../../../interfaces/common';
 import { FormActions } from '../../../../src/constants';
+import MfaVoiceChallenge from '../../../../src/screens/mfa-voice-challenge';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from '../../../../interfaces/common';
+import type { MfaVoiceChallengeContinueOptions } from '../../../../interfaces/screens/mfa-voice-challenge';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -36,7 +37,7 @@ describe('MfaVoiceChallenge', () => {
 
   describe('continue method', () => {
     it('should handle continue with valid code correctly', async () => {
-      const payload: ContinueOptions = {
+      const payload: MfaVoiceChallengeContinueOptions = {
         code: '123456',
       };
 
@@ -52,7 +53,7 @@ describe('MfaVoiceChallenge', () => {
     });
 
     it('should handle continue with remember browser option correctly', async () => {
-      const payload: ContinueOptions = {
+      const payload: MfaVoiceChallengeContinueOptions = {
         code: '123456',
         rememberDevice: true,
       };
@@ -71,11 +72,11 @@ describe('MfaVoiceChallenge', () => {
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      
-      const payload: ContinueOptions = {
+
+      const payload: MfaVoiceChallengeContinueOptions = {
         code: '123456',
       };
-      
+
       await expect(mfaVoiceChallenge.continue(payload)).rejects.toThrow(
         'Mocked reject'
       );
@@ -112,7 +113,7 @@ describe('MfaVoiceChallenge', () => {
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      
+
       await expect(mfaVoiceChallenge.pickPhone()).rejects.toThrow(
         'Mocked reject'
       );
@@ -149,7 +150,7 @@ describe('MfaVoiceChallenge', () => {
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      
+
       await expect(mfaVoiceChallenge.switchToSms()).rejects.toThrow(
         'Mocked reject'
       );
@@ -186,7 +187,7 @@ describe('MfaVoiceChallenge', () => {
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      
+
       await expect(mfaVoiceChallenge.resendCode()).rejects.toThrow(
         'Mocked reject'
       );
@@ -223,7 +224,7 @@ describe('MfaVoiceChallenge', () => {
 
     it('should throw error when promise is rejected', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
-      
+
       await expect(mfaVoiceChallenge.tryAnotherMethod()).rejects.toThrow(
         'Mocked reject'
       );

--- a/packages/auth0-acul-js/typedoc.js
+++ b/packages/auth0-acul-js/typedoc.js
@@ -1,4 +1,3 @@
-// typedoc.js
 export default {
   out: 'docs',
   entryPoints: ['./src/export.ts'],
@@ -10,5 +9,6 @@ export default {
   excludeProtected: true,
   excludeExternals: true,
   includeVersion: true,
-  categorizeByGroup: true
+  categorizeByGroup: true,
+  json: 'docs/index.json',
 };


### PR DESCRIPTION
###
🔧 PR Description: Refactor & Export Enhancements Across MFA Screens  
This PR includes refactoring and export updates across several MFA-related screens in the `auth0-acul-js` package to improve clarity, consistency, and reusability.

✅ Changes Summary  

**Type Refactor in MFA Voice Challenge**
- Renamed `ContinueOptions` to `MfaVoiceChallengeContinueOptions`
- Updated all relevant type imports/exports and method signatures accordingly 

**Enhanced Exports for Reusability**  

**Device Code Confirmation**  
- Exported `screenOptions` as `ScreenMembersOnDeviceCodeConfirmation`

**MFA Email List**  
- Added export for `SelectMfaEmailOptions`

**MFA Login Options**  
- Added import for `ScreenMembersOnMfaLoginOptions`

**MFA Push List**  
- Added export for `SelectMfaPushDeviceOptions` 

**MFA Recovery Code Enrollment**  
- Added export for `ContinueOptions`

- General Consistency Improvements  
- Standardized naming conventions and cleaned up redundant or outdated export patterns

📦 Affected Files & Packages  
- `packages/auth0-acul-js/interfaces/...`  
- `packages/auth0-acul-js/src/screens/...`  

📌 Motivation  
- Improve code readability and maintainability.  
- Avoid naming collisions with more descriptive type names.  
- Support better modular usage of screen-specific options across the codebase.  
