### PR TITLE
Add pickCountryCode method to SignupId class

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/signup-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-id.ts
@@ -1,4 +1,5 @@
 import type { IdentifierType } from '../../src/constants';
+import type { CustomOptions } from '../common';
 import type { BaseContext } from '../models/base-context';
 import type { ScreenContext, ScreenMembers } from '../models/screen';
 import type { TransactionMembers, UsernamePolicy } from '../models/transaction';
@@ -53,4 +54,5 @@ export interface SignupIdMembers {
   transaction: TransactionMembersOnSignupId;
   signup(payload: SignupOptions): Promise<void>;
   federatedSignup(payload: FederatedSignupOptions): Promise<void>;
+  pickCountryCode(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -1,4 +1,4 @@
-import { ScreenIds } from '../../constants';
+import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { getBrowserCapabilities } from '../../utils/browser-capabilities';
 import { FormHandler } from '../../utils/form-handler';
@@ -104,6 +104,24 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
       telemetry: [SignupId.screenIdentifier, 'federatedSignup'],
     };
     await new FormHandler(options).submitData<FederatedSignupOptions>(payload);
+  }
+
+  /**
+   * @example
+   * import SignupId from "@auth0/auth0-acul-js/signup-id";
+   * const signupIdManager = new SignupId();
+   *
+   * signupIdManager.pickCountryCode();
+   */
+  async pickCountryCode(): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [SignupId.screenIdentifier, 'pickCountryCode'],
+    };
+
+    await new FormHandler(options).submitData({
+      action: FormActions.PICK_COUNTRY_CODE,
+    });
   }
 }
 

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
@@ -1,4 +1,4 @@
-import { ScreenIds } from '../../../../src/constants';
+import { ScreenIds, FormActions } from '../../../../src/constants';
 import SignupId from '../../../../src/screens/signup-id';
 import { getBrowserCapabilities } from '../../../../src/utils/browser-capabilities';
 import { FormHandler } from '../../../../src/utils/form-handler';
@@ -134,6 +134,23 @@ describe('SignupId', () => {
       await expect(signupId.federatedSignup(payload)).rejects.toThrow(
         'Mocked reject'
       );
+    });
+  });
+
+  describe('pickCountryCode', () => {
+    it('should submit pick-country-code action', async () => {
+      await signupId.pickCountryCode();
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        action: FormActions.PICK_COUNTRY_CODE,
+      });
+    });
+
+    it('should throw an error if submitData fails', async () => {
+      const expectedError = new Error('Submission failed');
+      mockFormHandler.submitData.mockRejectedValue(expectedError);
+
+      await expect(signupId.pickCountryCode()).rejects.toThrow(expectedError);
     });
   });
 });


### PR DESCRIPTION
### Summary

This PR adds support for the `pickCountryCode` action in the `signup-id` screen of the React SDK. It allows applications to programmatically trigger the country code selection step via a dedicated method on the `SignupId` screen object.

### Changes Introduced

- Added `pickCountryCode(payload?: CustomOptions): Promise<void>` to the `SignupIdMembers` interface.  
- Implemented the `pickCountryCode` method inside the `SignupId` class using `FormHandler.submitData` with action `FormActions.PICK_COUNTRY_CODE`.  
- Included telemetry information for better tracking of screen transitions.  
- Added unit tests to:  
  - Confirm that `submitData` is called with the expected action.  
  - Ensure proper error propagation if the submission fails.

### Testing

- ✅ Unit tests cover both success and failure scenarios for `pickCountryCode`.  
- ✅ Manual testing confirms correct triggering of the screen and expected behavior.

###
