### PR TITLE
feat: Introduce validatePassword helper method on reset-password screen

### DIFF
--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,4 +1,4 @@
-export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail } from '../models/screen';
+export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordValidationResult, IdentifierType as ScreenIdentifierType } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
 export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme } from '../common/index';

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -14,7 +14,7 @@ export type { LoginMembers } from '../screens/login';
 export type { SignupMembers } from '../screens/signup';
 export type { ResetPasswordEmailMembers } from '../screens/reset-password-email';
 export type { ResetPasswordRequestMembers } from '../screens/reset-password-request';
-export type { ResetPasswordMembers } from '../screens/reset-password';
+export type { ResetPasswordMembers, TransactionMembersOnResetPassword } from '../screens/reset-password';
 export type { ResetPasswordErrorMembers } from '../screens/reset-password-error';
 export type { ResetPasswordSuccessMembers } from '../screens/reset-password-success';
 export type { ResetPasswordMfaPushChallengePushMembers } from '../screens/reset-password-mfa-push-challenge-push';

--- a/packages/auth0-acul-js/interfaces/screens/reset-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password.ts
@@ -1,5 +1,7 @@
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers, ScreenData } from '../models/screen';
+import type { TransactionMembers, PasswordPolicy } from '../models/transaction';
+
 export interface ResetPasswordOptions {
   'password-reset': string;
   're-enter-password': string;
@@ -15,5 +17,10 @@ export interface ScreenMembersOnResetPassword extends ScreenMembers {
 }
 export interface ResetPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnResetPassword;
+  transaction: TransactionMembersOnResetPassword;
   resetPassword(payload: ResetPasswordOptions): Promise<void>;
+}
+
+export interface TransactionMembersOnResetPassword extends TransactionMembers {
+  passwordPolicy: PasswordPolicy | null;
 }

--- a/packages/auth0-acul-js/src/screens/reset-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password/index.ts
@@ -1,24 +1,32 @@
 import { ScreenIds } from '../../constants';
+import coreValidatePassword from '../../helpers/validatePassword';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
 import { ScreenOverride } from './screen-override';
+import { TransactionOverride } from './transaction-override';
 
-import type { ScreenContext } from '../../../interfaces/models/screen';
+import type { ScreenContext, PasswordValidationResult } from '../../../interfaces/models/screen';
+import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
   ResetPasswordOptions,
   ResetPasswordMembers,
   ScreenMembersOnResetPassword as ScreenOptions,
+  TransactionMembersOnResetPassword as TransactionOptions
 } from '../../../interfaces/screens/reset-password';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 export default class ResetPassword extends BaseContext implements ResetPasswordMembers {
   static screenIdentifier: string = ScreenIds.RESET_PASSWORD;
   screen: ScreenOptions;
+  transaction: TransactionOptions;
 
   constructor() {
     super();
     const screenContext = this.getContext('screen') as ScreenContext;
     this.screen = new ScreenOverride(screenContext);
+    const transactionContext = this.getContext('transaction') as TransactionContext;
+
+    this.transaction = new TransactionOverride(transactionContext);
   }
   /**
    * @example
@@ -36,6 +44,23 @@ export default class ResetPassword extends BaseContext implements ResetPasswordM
       telemetry: [ResetPassword.screenIdentifier, 'resetPassword'],
     };
     await new FormHandler(options).submitData(payload);
+  }
+
+  /**
+   * Validates a given password against the current password policy
+   * defined in the transaction context.
+   *
+   * @param password - The password string to validate.
+   * @returns Result object indicating whether the password is valid and why.
+   *
+   * @example
+   * const resetPassword = new ResetPassword();
+   * const result = resetPassword.validatePassword('MyP@ssw0rd');
+   * // result => { valid: true, errors: [] }
+   */
+  validatePassword(password: string): PasswordValidationResult {
+    const passwordPolicy = this.transaction?.passwordPolicy;
+    return coreValidatePassword(password, passwordPolicy);
   }
 }
 export { ResetPasswordMembers, ResetPasswordOptions, ScreenOptions as ScreenMembersOnResetPassword };

--- a/packages/auth0-acul-js/src/screens/reset-password/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password/transaction-override.ts
@@ -1,0 +1,14 @@
+import { Transaction } from '../../models/transaction';
+import { getPasswordPolicy } from '../../shared/transaction';
+
+import type { TransactionContext } from '../../../interfaces/models/transaction';
+import type { TransactionMembersOnResetPassword as OverrideOptions } from '../../../interfaces/screens/reset-password';
+
+export class TransactionOverride extends Transaction implements OverrideOptions {
+  passwordPolicy: OverrideOptions['passwordPolicy'];
+
+  constructor(transactionContext: TransactionContext) {
+    super(transactionContext);
+    this.passwordPolicy = getPasswordPolicy(transactionContext);
+  }
+}


### PR DESCRIPTION
### Description

This PR introduces a new helper method to support reusable logic in password validation against password policy on  reset-password screen.
Also, we added passwordPolicy on transaction context of reset-password screen, which was missing earlier.

🔧 **Changes Introduced:**

**validatePassword**:

Validates password input against the current passwordPolicy from context.

Helps prevent network requests when client-side password validation fails.

🎯 **Purpose**:

Centralizes password validation logic to ensure consistency across screens.

Avoids direct use of transaction.errors for pre-submit validations.

🧪 **Screens Affected**:
- reset-password


### Testing

Tested and validated these changes with sample react app via universal-login-samples screen examples.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
