### PR TITLE
feat: Introduce getActiveIdentifiers helper method

### DIFF
--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -65,7 +65,13 @@ const LoginScreen: React.FC = () => {
   
   const loginManager = new Login();
   const { transaction } = loginManager;
-  
+  const activeIdentifiers = useMemo(() => loginManager.getActiveIdentifiers(), []);
+
+  const getIdentifierLabel = () => {
+    if (activeIdentifiers?.length === 1) return `Enter your ${activeIdentifiers[0]}`;
+    return `Enter your ${activeIdentifiers?.join(" or ")}`;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
@@ -101,7 +107,7 @@ const LoginScreen: React.FC = () => {
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div>
               <label htmlFor="username" className="block text-sm font-medium text-gray-700">
-                Username or Email
+                {getIdentifierLabel()}
               </label>
               <div className="mt-1">
                 <input
@@ -111,6 +117,7 @@ const LoginScreen: React.FC = () => {
                   required
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
+                  placeholder= {getIdentifierLabel()}
                   className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                 />
               </div>

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -61,4 +61,5 @@ export interface LoginIdMembers extends BaseMembers {
   federatedLogin(payload: FederatedLoginOptions): Promise<void>;
   passkeyLogin(payload?: CustomOptions): Promise<void>;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
+  getActiveIdentifiers(): string[] | null;
 }

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -90,4 +90,9 @@ export interface LoginMembers extends BaseMembers {
    * @param payload The social login options
    */
   federatedLogin(payload: FederatedLoginOptions): Promise<void>;
+  /**
+   * Gets the active identifier types for the login screen
+   * @returns An array of active identifier types or null if none are active
+   */
+  getActiveIdentifiers(): string[] | null;
 }

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -133,6 +133,20 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
       action: FormActions.PICK_COUNTRY_CODE,
     });
   }
+
+  /**
+   * Gets the active identifier types for the login screen
+   * @returns An array of active identifier types or null if none are active
+   * @example
+   * ```typescript
+   * import LoginId from "@auth0/auth0-acul-js/login";
+   * const loginIdManager = new LoginId();
+   * loginIdManager.getActiveIdentifiers();
+   * ```
+   */
+  getActiveIdentifiers(): string[] | null {
+    return this.transaction.allowedIdentifiers;
+  }
 }
 
 export {

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -69,6 +69,20 @@ export default class Login extends BaseContext implements LoginMembers {
     const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'federatedLogin'] };
     await new FormHandler(options).submitData<FederatedLoginOptions>(payload);
   }
+
+  /**
+   * Gets the active identifier types for the login screen
+   * @returns An array of active identifier types or null if none are active
+   * @example
+   * ```typescript
+   * import Login from "@auth0/auth0-acul-js/login";
+   * const loginManager = new Login();
+   * loginManager.getActiveIdentifiers();
+   * ```
+   */
+  getActiveIdentifiers(): string[] | null {
+    return this.transaction.allowedIdentifiers || null;
+  }
 }
 
 export { LoginMembers, LoginOptions, FederatedLoginOptions, ScreenOptions as ScreenMembersOnLogin, TransactionOptions as TransactionMembersOnLogin };

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
@@ -107,4 +107,19 @@ describe('LoginId', () => {
   it('should extend BaseContext', () => {
     expect(loginId).toBeInstanceOf(BaseContext);
   });
+
+  describe('getActiveIdentifiers method', () => {
+    it('should return allowedIdentifiers when set in transaction', () => {
+      loginId.transaction.allowedIdentifiers = ['email', 'username'];
+      const result = loginId.getActiveIdentifiers();
+      expect(result).toEqual(['email', 'username']);
+    });
+
+    it('should return null when allowedIdentifiers is null or empty', () => {
+      loginId.transaction.allowedIdentifiers = null;
+      expect(loginId.getActiveIdentifiers()).toBeNull();
+      loginId.transaction.allowedIdentifiers = [];
+      expect(loginId.getActiveIdentifiers()).toEqual([]);
+    });
+  });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -96,4 +96,20 @@ describe('Login', () => {
       await expect(login.federatedLogin(payload)).rejects.toThrow('Mocked reject');
     });
   });
+
+  describe('getActiveIdentifiers method', () => {
+      it('should return allowedIdentifiers when set in transaction', () => {
+        login.transaction.allowedIdentifiers = ['email', 'username'];
+        const result = login.getActiveIdentifiers();
+        expect(result).toEqual(['email', 'username']);
+      });
+
+      it('should return null when allowedIdentifiers is null or empty', () => {
+        login.transaction.allowedIdentifiers = null;
+        expect(login.getActiveIdentifiers()).toBeNull();
+        login.transaction.allowedIdentifiers = [];
+        expect(login.getActiveIdentifiers()).toEqual([]);
+      });
+  });
+
 });


### PR DESCRIPTION
### Description

This PR introduces a new helper method `getActiveIdentifiers` to easily access allowedIdentifiers property on login screens. 

🔧 **Changes Introduced:**

**getActiveIdentifiers**:

Gets the active identifier types for the login screen

🧪 **Screens Affected**:
- login
- login-id


### Testing

Tested and validated these changes with sample react app via universal-login-samples screen examples.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
