### PR TITLE
Update: Refactored validatePassword structure to align with UL screen validation requirements

### DIFF
--- a/packages/auth0-acul-js/examples/signup.md
+++ b/packages/auth0-acul-js/examples/signup.md
@@ -2,189 +2,271 @@
 ## React Component Example with TailwindCSS
 
 ```tsx
-import React, { useState, useEffect, useRef } from 'react';
-import Signup from '@auth0/auth0-acul-js/signup';
+import React, { useState, useRef } from 'react';
+import LoginInstance from "@auth0/auth0-acul-js/signup";
+import { withWindowDebug } from "../../../utils";
+import { Logo } from '../../components/Logo';
+import { Title } from './components/Title';
+import { FederatedLogin } from './components/FederatedLogin';
+import { Links } from './components/Links';
+import { ErrorMessages } from './components/ErrorMessages';
+import Button from '../../components/Button';
 
 const SignupScreen: React.FC = () => {
-  const signupManager = new Signup();
-  const { transaction, screen } = signupManager;
+  // Initialize signupManager once
+  const [signupManager] = useState(() => new LoginInstance());
+  withWindowDebug(signupManager, 'signup');
 
-  const emailRef = useRef<HTMLInputElement>(null);
+  // Refs for form inputs
   const usernameRef = useRef<HTMLInputElement>(null);
   const phoneNumberRef = useRef<HTMLInputElement>(null);
+  const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const captchaRef = useRef<HTMLInputElement>(null);
 
-  const [errors, setErrors] = useState<Array<{ code: string; message: string }>>([]);
+  // Validation & error states
   const [isValid, setIsValid] = useState(true);
-  const [identifiers, setIdentifiers] = useState<Array<{ type: string; required: boolean }>>([]);
-  const [errorMessage, setErrorMessage] = useState('');
+  const [errors, setErrors] = useState<Array<{ code: string; message: string }>>([]);
+  const [passwordValidation, setPasswordValidation] = useState<
+    Array<{ code: string; policy: string; isValid: boolean }>
+  >([]);
+  const [hasTypedPassword, setHasTypedPassword] = useState(false);
 
-  useEffect(() => {
-    const ids = signupManager.getEnabledIdentifiers();
-    setIdentifiers(ids ?? []);
-  }, []);
+  // Extract enabled identifiers from signupManager
+  const identifiers = signupManager.getEnabledIdentifiers();
 
-  const getValue = (ref: React.RefObject<HTMLInputElement>) => ref.current?.value?.trim() ?? '';
+  // Helper to get all form values at once
+  const getFormValues = () => ({
+    username: usernameRef.current?.value ?? "",
+    phoneNumber: phoneNumberRef.current?.value ?? "",
+    email: emailRef.current?.value ?? "",
+    password: passwordRef.current?.value ?? "",
+    captcha: captchaRef.current?.value ?? "",
+  });
 
-  const handleSignupClick = async () => {
-    const email = getValue(emailRef);
-    const username = getValue(usernameRef);
-    const phoneNumber = getValue(phoneNumberRef);
-    const password = getValue(passwordRef);
-    const captcha = getValue(captchaRef);
+  // Password input change handler
+  const onPasswordChange = (password: string) => {
+    if (!hasTypedPassword && password.length > 0) setHasTypedPassword(true);
 
-    const { isValid, errors } = signupManager.validatePassword(password);
-    setIsValid(isValid);
-    setErrors(errors);
+    const results = signupManager.validatePassword(password);
+    setPasswordValidation(results);
 
-    if (!isValid) return;
-
-    try {
-      await signupManager.signup({ email, username, phone: phoneNumber, password, captcha });
-    } catch {
-      setErrorMessage('Signup failed. Please check your inputs.');
-    }
+    const failedRules = results.filter((r) => !r.isValid);
+    setIsValid(failedRules.length === 0);
+    setErrors(failedRules.map((r) => ({ code: r.code, message: r.policy })));
   };
 
-  const handleSocialSignup = async (connection: string) => {
-    try {
-      await signupManager.federatedSignup({ connection });
-    } catch {
-      setErrorMessage('Social signup failed. Please try again.');
-    }
+  // Signup button click handler
+  const onSignupClick = () => {
+    const { username, email, phoneNumber, password, captcha } = getFormValues();
+
+    const results = signupManager.validatePassword(password);
+    const failed = results.filter((rule) => !rule.isValid);
+    const valid = failed.length === 0;
+
+    setIsValid(valid);
+    setErrors(failed.map((rule) => ({ code: rule.code, message: rule.policy })));
+
+    if (!valid) return;
+
+    const options = {
+      username,
+      email,
+      phoneNumber,
+      password,
+      captcha: signupManager.screen.isCaptchaAvailable ? captcha : "",
+    };
+    signupManager.signup(options);
   };
 
-  const renderIdentifierField = (
-    type: 'email' | 'username' | 'phone',
-    label: string,
-    ref: React.RefObject<HTMLInputElement>
-  ) => {
-    const identifier = identifiers.find((id) => id.type === type);
-    if (!identifier) return null;
-
-    const inputType = type === 'phone' ? 'tel' : type === 'email' ? 'email' : 'text';
-    const id = type === 'phone' ? 'phoneNumber' : type;
-
-    return (
-      <div>
-        <label htmlFor={id} className="block text-sm font-medium text-gray-700">
-          {label}{' '}
-          {identifier.required ? (
-            <span className="text-red-500">*</span>
-          ) : (
-            <span className="text-gray-500 text-sm">(optional)</span>
-          )}
-        </label>
-        <div className="mt-1">
-          <input
-            id={id}
-            name={id}
-            type={inputType}
-            ref={ref}
-            required={identifier.required}
-            className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-          />
-        </div>
-      </div>
-    );
+  // Social login handler
+  const handleSocialSignup = (connectionName: string) => {
+    signupManager.federatedSignup({ connection: connectionName });
   };
 
+  // JSX UI part (same as before)
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-      <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">Signup</h2>
-      </div>
+    <div className="prompt-container">
+      <Logo />
+      <Title screenTexts={signupManager.screen.texts!} />
 
-      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          <form className="space-y-6" onSubmit={(e) => e.preventDefault()}>
-            {renderIdentifierField('email', 'Email', emailRef)}
-            {renderIdentifierField('username', 'Username', usernameRef)}
-            {renderIdentifierField('phone', 'Phone', phoneNumberRef)}
+      <div className="input-container">
+        {/* Country code button */}
+        <button className="pick-country-code hidden" id="pick-country-code">
+          Pick country code - {signupManager.transaction.countryCode}: +{signupManager.transaction.countryPrefix}
+        </button>
 
-            <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-                Password <span className="text-red-500">*</span>
-              </label>
-              <div className="mt-1">
-                <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  ref={passwordRef}
-                  required
-                  className={`appearance-none block w-full px-3 py-2 border rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 ${
-                    !isValid ? 'border-red-500' : 'border-gray-300'
-                  }`}
-                />
-              </div>
-              {!isValid && (
-                <ul className="text-red-500 text-sm list-disc list-inside mt-1">
-                  {errors.map((err) => (
-                    <li key={err.code}>{err.message}</li>
-                  ))}
-                </ul>
+        {/* Email input */}
+        {identifiers?.find((id) => id.type === 'email') && (
+          <>
+            <label htmlFor="email">
+              Enter your email{' '}
+              {identifiers.find((id) => id.type === 'email')?.required ? (
+                <span className="text-red-500">*</span>
+              ) : (
+                <span className="text-gray-500 text-sm">(optional)</span>
               )}
-            </div>
+            </label>
+            <input
+              type="email"
+              id="email"
+              ref={emailRef}
+              placeholder="Enter your email"
+              required={identifiers.find((id) => id.type === 'email')?.required}
+            />
+          </>
+        )}
 
-            {screen?.isCaptchaAvailable && (
-              <div>
-                <label htmlFor="captcha" className="block text-sm font-medium text-gray-700">
-                  Captcha
-                </label>
-                <div className="captcha-container mt-1">
-                  <img src={screen?.captchaImage ?? ''} alt="Captcha" className="mb-2" />
-                  <input
-                    type="text"
-                    id="captcha"
-                    ref={captchaRef}
-                    placeholder="Enter the captcha"
-                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm"
-                  />
-                </div>
-              </div>
-            )}
+        {/* Username input */}
+        {identifiers?.find((id) => id.type === 'username') && (
+          <>
+            <label htmlFor="username">
+              Enter your username{' '}
+              {identifiers.find((id) => id.type === 'username')?.required ? (
+                <span className="text-red-500">*</span>
+              ) : (
+                <span className="text-gray-500 text-sm">(optional)</span>
+              )}
+            </label>
+            <input
+              type="text"
+              id="username"
+              ref={usernameRef}
+              placeholder="Enter your username"
+              required={identifiers.find((id) => id.type === 'username')?.required}
+            />
+          </>
+        )}
 
-            {errorMessage && <div className="text-red-600 text-sm">{errorMessage}</div>}
+        {/* Phone input */}
+        {identifiers?.find((id) => id.type === 'phone') && (
+          <>
+            <label htmlFor="phoneNumber">
+              Enter your phone number{' '}
+              {identifiers.find((id) => id.type === 'phone')?.required ? (
+                <span className="text-red-500">*</span>
+              ) : (
+                <span className="text-gray-500 text-sm">(optional)</span>
+              )}
+            </label>
+            <input
+              type="tel"
+              id="phoneNumber"
+              ref={phoneNumberRef}
+              placeholder="Enter your phone number"
+              required={identifiers.find((id) => id.type === 'phone')?.required}
+            />
+          </>
+        )}
 
-            <div>
-              <button
-                type="button"
-                onClick={handleSignupClick}
-                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-              >
-                Sign Up
-              </button>
-            </div>
-          </form>
+        {/* Password input */}
+        <label htmlFor="password">
+          Enter your password <span className="text-red-500">*</span>
+        </label>
+        <input
+          type="password"
+          id="password"
+          ref={passwordRef}
+          placeholder="Enter your password"
+          aria-invalid={!isValid}
+          required
+          className={`input w-full border px-4 py-2 rounded ${
+            !isValid ? 'border-red-500' : 'border-gray-300'
+          }`}
+          onChange={(e) => onPasswordChange(e.target.value)}
+        />
 
-          {transaction.alternateConnections?.length > 0 && (
-            <div className="mt-6">
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <div className="w-full border-t border-gray-300" />
-                </div>
-                <div className="relative flex justify-center text-sm">
-                  <span className="px-2 bg-white text-gray-500">Or continue with</span>
-                </div>
-              </div>
-
-              <div className="mt-6 grid grid-cols-3 gap-3">
-                {transaction.alternateConnections.map((connection) => (
-                  <button
-                    key={connection.name}
-                    onClick={() => handleSocialSignup(connection.name)}
-                    className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50"
-                  >
-                    {connection.name}
-                  </button>
+        {/* Password validation hints */}
+        {hasTypedPassword && passwordValidation.length > 0 && (
+          <div className="mt-2 border border-gray-300 rounded p-3 text-sm">
+            <p className="mb-1 text-gray-700">Your password must contain:</p>
+            <ul className="list-disc list-inside space-y-1">
+              {passwordValidation
+                .filter(
+                  (rule) =>
+                    ![
+                      'password-policy-lower-case',
+                      'password-policy-upper-case',
+                      'password-policy-numbers',
+                      'password-policy-special-characters'
+                    ].includes(rule.code)
+                )
+                .map((rule) => (
+                  <li key={rule.code} className={rule.isValid ? 'text-green-600' : 'text-gray-700'}>
+                    {rule.policy}
+                  </li>
                 ))}
-              </div>
-            </div>
-          )}
+
+              {passwordValidation.some((rule) =>
+                [
+                  'password-policy-lower-case',
+                  'password-policy-upper-case',
+                  'password-policy-numbers',
+                  'password-policy-special-characters'
+                ].includes(rule.code)
+              ) && (
+                <li className="text-gray-700">
+                  At least 3 of the following:
+                  <ul className="list-disc list-inside ml-5 mt-1 space-y-1">
+                    {passwordValidation
+                      .filter((rule) =>
+                        [
+                          'password-policy-lower-case',
+                          'password-policy-upper-case',
+                          'password-policy-numbers',
+                          'password-policy-special-characters'
+                        ].includes(rule.code)
+                      )
+                      .map((rule) => (
+                        <li
+                          key={rule.code}
+                          className={rule.isValid ? 'text-green-600' : 'text-gray-700'}
+                        >
+                          {rule.policy}
+                        </li>
+                      ))}
+                  </ul>
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+
+        {/* Captcha input */}
+        {signupManager.screen.isCaptchaAvailable && (
+          <div className="captcha-container">
+            <img src={signupManager.screen.captchaImage ?? ''} alt="Captcha" />
+            <label htmlFor="captcha">Enter the captcha</label>
+            <input
+              type="text"
+              id="captcha"
+              ref={captchaRef}
+              placeholder="Enter the captcha"
+            />
+          </div>
+        )}
+
+        {/* Signup button */}
+        <div className="button-container mt-4">
+          <Button onClick={onSignupClick}>Continue</Button>
         </div>
       </div>
+
+      {/* Social login buttons */}
+      <FederatedLogin
+        connections={signupManager.transaction.alternateConnections!}
+        onFederatedLogin={handleSocialSignup}
+      />
+
+      {/* Links */}
+      {signupManager.screen.links && (
+        <Links loginLink={signupManager.screen.links.loginLink!} />
+      )}
+
+      {/* Error messages */}
+      {signupManager.transaction.hasErrors && signupManager.transaction.errors && (
+        <ErrorMessages errors={signupManager.transaction.errors!} />
+      )}
     </div>
   );
 };

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,4 +1,4 @@
-export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordValidationResult, IdentifierType as ScreenIdentifierType } from '../models/screen';
+export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordRuleValidation, IdentifierType as ScreenIdentifierType } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
 export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme } from '../common/index';

--- a/packages/auth0-acul-js/interfaces/models/screen.ts
+++ b/packages/auth0-acul-js/interfaces/models/screen.ts
@@ -1,4 +1,3 @@
-import type { Error } from "./transaction";
 export interface CaptchaContext {
   provider: string;
   image?: string;
@@ -87,7 +86,8 @@ export interface Identifier {
   required: boolean;
 }
 
-export type PasswordValidationResult = {
+export type PasswordRuleValidation = {
+  policy: string;
   isValid: boolean;
-  errors: Error[];
+  code: string;
 };

--- a/packages/auth0-acul-js/interfaces/screens/reset-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password.ts
@@ -1,5 +1,5 @@
 import type { BaseMembers } from '../models/base-context';
-import type { ScreenMembers, ScreenData, PasswordValidationResult} from '../models/screen';
+import type { ScreenMembers, ScreenData, PasswordRuleValidation} from '../models/screen';
 import type { TransactionMembers, PasswordPolicy } from '../models/transaction';
 
 export interface ResetPasswordOptions {
@@ -19,7 +19,7 @@ export interface ResetPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnResetPassword;
   transaction: TransactionMembersOnResetPassword;
   resetPassword(payload: ResetPasswordOptions): Promise<void>;
-  validatePassword(password: string): PasswordValidationResult;
+  validatePassword(password: string): PasswordRuleValidation[];
 }
 
 export interface TransactionMembersOnResetPassword extends TransactionMembers {

--- a/packages/auth0-acul-js/interfaces/screens/signup-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-password.ts
@@ -1,4 +1,4 @@
-import type { PasswordValidationResult } from '../../interfaces/models/screen'
+import type { PasswordRuleValidation } from '../../interfaces/models/screen'
 import type { IdentifierType } from '../../src/constants';
 import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers } from '../models/screen';
@@ -57,5 +57,5 @@ export interface SignupPasswordMembers extends BaseMembers {
   transaction: TransactionMembersOnSignupPassword;
   signup(payload: SignupPasswordOptions): Promise<void>;
   federatedSignup(payload: FederatedSignupOptions): Promise<void>;
-  validatePassword(password: string): PasswordValidationResult;
+  validatePassword(password: string): PasswordRuleValidation[];
 }

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -1,4 +1,4 @@
-import type { Identifier, PasswordValidationResult } from '../../interfaces/models/screen'
+import type { Identifier, PasswordRuleValidation } from '../../interfaces/models/screen'
 import type { IdentifierType } from '../../src/constants';
 import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
@@ -36,6 +36,6 @@ export interface SignupMembers extends BaseMembers {
   signup(payload: SignupOptions): Promise<void>;
   federatedSignup(payload: FederatedSignupOptions): Promise<void>;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
-  validatePassword(password: string): PasswordValidationResult;
+  validatePassword(password: string): PasswordRuleValidation[];
   getEnabledIdentifiers(): Identifier[] | null;
 }

--- a/packages/auth0-acul-js/src/helpers/validatePassword.ts
+++ b/packages/auth0-acul-js/src/helpers/validatePassword.ts
@@ -1,51 +1,83 @@
-import type { PasswordValidationResult } from '../../interfaces/models/screen';
-import type { PasswordPolicy, Error, PasswordComplexityRule } from '../../interfaces/models/transaction';
+import type { PasswordRuleValidation } from '../../interfaces/models/screen';
+import type { PasswordPolicy, PasswordComplexityRule } from '../../interfaces/models/transaction';
 
 /**
- * Validates a password string against the given password policy.
+ * Validates a password string against a given password policy.
  *
- * Checks for minimum length, character complexity (lowercase, uppercase,
- * numbers, special characters), identical consecutive characters, and 
- * other custom rules defined in the policy.
+ * This function checks whether the provided password meets specific
+ * password policy requirements such as:
+ * - Minimum length
+ * - Character complexity (lowercase, uppercase, numbers, special characters)
+ * - Identical consecutive characters
+ * - A minimum number of passed complexity rules (e.g. "at least 3 of the following")
  *
- * @param password - The password string to validate.
- * @param policy - Optional password policy specifying complexity requirements.
- * @returns An object with isValid boolean and an array of error details.
+ * It returns a list of validation results for each policy rule, where each result
+ * includes the rule code, message (label), and a boolean indicating whether it passed.
+ *
+ * @param {string} password - The password string to validate.
+ * @param {PasswordPolicy | null | undefined} policy - The password policy to validate against.
+ *        If not provided, the password is only checked for being non-empty.
+ *
+ * @returns {PasswordRuleValidation[]} An array of rule validation results.
+ *          Each result contains:
+ *          - `code`: string (the rule identifier)
+ *          - `policy`: string (the user-friendly rule description)
+ *          - `isValid`: boolean (true if the password satisfies the rule)
  *
  * @example
  * const policy = {
- *   minLength: 8,
+ *   minLength: 12,
  *   passwordSecurityInfo: [
- *     { code: 'password-policy-length-at-least', label: 'Password must be at least 8 characters.', args: { count: 8 } },
- *     { code: 'password-policy-upper-case', label: 'Password must contain uppercase letters.' },
- *     { code: 'password-policy-numbers', label: 'Password must contain numbers.' }
+ *     { code: 'password-policy-length-at-least', label: 'At least 12 characters', args: { count: 12 } },
+ *     { code: 'password-policy-contains-at-least', label: 'At least 3 of the following:', args: { count: 3 }, items: [
+ *       { code: 'password-policy-lower-case', label: 'Lowercase letters (a-z)' },
+ *       { code: 'password-policy-upper-case', label: 'Uppercase letters (A-Z)' },
+ *       { code: 'password-policy-numbers', label: 'Numbers (0-9)' },
+ *       { code: 'password-policy-special-characters', label: 'Special characters (!@#$%^&*)' }
+ *     ]},
+ *     { code: 'password-policy-identical-chars', label: 'No more than 2 identical characters in a row' }
  *   ]
  * };
- * const result = validatePassword('P@ssw0rd', policy);
- * // result.isValid === true
+ *
+ * const result = validatePassword('P@ssword123', policy);
+ * console.log(result);
+ * // [
+ * //   { code: 'password-policy-length-at-least', policy: 'At least 12 characters', isValid: true },
+ * //   { code: 'password-policy-contains-at-least', policy: 'At least 3 of the following:', isValid: true },
+ * //   { code: 'password-policy-lower-case', policy: 'Lowercase letters (a-z)', isValid: true },
+ * //   { code: 'password-policy-upper-case', policy: 'Uppercase letters (A-Z)', isValid: true },
+ * //   { code: 'password-policy-numbers', policy: 'Numbers (0-9)', isValid: true },
+ * //   { code: 'password-policy-special-characters', policy: 'Special characters (!@#$%^&*)', isValid: true },
+ * //   { code: 'password-policy-identical-chars', policy: 'No more than 2 identical characters in a row', isValid: true }
+ * // ]
  */
+
 function validatePassword(
   password: string,
   policy?: PasswordPolicy | null
-): PasswordValidationResult {
-
-  const errors: Error[] = [];
+): PasswordRuleValidation[] {
+  const results: PasswordRuleValidation[] = [];
 
   if (!policy) {
-    if (!password || typeof password !== 'string') {
-      errors.push({ code: 'password_required', message: 'Password is required.' });
-      return { isValid: false, errors };
-    }
-    return { isValid: true, errors };
+    return password
+      ? []
+      : [{
+          code: 'password_required',
+          policy: 'Password is required.',
+          isValid: false
+        }];
   }
 
   const minLength = policy.minLength ?? 8;
 
+  // Base checks
   const lower = /[a-z]/.test(password);
   const upper = /[A-Z]/.test(password);
   const number = /\d/.test(password);
   const special = /[\W_]/.test(password);
   const identicalChars = /(.)\1\1/.test(password); // 3+ identical chars in a row
+
+  // Map for complexity checks
   const complexityMap: Record<string, boolean> = {
     'password-policy-lower-case': lower,
     'password-policy-upper-case': upper,
@@ -59,54 +91,76 @@ function validatePassword(
 
   for (const rule of securityInfo) {
     switch (rule.code) {
-      case 'password-policy-length-at-least':
-        if (password.length < (rule.args?.count ?? minLength)) {
-          errors.push({ code: rule.code, message: rule.label });
-        }
+      case 'password-policy-length-at-least': {
+        const required = rule.args?.count ?? minLength;
+        const valid = password.length >= required;
+        results.push({
+          code: rule.code,
+          policy: rule.label,
+          isValid: valid,
+        });
         break;
+      }
 
       case 'password-policy-lower-case':
       case 'password-policy-upper-case':
       case 'password-policy-numbers':
-      case 'password-policy-special-characters':
-        if (!complexityMap[rule.code]) {
-          errors.push({ code: rule.code, message: rule.label });
-        }
+      case 'password-policy-special-characters': {
+        const valid = complexityMap[rule.code] ?? true;
+        results.push({
+          code: rule.code,
+          policy: rule.label,
+          isValid: valid,
+        });
         break;
+      }
 
-      case 'password-policy-identical-chars':
-        if (identicalChars) {
-          errors.push({ code: rule.code, message: rule.label });
-        }
+      case 'password-policy-identical-chars': {
+        results.push({
+          code: rule.code,
+          policy: rule.label,
+          isValid: !identicalChars,
+        });
         break;
+      }
 
       case 'password-policy-contains-at-least': {
         const requiredCount = rule.args?.count ?? 3;
-        if (passedComplexityChecks < requiredCount) {
-          errors.push({ code: rule.code, message: rule.label });
-        }
+        const isMainRuleValid = passedComplexityChecks >= requiredCount;
 
-        // Check nested items and push individual failed items too
+        results.push({
+          code: rule.code,
+          policy: rule.label,
+          isValid: isMainRuleValid,
+        });
+
+        // Also evaluate nested complexity rules (like lower-case, numbers, etc.)
         if (rule.items) {
           for (const item of rule.items) {
             const passed = complexityMap[item.code] ?? true;
-            if (!passed) {
-              errors.push({ code: item.code, message: item.label });
-            }
+            results.push({
+              code: item.code,
+              policy: item.label,
+              isValid: passed,
+            });
           }
         }
         break;
       }
 
-      default:
+      default: {
+        // Optional: if unknown rule, assume valid
+        results.push({
+          code: rule.code,
+          policy: rule.label,
+          isValid: true,
+        });
         break;
+      }
     }
   }
 
-  return {
-    isValid: errors.length === 0,
-    errors,
-  };
+  return results;
 }
 
 export default validatePassword;

--- a/packages/auth0-acul-js/src/screens/reset-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password/index.ts
@@ -6,7 +6,7 @@ import { FormHandler } from '../../utils/form-handler';
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
-import type { ScreenContext, PasswordValidationResult } from '../../../interfaces/models/screen';
+import type { ScreenContext, PasswordRuleValidation } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
   ResetPasswordOptions,
@@ -58,7 +58,7 @@ export default class ResetPassword extends BaseContext implements ResetPasswordM
    * const result = resetPassword.validatePassword('MyP@ssw0rd');
    * // result => { valid: true, errors: [] }
    */
-  validatePassword(password: string): PasswordValidationResult {
+  validatePassword(password: string): PasswordRuleValidation[] {
     const passwordPolicy = this.transaction?.passwordPolicy;
     return coreValidatePassword(password, passwordPolicy);
   }

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -6,7 +6,7 @@ import { FormHandler } from '../../utils/form-handler';
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
-import type { PasswordValidationResult } from '../../../interfaces/models/screen';
+import type { PasswordRuleValidation } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
   SignupPasswordMembers,
@@ -114,7 +114,7 @@ export default class SignupPassword extends BaseContext implements SignupPasswor
    * const result = signupPassword.validatePassword('MyP@ssw0rd');
    * // result => { valid: true, errors: [] }
    */
-  validatePassword(password: string): PasswordValidationResult {
+  validatePassword(password: string): PasswordRuleValidation[] {  
     const passwordPolicy = this.transaction?.passwordPolicy;
     return coreValidatePassword(password, passwordPolicy);
   }

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -9,7 +9,7 @@ import { TransactionOverride } from './transaction-override';
 
 import type { Identifier } from '../../../interfaces/models/screen';
 import type { ScreenContext } from '../../../interfaces/models/screen';
-import type { PasswordValidationResult } from '../../../interfaces/models/screen';
+import type { PasswordRuleValidation } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
   SignupMembers,
@@ -115,7 +115,7 @@ export default class Signup extends BaseContext implements SignupMembers {
    * const result = signup.validatePassword('MyP@ssw0rd');
    * // result => { valid: true, errors: [] }
    */
-  validatePassword(password: string): PasswordValidationResult {
+  validatePassword(password: string): PasswordRuleValidation[] {
     const passwordPolicy = this.transaction?.passwordPolicy;
     return coreValidatePassword(password, passwordPolicy);
   }
@@ -140,6 +140,6 @@ export default class Signup extends BaseContext implements SignupMembers {
   } 
 }
 
-export { PasswordValidationResult, Identifier, SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
+export { PasswordRuleValidation, Identifier, SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-react/src/screens/reset-password.tsx
+++ b/packages/auth0-acul-react/src/screens/reset-password.tsx
@@ -27,9 +27,9 @@ export const {
 
 export const useScreen: () => ScreenMembersOnResetPassword = () => useMemo(() => getInstance().screen, []);
 export const useTransaction = () => useMemo(() => getInstance().transaction, []);
-export const usePasswordValidation = () => useMemo(() => getInstance().validatePassword, []);
 // Screen methods
 export const resetPassword = (payload: ResetPasswordOptions) => getInstance().resetPassword(payload);
+export const usePasswordValidation = (password: string) => getInstance().validatePassword(password);
 
 export type { ResetPasswordOptions, ScreenMembersOnResetPassword, ResetPasswordMembers } from '@auth0/auth0-acul-js/reset-password';
 


### PR DESCRIPTION
**Description**

This PR updates the core logic of validatePassword to improve password strength evaluation and user feedback in the signup flow. It also includes updates to the associated test cases to reflect the new validation structure and logic.

🔧 **Changes Introduced**:

**validatePassword** (Core Logic):

Implements a refined rule structure that supports:

- Required password length and complexity rules

- Grouped requirements (e.g. “at least 3 of 4” from lowercase, uppercase, number, special character)

- Enhanced code, policy, and isValid metadata per rule

- Provides a cleaner interface for use in UI components and form validation

**Test Updates:**

Updates existing test cases to align with the new validation rules

Adds edge case coverage for grouped password policy enforcement

Ensures backward compatibility and accuracy of rule evaluation

🎯 **Purpose**:

Improves UX by providing more granular and user-friendly password validation feedback

Reduces unnecessary signup attempts by performing validation on the client

Unifies password rule logic to make UI implementation simpler and consistent

🧪 **Screens Affected**:

-Signup

- Signup-password

- Reset-password

**Testing**

Tested and validated the new logic using the sample React app in the universal-login-samples repository.

Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch