### PR TITLE
feat - Introduce usePasswordValidation, useEnabledIdentifiers and useActiveIdentifiers utility hooks fro React SDK

### DIFF
--- a/packages/auth0-acul-react/src/classes.ts
+++ b/packages/auth0-acul-react/src/classes.ts
@@ -656,28 +656,28 @@ export namespace ResetPassword {
   export const resetPassword = resetPassword_ResetPassword;
 }
 
-import { useSignupId as useSignupId_SignupId, useScreen as useScreen_SignupId, useTransaction as useTransaction_SignupId, signup as signup_SignupId, federatedSignup as federatedSignup_SignupId, getEnabledIdentifiers as getEnabledIdentifiers_SignupId, pickCountryCode as pickCountryCode_SignupId } from './screens/signup-id';
+import { useSignupId as useSignupId_SignupId, useScreen as useScreen_SignupId, useTransaction as useTransaction_SignupId, signup as signup_SignupId, federatedSignup as federatedSignup_SignupId, useEnabledIdentifiers as useEnabledIdentifiers_SignupId, pickCountryCode as pickCountryCode_SignupId } from './screens/signup-id';
 export namespace SignupId {
   export const useSignupId = useSignupId_SignupId;
   export const useScreen = useScreen_SignupId;
   export const useTransaction = useTransaction_SignupId;
   export const signup = signup_SignupId;
   export const federatedSignup = federatedSignup_SignupId;
-  export const getEnabledIdentifiers = getEnabledIdentifiers_SignupId;
+  export const useEnabledIdentifiers = useEnabledIdentifiers_SignupId;
   export const pickCountryCode = pickCountryCode_SignupId;
 }
 
-import { useSignupPassword as useSignupPassword_SignupPassword, useScreen as useScreen_SignupPassword, useTransaction as useTransaction_SignupPassword, signup as signup_SignupPassword, federatedSignup as federatedSignup_SignupPassword, validatePassword as validatePassword_SignupPassword } from './screens/signup-password';
+import { useSignupPassword as useSignupPassword_SignupPassword, useScreen as useScreen_SignupPassword, useTransaction as useTransaction_SignupPassword, signup as signup_SignupPassword, federatedSignup as federatedSignup_SignupPassword, usePasswordValidation as usePasswordValidation_SignupPassword } from './screens/signup-password';
 export namespace SignupPassword {
   export const useSignupPassword = useSignupPassword_SignupPassword;
   export const useScreen = useScreen_SignupPassword;
   export const useTransaction = useTransaction_SignupPassword;
   export const signup = signup_SignupPassword;
   export const federatedSignup = federatedSignup_SignupPassword;
-  export const validatePassword = validatePassword_SignupPassword;
+  export const usePasswordValidation = usePasswordValidation_SignupPassword;
 }
 
-import { useSignup as useSignup_Signup, useScreen as useScreen_Signup, useTransaction as useTransaction_Signup, signup as signup_Signup, federatedSignup as federatedSignup_Signup, pickCountryCode as pickCountryCode_Signup, validatePassword as validatePassword_Signup, getEnabledIdentifiers as getEnabledIdentifiers_Signup } from './screens/signup';
+import { useSignup as useSignup_Signup, useScreen as useScreen_Signup, useTransaction as useTransaction_Signup, signup as signup_Signup, federatedSignup as federatedSignup_Signup, pickCountryCode as pickCountryCode_Signup, usePasswordValidation as usePasswordValidation_Signup, useEnabledIdentifiers as useEnabledIdentifiers_Signup } from './screens/signup';
 export namespace Signup {
   export const useSignup = useSignup_Signup;
   export const useScreen = useScreen_Signup;
@@ -685,8 +685,8 @@ export namespace Signup {
   export const signup = signup_Signup;
   export const federatedSignup = federatedSignup_Signup;
   export const pickCountryCode = pickCountryCode_Signup;
-  export const validatePassword = validatePassword_Signup;
-  export const getEnabledIdentifiers = getEnabledIdentifiers_Signup;
+  export const usePasswordValidation = usePasswordValidation_Signup;
+  export const useEnabledIdentifiers = useEnabledIdentifiers_Signup;
 }
 
 import { useCurrentScreen as use_currentScreen, useAuth0Themes as use_Auth0Themes, useErrors as use_Errors } from '../src/hooks/common-hooks';

--- a/packages/auth0-acul-react/src/screens/login-id.tsx
+++ b/packages/auth0-acul-react/src/screens/login-id.tsx
@@ -33,6 +33,7 @@ export const login = (payload: LoginOptions) => getInstance().login(payload);
 export const federatedLogin = (payload: FederatedLoginOptions) => getInstance().federatedLogin(payload);
 export const passkeyLogin = (payload?: CustomOptions) => getInstance().passkeyLogin(payload);
 export const pickCountryCode = (payload?: CustomOptions) => getInstance().pickCountryCode(payload);
+export const useActiveIdentifiers = () => getInstance().getActiveIdentifiers();
 
 export type { ScreenMembersOnLoginId, TransactionMembersOnLoginId, LoginOptions, FederatedLoginOptions, LoginIdMembers } from '@auth0/auth0-acul-js/login-id';
 

--- a/packages/auth0-acul-react/src/screens/login.tsx
+++ b/packages/auth0-acul-react/src/screens/login.tsx
@@ -31,6 +31,7 @@ export const useTransaction: () => TransactionMembersOnLogin = () => useMemo(() 
 // Screen methods
 export const login = (payload: LoginOptions) => getInstance().login(payload);
 export const federatedLogin = (payload: FederatedLoginOptions) => getInstance().federatedLogin(payload);
+export const useActiveIdentifiers = () => getInstance().getActiveIdentifiers();
 
 export type { ScreenMembersOnLogin, TransactionMembersOnLogin, LoginOptions, FederatedLoginOptions, LoginMembers } from '@auth0/auth0-acul-js/login';
 

--- a/packages/auth0-acul-react/src/screens/reset-password.tsx
+++ b/packages/auth0-acul-react/src/screens/reset-password.tsx
@@ -27,7 +27,7 @@ export const {
 
 export const useScreen: () => ScreenMembersOnResetPassword = () => useMemo(() => getInstance().screen, []);
 export const useTransaction = () => useMemo(() => getInstance().transaction, []);
-
+export const usePasswordValidation = () => useMemo(() => getInstance().validatePassword, []);
 // Screen methods
 export const resetPassword = (payload: ResetPasswordOptions) => getInstance().resetPassword(payload);
 

--- a/packages/auth0-acul-react/src/screens/signup-id.tsx
+++ b/packages/auth0-acul-react/src/screens/signup-id.tsx
@@ -31,7 +31,7 @@ export const useTransaction: () => TransactionMembersOnSignupId = () => useMemo(
 // Screen methods
 export const signup = (payload: SignupOptions) => getInstance().signup(payload);
 export const federatedSignup = (payload: FederatedSignupOptions) => getInstance().federatedSignup(payload);
-export const getEnabledIdentifiers = () => getInstance().getEnabledIdentifiers();
+export const useEnabledIdentifiers = () => getInstance().getEnabledIdentifiers();
 export const pickCountryCode = (payload?: CustomOptions) => getInstance().pickCountryCode(payload);
 
 export type { ScreenMembersOnSignupId, TransactionMembersOnSignupId, FederatedSignupOptions, SignupOptions, SignupIdMembers } from '@auth0/auth0-acul-js/signup-id';

--- a/packages/auth0-acul-react/src/screens/signup-password.tsx
+++ b/packages/auth0-acul-react/src/screens/signup-password.tsx
@@ -31,7 +31,7 @@ export const useTransaction: () => TransactionMembersOnSignupPassword = () => us
 // Screen methods
 export const signup = (payload: SignupPasswordOptions) => getInstance().signup(payload);
 export const federatedSignup = (payload: FederatedSignupOptions) => getInstance().federatedSignup(payload);
-export const validatePassword = (password: string) => getInstance().validatePassword(password);
+export const usePasswordValidation = (password: string) => getInstance().validatePassword(password);
 
 export type { FederatedSignupOptions, ScreenMembersOnSignupPassword, TransactionMembersOnSignupPassword, SignupPasswordOptions, SignupPasswordMembers } from '@auth0/auth0-acul-js/signup-password';
 

--- a/packages/auth0-acul-react/src/screens/signup.tsx
+++ b/packages/auth0-acul-react/src/screens/signup.tsx
@@ -32,8 +32,8 @@ export const useTransaction: () => TransactionMembersOnSignup = () => useMemo(()
 export const signup = (payload: SignupOptions) => getInstance().signup(payload);
 export const federatedSignup = (payload: FederatedSignupOptions) => getInstance().federatedSignup(payload);
 export const pickCountryCode = (payload?: CustomOptions) => getInstance().pickCountryCode(payload);
-export const validatePassword = (password: string) => getInstance().validatePassword(password);
-export const getEnabledIdentifiers = () => getInstance().getEnabledIdentifiers();
+export const usePasswordValidation = (password: string) => getInstance().validatePassword(password);
+export const useEnabledIdentifiers = () => getInstance().getEnabledIdentifiers();
 
 export type { SignupOptions, FederatedSignupOptions, ScreenMembersOnSignup, TransactionMembersOnSignup, SignupMembers } from '@auth0/auth0-acul-js/signup';
 


### PR DESCRIPTION
### Description

This PR introduces 3 new utility hooks in React SDK to support reusable logic in form validation and identifier handling across screens:

🔧 **Changes Introduced:**

**usePasswordValidation**:

Validates password input against the current passwordPolicy from context.

Helps prevent network requests when client-side password validation fails.

**useEnabledIdentifiers**:

Provides a unified list of required and optional identifiers (email, phone, username) based on the current transaction context.

Enables dynamic rendering of identifier fields in forms.

**useActiveIdentifiers**:

Provides a unified list of active identifier types for the login screens.


🎯 **Purpose**:

Centralizes password validation logic to ensure consistency across screens.

Improves form rendering flexibility based on identifier configuration.

Avoids direct use of transaction.errors for pre-submit validations.

🧪 **Screens Affected**:
- Signup
- Signup-password
- signup-id
- reset-password
- login
- login-id

### Testing

Tested and validated these changes with sample react app via universal-login-samples screen examples.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
