### PR TITLE
feat: introduce usePasswordValidation and useIdentifiers utility hooks

### DIFF
--- a/packages/auth0-acul-js/src/index.ts
+++ b/packages/auth0-acul-js/src/index.ts
@@ -9,7 +9,7 @@ export * from '../interfaces/export/screen-properties';
 export * from '../interfaces/export/options';
 export * from '../interfaces/export/extended-types';
 export * from '../interfaces/export/common';
-
+export { default as usePasswordValidation } from './utility-hooks/usePasswordValidation';
 export function getCurrentScreen(): string | null {
   return new BaseContext().getContext('screen')?.name ?? null;
 }

--- a/packages/auth0-acul-js/src/index.ts
+++ b/packages/auth0-acul-js/src/index.ts
@@ -9,7 +9,6 @@ export * from '../interfaces/export/screen-properties';
 export * from '../interfaces/export/options';
 export * from '../interfaces/export/extended-types';
 export * from '../interfaces/export/common';
-export { default as usePasswordValidation } from './utility-hooks/usePasswordValidation';
 export function getCurrentScreen(): string | null {
   return new BaseContext().getContext('screen')?.name ?? null;
 }

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -77,3 +77,6 @@ export { default as ResetPasswordMfaWebAuthnRoamingChallenge } from './reset-pas
 // export { default as BruteForceProtectionUnblock } from './brute-force-protection-unblock';
 // export { default as BruteForceProtectionUnblockFailure } from './brute-force-protection-unblock-failure';
 // export { default as BruteForceProtectionUnblockSuccess } from './brute-force-protection-unblock-success';
+export { validatePassword as validatePasswordFromSignup } from './signup';
+export { validatePassword as validatePasswordFromSignupPassword } from './signup-password';
+export { getIdentifier as getIdentifierFromUtilityHooks } from './signup';

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -1,5 +1,6 @@
 import { ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
+import { validatePasswordforSignupPassword } from '../../utility-hooks/signup-password/validatePassword';
 import { FormHandler } from '../../utils/form-handler';
 
 import { ScreenOverride } from './screen-override';
@@ -110,3 +111,4 @@ export {
 };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';
+export const validatePassword = validatePasswordforSignupPassword;

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -1,9 +1,12 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
+import getIdentifierFn from '../../utility-hooks/getIdentifier';
+import { validatePasswordforSignup } from '../../utility-hooks/signup/validatePassword';
 import { FormHandler } from '../../utils/form-handler';
 
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
+
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
@@ -15,6 +18,9 @@ import type {
   TransactionMembersOnSignup as TransactionOptions,
 } from '../../../interfaces/screens/signup';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type {Identifier} from '../../utility-hooks/getIdentifier';
+import type {PasswordValidationResult} from '../../utility-hooks/validatePassword';
+
 export default class Signup extends BaseContext implements SignupMembers {
   static screenIdentifier: string = ScreenIds.SIGNUP;
   screen: ScreenOptions;
@@ -99,6 +105,8 @@ export default class Signup extends BaseContext implements SignupMembers {
   }
 }
 
-export { SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
+export { PasswordValidationResult, Identifier, SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';
+export const validatePassword = validatePasswordforSignup;
+export const getIdentifier = getIdentifierFn;

--- a/packages/auth0-acul-js/src/utility-hooks/getIdentifier.ts
+++ b/packages/auth0-acul-js/src/utility-hooks/getIdentifier.ts
@@ -1,0 +1,60 @@
+import { BaseContext } from '../models/base-context';
+
+import type { DBConnection } from '../../interfaces/models/transaction';
+
+type IdentifierType = 'email' | 'phone' | 'username';
+
+export interface Identifier {
+  type: IdentifierType;
+  required: boolean;
+}
+
+/**
+ * Type guard to ensure connection is of type DBConnection.
+ */
+function isDBConnection(conn: unknown): conn is DBConnection {
+  return typeof conn === 'object' && conn !== null && 'options' in conn;
+}
+
+/**
+ * Returns the list of identifiers (email, phone, username) with their required status
+ * based on transaction context's connection configuration.
+ *
+ * @example
+ * getIdentifier();
+ * // Returns: [{ type: 'email', required: true }, { type: 'username', required: false }]
+ */
+function getIdentifier(): Identifier[] {
+  const context = new BaseContext();
+  const transactionContext = context.getContext('transaction');
+
+  if (!transactionContext?.connection) return [];
+
+  const connection = transactionContext.connection;
+
+  // Safely check if it's a DBConnection
+  if (!isDBConnection(connection) || !connection.options?.attributes) {
+    return [];
+  }
+
+  const attributes = connection.options.attributes;
+  const identifiers: Identifier[] = [];
+
+  const identifierFields: IdentifierType[] = ['email', 'phone', 'username'];
+
+  for (const field of identifierFields) {
+    const attr = attributes[field];
+    if (!attr || attr.signup_status === 'inactive') {
+      continue;
+    }
+
+    identifiers.push({
+      type: field,
+      required: attr.signup_status === 'required',
+    });
+  }
+
+  return identifiers;
+}
+
+export default getIdentifier;

--- a/packages/auth0-acul-js/src/utility-hooks/signup-password/validatePassword.ts
+++ b/packages/auth0-acul-js/src/utility-hooks/signup-password/validatePassword.ts
@@ -1,0 +1,10 @@
+import signupPasswordInstance from '../../screens/signup-password';
+import coreValidatePassword from '../validatePassword';
+
+import type { PasswordValidationResult } from '../validatePassword';
+
+export function validatePasswordforSignupPassword(password: string): PasswordValidationResult {
+  const context = new signupPasswordInstance();
+  const passwordPolicy = context.transaction?.passwordPolicy;
+  return coreValidatePassword(password, passwordPolicy);
+}

--- a/packages/auth0-acul-js/src/utility-hooks/signup/validatePassword.ts
+++ b/packages/auth0-acul-js/src/utility-hooks/signup/validatePassword.ts
@@ -1,0 +1,10 @@
+import signupPasswordInstance from '../../screens/signup';
+import coreValidatePassword from '../validatePassword';
+
+import type { PasswordValidationResult } from '../validatePassword';
+
+export function validatePasswordforSignup(password: string): PasswordValidationResult {
+  const context = new signupPasswordInstance();
+  const passwordPolicy = context.transaction?.passwordPolicy;
+  return coreValidatePassword(password, passwordPolicy);
+}

--- a/packages/auth0-acul-js/src/utility-hooks/usePasswordValidation.ts
+++ b/packages/auth0-acul-js/src/utility-hooks/usePasswordValidation.ts
@@ -1,0 +1,92 @@
+import type { PasswordPolicy, Error, PasswordComplexityRule } from '../../interfaces/models/transaction';
+
+type PasswordValidationResult = {
+  isValid: boolean;
+  errors: Error[];
+};
+
+function validatePassword(
+  password: string,
+  policy?: PasswordPolicy | null
+): PasswordValidationResult {
+  const errors: Error[] = [];
+
+  if (!policy) {
+    if (!password || typeof password !== 'string') {
+      errors.push({ code: 'password_required', message: 'Password is required.' });
+      return { isValid: false, errors };
+    }
+    return { isValid: true, errors };
+  }
+
+  const minLength = policy.minLength ?? 8;
+
+  const lower = /[a-z]/.test(password);
+  const upper = /[A-Z]/.test(password);
+  const number = /\d/.test(password);
+  const special = /[\W_]/.test(password);
+  const identicalChars = /(.)\1\1/.test(password); // 3+ identical chars in a row
+  const complexityMap: Record<string, boolean> = {
+    'password-policy-lower-case': lower,
+    'password-policy-upper-case': upper,
+    'password-policy-numbers': number,
+    'password-policy-special-characters': special,
+  };
+
+  const passedComplexityChecks = Object.values(complexityMap).filter(Boolean).length;
+
+const securityInfo = (policy.passwordSecurityInfo ?? []) as PasswordComplexityRule[];
+
+  for (const rule of securityInfo) {
+    switch (rule.code) {
+      case 'password-policy-length-at-least':
+        if (password.length < (rule.args?.count ?? minLength)) {
+          errors.push({ code: rule.code, message: rule.label });
+        }
+        break;
+
+      case 'password-policy-lower-case':
+      case 'password-policy-upper-case':
+      case 'password-policy-numbers':
+      case 'password-policy-special-characters':
+        if (!complexityMap[rule.code]) {
+          errors.push({ code: rule.code, message: rule.label });
+        }
+        break;
+
+      case 'password-policy-identical-chars':
+        if (identicalChars) {
+          errors.push({ code: rule.code, message: rule.label });
+        }
+        break;
+
+      case 'password-policy-contains-at-least': {
+        const requiredCount = rule.args?.count ?? 3;
+        if (passedComplexityChecks < requiredCount) {
+          errors.push({ code: rule.code, message: rule.label });
+        }
+
+        // Check nested items and push individual failed items too
+        if (rule.items) {
+          for (const item of rule.items) {
+            const passed = complexityMap[item.code] ?? true;
+            if (!passed) {
+              errors.push({ code: item.code, message: item.label });
+            }
+          }
+        }
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+export default validatePassword;

--- a/packages/auth0-acul-js/src/utility-hooks/validatePassword.ts
+++ b/packages/auth0-acul-js/src/utility-hooks/validatePassword.ts
@@ -1,6 +1,6 @@
 import type { PasswordPolicy, Error, PasswordComplexityRule } from '../../interfaces/models/transaction';
 
-type PasswordValidationResult = {
+export type PasswordValidationResult = {
   isValid: boolean;
   errors: Error[];
 };
@@ -9,6 +9,7 @@ function validatePassword(
   password: string,
   policy?: PasswordPolicy | null
 ): PasswordValidationResult {
+
   const errors: Error[] = [];
 
   if (!policy) {
@@ -35,7 +36,7 @@ function validatePassword(
 
   const passedComplexityChecks = Object.values(complexityMap).filter(Boolean).length;
 
-const securityInfo = (policy.passwordSecurityInfo ?? []) as PasswordComplexityRule[];
+  const securityInfo = (policy.passwordSecurityInfo ?? []) as PasswordComplexityRule[];
 
   for (const rule of securityInfo) {
     switch (rule.code) {


### PR DESCRIPTION
### Description

This PR introduces two new utility hooks to support reusable logic in form validation and identifier handling across screens:

🔧 **Changes Introduced:**

**usePasswordValidation**:

Validates password input against the current passwordPolicy from context.

Helps prevent network requests when client-side password validation fails.

**useIdentifiers**:

Provides a unified list of required and optional identifiers (email, phone, username) based on the current transaction context.

Enables dynamic rendering of identifier fields in forms.

🎯 **Purpose**:

Centralizes password validation logic to ensure consistency across screens.

Improves form rendering flexibility based on identifier configuration.

Avoids direct use of transaction.errors for pre-submit validations.

🧪 **Screens Affected**:

- Signup
- Signup-password
- signup-id


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

Tested and validated these changes with sample react app via universal-login-samples screen examples.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
