### PR TITLE
chore(ci): Remove Semgrep GHA Workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,14 +31,3 @@ jobs:
             echo "Scanning $dir"
             snyk test --all-projects --file=$dir/package.json || true
           done
-
-  semgrep:
-    name: Semgrep Scan
-    runs-on: ubuntu-latest
-    container:
-      image: returntocorp/semgrep
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run Semgrep
-        run: semgrep scan --config auto --exclude node_modules


### PR DESCRIPTION
Semgrep is Okta's static application security testing tool. It was previously recommended to add Semgrep directly into CI/CD pipelines or workflows. However, the ProdSec team has enhanced the tooling, and Semgrep scanning is now built into the platform via a GitHub Application.

### :information_source: Details

* You'll find all of your PRs are *already* being scanned by a dedicated Semgrep step. Given this, you no longer need to run Semgrep via a Github Action workflow.
* :warning: This PR attempts to help remove it for you. Please review this change carefully to ensure it doesn't impact any other jobs. Any adjustments needed to make this PR pass is the responsibility of the owners of the repository. (You are also welcome to close this PR and remove Semgrep CI separately).