### PR TITLE
feat: Implement resend functionality with timeout management 

### DIFF
--- a/packages/auth0-acul-js/interfaces/common/index.ts
+++ b/packages/auth0-acul-js/interfaces/common/index.ts
@@ -61,13 +61,24 @@ export interface FlattenedTheme {
 }
 
 /**
+ * Callback function for status changes during resend countdown.
+ * @param remainingSeconds - Number of seconds remaining in the countdown
+ * @param isDisabled - Whether the resend functionality is currently disabled
+ */
+export type OnStatusChangeCallback = (remainingSeconds: number, isDisabled: boolean) => void;
+
+/**
+ * Callback function for timeout events when the resend countdown reaches zero.
+ */
+export type OnTimeoutCallback = () => void;
+
+/**
  * Options for configuring resend functionality
  */
-
 export interface StartResendOptions {
   timeoutSeconds?: number;
-  onStatusChange?: (remainingSeconds: number, isDisabled: boolean) => void;
-  onTimeout?: () => void;
+  onStatusChange?: OnStatusChangeCallback;
+  onTimeout?: OnTimeoutCallback;
 }
 
 /**

--- a/packages/auth0-acul-js/interfaces/common/index.ts
+++ b/packages/auth0-acul-js/interfaces/common/index.ts
@@ -63,9 +63,11 @@ export interface FlattenedTheme {
 /**
  * Options for configuring resend functionality
  */
+
 export interface StartResendOptions {
   timeoutSeconds?: number;
-  resendCallback?: () => Promise<void> | void;
+  onResend?: () => Promise<void> | void; 
+  onStateChange?: (remainingSeconds: number, isDisabled: boolean) => void;
 }
 
 /**

--- a/packages/auth0-acul-js/interfaces/common/index.ts
+++ b/packages/auth0-acul-js/interfaces/common/index.ts
@@ -59,3 +59,20 @@ export interface FlattenedTheme {
   pageBackground: Record<string, string>;
   widget: Record<string, string | number>;
 }
+
+/**
+ * Options for configuring resend functionality
+ */
+export interface StartResendOptions {
+  timeoutSeconds?: number;
+  resendCallback?: () => Promise<void> | void;
+}
+
+/**
+ * Control object returned by startResend method
+ */
+export interface ResendControl {
+  disabled: boolean;
+  remaining: number;
+  callback: () => Promise<void>;
+}

--- a/packages/auth0-acul-js/interfaces/common/index.ts
+++ b/packages/auth0-acul-js/interfaces/common/index.ts
@@ -66,15 +66,13 @@ export interface FlattenedTheme {
 
 export interface StartResendOptions {
   timeoutSeconds?: number;
-  onResend?: () => Promise<void> | void; 
-  onStateChange?: (remainingSeconds: number, isDisabled: boolean) => void;
+  onStatusChange?: (remainingSeconds: number, isDisabled: boolean) => void;
+  onTimeout?: () => void;
 }
 
 /**
- * Control object returned by startResend method
+ * Control object returned by resendManager method
  */
 export interface ResendControl {
-  disabled: boolean;
-  remaining: number;
-  callback: () => Promise<void>;
+  startResend: () => Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,7 +1,7 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordValidationResult, IdentifierType as ScreenIdentifierType } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
-export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, StartResendOptions, ResendControl } from '../common/index';
+export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, StartResendOptions } from '../common/index';
 export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../models/user';
 export type { IdentifierType } from '../../src/constants';
 export type { PasskeyCreateResponse, CredentialResponse } from '../utils/passkeys';

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,7 +1,7 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordValidationResult, IdentifierType as ScreenIdentifierType } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
-export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, StartResendOptions, ResendControl } from '../common/index';
+export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, OnStatusChangeCallback, OnTimeoutCallback, StartResendOptions, ResendControl } from '../common/index';
 export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../models/user';
 export type { IdentifierType } from '../../src/constants';
 export type { PasskeyCreateResponse, CredentialResponse } from '../utils/passkeys';

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,7 +1,7 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordValidationResult, IdentifierType as ScreenIdentifierType } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
-export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, StartResendOptions } from '../common/index';
+export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, StartResendOptions, ResendControl } from '../common/index';
 export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../models/user';
 export type { IdentifierType } from '../../src/constants';
 export type { PasskeyCreateResponse, CredentialResponse } from '../utils/passkeys';

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,7 +1,7 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordValidationResult, IdentifierType as ScreenIdentifierType } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
-export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme } from '../common/index';
+export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, StartResendOptions, ResendControl } from '../common/index';
 export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../models/user';
 export type { IdentifierType } from '../../src/constants';
 export type { PasskeyCreateResponse, CredentialResponse } from '../utils/passkeys';

--- a/packages/auth0-acul-js/interfaces/index.ts
+++ b/packages/auth0-acul-js/interfaces/index.ts
@@ -4,3 +4,4 @@ export * as Payload from './export/options';
 export * as Extended from './export/extended-types';
 export * as Common from './export/common';
 export * as Utils from '../src/utils/theme-utils';
+export * as ResendUtils from '../src/utils/resend-utils';

--- a/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions } from '../common';
+import type { CustomOptions, StartResendOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
 
@@ -20,5 +20,6 @@ export interface EmailIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnEmailIdentifierChallenge;
   submitEmailChallenge(payload: EmailChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
+  resendManager(payload?: StartResendOptions): () => Promise<void>;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions, StartResendOptions } from '../common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
 
@@ -20,6 +20,6 @@ export interface EmailIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnEmailIdentifierChallenge;
   submitEmailChallenge(payload: EmailChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
-  resendManager(payload?: StartResendOptions): () => Promise<void>;
+  resendManager(payload?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
+import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
 
@@ -20,6 +20,5 @@ export interface EmailIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnEmailIdentifierChallenge;
   submitEmailChallenge(payload: EmailChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
-  startResend(options?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions } from '../common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
 
@@ -12,6 +12,7 @@ export interface ScreenMembersOnEmailIdentifierChallenge extends ScreenMembers {
   data: {
     messageType?: string;
     email?: string;
+    resendLimitReached?: boolean;
   } | null;
 }
 
@@ -19,5 +20,6 @@ export interface EmailIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnEmailIdentifierChallenge;
   submitEmailChallenge(payload: EmailChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
+  startResend(options?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions } from '../common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers, ScreenData } from '../models/screen';
 
@@ -11,12 +11,14 @@ export interface PhoneChallengeOptions {
 export interface ScreenDataOptions extends ScreenData {
   messageType?: 'text' | 'voice';
   phone?: 'string';
+  resendLimitReached?: boolean;
 }
 
 export interface ExtendedScreenContext extends ScreenContext {
   data: {
     message_type: 'text' | 'voice';
     phone: string;
+    resendLimitReached?: boolean;
   };
 }
 
@@ -24,6 +26,7 @@ export interface ScreenMembersOnPhoneIdentifierChallenge extends ScreenMembers {
   data: {
     messageType?: 'text' | 'voice';
     phone?: string;
+    resendLimitReached?: boolean;
   } | null;
 }
 
@@ -31,5 +34,6 @@ export interface PhoneIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnPhoneIdentifierChallenge;
   submitPhoneChallenge(payload: PhoneChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
+  startResend(options?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
+import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers, ScreenData } from '../models/screen';
 
@@ -34,6 +34,5 @@ export interface PhoneIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnPhoneIdentifierChallenge;
   submitPhoneChallenge(payload: PhoneChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
-  startResend(options?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions, StartResendOptions } from '../common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers, ScreenData } from '../models/screen';
 
@@ -34,6 +34,6 @@ export interface PhoneIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnPhoneIdentifierChallenge;
   submitPhoneChallenge(payload: PhoneChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
-  resendManager(options?: StartResendOptions): () => Promise<void>;
+  resendManager(options?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions } from '../common';
+import type { CustomOptions, StartResendOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers, ScreenData } from '../models/screen';
 
@@ -34,5 +34,6 @@ export interface PhoneIdentifierChallengeMembers extends BaseMembers {
   screen: ScreenMembersOnPhoneIdentifierChallenge;
   submitPhoneChallenge(payload: PhoneChallengeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
+  resendManager(options?: StartResendOptions): () => Promise<void>;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
@@ -1,11 +1,10 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
-import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
+import type { CustomOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   EmailChallengeOptions,
@@ -69,30 +68,6 @@ export default class EmailIdentifierChallenge extends BaseContext implements Ema
       telemetry: [EmailIdentifierChallenge.screenIdentifier, 'returnToPrevious'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
-  }
-
-  /**
-   * Gets resend functionality with timeout management for this screen
-   * @param options - Configuration options for resend functionality
-   * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
-   * @param options.resendCallback - Optional custom callback function to execute on resend
-   * @returns Object containing disabled state, remaining time, and callback function
-   * 
-   * @example
-   * import EmailIdentifierChallenge from '@auth0/auth0-acul-js/email-identifier-challenge';
-   *
-   * const emailIdentifierChallenge = new EmailIdentifierChallenge();
-   * const resendControl = emailIdentifierChallenge.startResend({ timeoutSeconds: 40 });
-   * if (!resendControl.disabled) {
-   *   await resendControl.callback();
-   * }
-   */
-  startResend(options?: StartResendOptions): ResendControl {
-    return createResendControl(
-      EmailIdentifierChallenge.screenIdentifier,
-      () => this.resendCode(),
-      options || {}
-    );
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
@@ -1,10 +1,11 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   EmailChallengeOptions,
@@ -68,6 +69,30 @@ export default class EmailIdentifierChallenge extends BaseContext implements Ema
       telemetry: [EmailIdentifierChallenge.screenIdentifier, 'returnToPrevious'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
+  }
+
+  /**
+   * Gets resend functionality with timeout management for this screen
+   * @param options - Configuration options for resend functionality
+   * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
+   * @param options.resendCallback - Optional custom callback function to execute on resend
+   * @returns Object containing disabled state, remaining time, and callback function
+   * 
+   * @example
+   * import EmailIdentifierChallenge from '@auth0/auth0-acul-js/email-identifier-challenge';
+   *
+   * const emailIdentifierChallenge = new EmailIdentifierChallenge();
+   * const resendControl = emailIdentifierChallenge.startResend({ timeoutSeconds: 40 });
+   * if (!resendControl.disabled) {
+   *   await resendControl.callback();
+   * }
+   */
+  startResend(options?: StartResendOptions): ResendControl {
+    return createResendControl(
+      EmailIdentifierChallenge.screenIdentifier,
+      () => this.resendCode(),
+      options || {}
+    );
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
@@ -1,10 +1,11 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   EmailChallengeOptions,
@@ -68,6 +69,38 @@ export default class EmailIdentifierChallenge extends BaseContext implements Ema
       telemetry: [EmailIdentifierChallenge.screenIdentifier, 'returnToPrevious'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
+  }
+  /**
+   * Gets resend functionality with timeout management for this screen
+   * @param options - Configuration options for resend functionality
+   * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
+   * @param options.onResend - Optional custom callback function to execute on resend
+   * @param options.onStateChange - Callback to receive state updates (remaining seconds, disabled status)
+   * @returns Callback function to execute resend with timeout management
+   * 
+   * @example
+   * import EmailIdentifierChallenge from '@auth0/auth0-acul-js/email-identifier-challenge';
+   *   const handleStateChange = (remainingSeconds, isDisabled) => {
+   *     setDisabled(isDisabled);
+   *     setRemaining(remainingSeconds);
+   *   };
+   * 
+   *   const handleResend = async () => {
+   *       const resendCallback = emailChallenge.resendManager({
+   *         timeoutSeconds: 15,
+   *         onStateChange: handleStateChange
+   *       });
+   *       await resendCallback();
+   *   };
+   * 
+   */
+  resendManager(options?: StartResendOptions): () => Promise<void> {
+    return createResendControl(
+      EmailIdentifierChallenge.screenIdentifier,
+      () => this.resendCode(),
+      options || {},
+      this.screen.data?.resendLimitReached
+    );
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -5,7 +5,7 @@ import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions, StartResendOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   PhoneChallengeOptions,
@@ -73,36 +73,39 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
   }
 
   /**
-     * Gets resend functionality with timeout management for this screen
-     * @param options - Configuration options for resend functionality
-     * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
-     * @param options.onResend - Optional custom callback function to execute on resend
-     * @param options.onStateChange - Callback to receive state updates (remaining seconds, disabled status)
-     * @returns Callback function to execute resend with timeout management
-     * 
-     * @example
-     * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
-     *
-     * const phoneChallenge = new PhoneIdentifierChallenge();
-     * 
-     *   const handleStateChange = (remainingSeconds, isDisabled) => {
-     *     setDisabled(isDisabled);
-     *     setRemaining(remainingSeconds);
-     *   };
-     * 
-     * const handleResend = async () => {
-     *     const resendCallback = phoneChallenge.resendManager({
-     *       timeoutSeconds: 30,
-     *       onStateChange: handleStateChange
-     *     });
-     *     await resendCallback();
-     *    };
-     */
-  resendManager(options?: StartResendOptions): () => Promise<void> {
+   * Gets resend functionality with timeout management for this screen
+   * @param options - Configuration options for resend functionality
+   * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
+   * @param options.onStatusChange - Callback to receive state updates (remaining seconds, disabled status)
+   * @param options.onTimeout - Callback to execute when timeout countdown reaches zero
+   * @returns ResendControl object with startResend method
+   * 
+   * @example
+   * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
+   *   const handleStatusChange = (remainingSeconds, isDisabled) => {
+   *     setDisabled(isDisabled);
+   *     setRemaining(remainingSeconds);
+   *   };
+   * 
+   *   const handleTimeout = () => {
+   *     console.log('Timeout completed, resend is now available');
+   *   };
+   * 
+   *   const { startResend } = phoneChallenge.resendManager({
+   *     timeoutSeconds: 30,
+   *     onStatusChange: handleStatusChange,
+   *     onTimeout: handleTimeout
+   *   });
+   *   
+   *   // Call startResend when user clicks resend button
+   *   await startResend();
+   * 
+   */
+  resendManager(options?: StartResendOptions): ResendControl {
     return createResendControl(
       PhoneIdentifierChallenge.screenIdentifier,
       () => this.resendCode(),
-      options || {},
+      options,
       this.screen.data?.resendLimitReached
     );
   }

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -1,10 +1,11 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   PhoneChallengeOptions,
@@ -69,6 +70,41 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
       telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'returnToPrevious'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
+  }
+
+  /**
+     * Gets resend functionality with timeout management for this screen
+     * @param options - Configuration options for resend functionality
+     * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
+     * @param options.onResend - Optional custom callback function to execute on resend
+     * @param options.onStateChange - Callback to receive state updates (remaining seconds, disabled status)
+     * @returns Callback function to execute resend with timeout management
+     * 
+     * @example
+     * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
+     *
+     * const phoneChallenge = new PhoneIdentifierChallenge();
+     * 
+     *   const handleStateChange = (remainingSeconds, isDisabled) => {
+     *     setDisabled(isDisabled);
+     *     setRemaining(remainingSeconds);
+     *   };
+     * 
+     * const handleResend = async () => {
+     *     const resendCallback = phoneChallenge.resendManager({
+     *       timeoutSeconds: 30,
+     *       onStateChange: handleStateChange
+     *     });
+     *     await resendCallback();
+     *    };
+     */
+  resendManager(options?: StartResendOptions): () => Promise<void> {
+    return createResendControl(
+      PhoneIdentifierChallenge.screenIdentifier,
+      () => this.resendCode(),
+      options || {},
+      this.screen.data?.resendLimitReached
+    );
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -1,11 +1,10 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
-import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
+import type { CustomOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   PhoneChallengeOptions,
@@ -70,30 +69,6 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
       telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'returnToPrevious'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
-  }
-
-  /**
-   * Gets resend functionality with timeout management for this screen
-   * @param options - Configuration options for resend functionality
-   * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
-   * @param options.resendCallback - Optional custom callback function to execute on resend
-   * @returns Object containing disabled state, remaining time, and callback function
-   * 
-   * @example
-   * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
-   *
-   * const phoneIdentifierChallenge = new PhoneIdentifierChallenge();
-   * const resendControl = phoneIdentifierChallenge.startResend({ timeoutSeconds: 40 });
-   * if (!resendControl.disabled) {
-   *   await resendControl.callback();
-   * }
-   */
-  startResend(options?: StartResendOptions): ResendControl {
-    return createResendControl(
-      PhoneIdentifierChallenge.screenIdentifier,
-      () => this.resendCode(),
-      options || {}
-    );
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -1,10 +1,11 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   PhoneChallengeOptions,
@@ -69,6 +70,30 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
       telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'returnToPrevious'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
+  }
+
+  /**
+   * Gets resend functionality with timeout management for this screen
+   * @param options - Configuration options for resend functionality
+   * @param options.timeoutSeconds - Number of seconds to wait before allowing resend (default: 10)
+   * @param options.resendCallback - Optional custom callback function to execute on resend
+   * @returns Object containing disabled state, remaining time, and callback function
+   * 
+   * @example
+   * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
+   *
+   * const phoneIdentifierChallenge = new PhoneIdentifierChallenge();
+   * const resendControl = phoneIdentifierChallenge.startResend({ timeoutSeconds: 40 });
+   * if (!resendControl.disabled) {
+   *   await resendControl.callback();
+   * }
+   */
+  startResend(options?: StartResendOptions): ResendControl {
+    return createResendControl(
+      PhoneIdentifierChallenge.screenIdentifier,
+      () => this.resendCode(),
+      options || {}
+    );
   }
 }
 

--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -39,7 +39,7 @@ export function createResendControl(
     remaining = Math.max(0, Math.ceil((timeoutMs - timeElapsed) / 1000));
     disabled = remaining > 0 || !!resendLimitReached;
 
-    // Call onTimeout when countdown reaches 0 from a positive value
+    // Call onTimeout when countdown reaches 0
     if (onTimeout && previousRemaining > 0 && remaining === 0 && !hasCalledOnTimeout) {
       hasCalledOnTimeout = true;
       onTimeout();
@@ -73,25 +73,19 @@ export function createResendControl(
     startTimer();
   };
 
+  calculateState(); // ensures disabled state is computed immediately
 
-  setTimeout(() => {
+  if (remaining > 0) {
     cleanup();
-    calculateState();
-    if (remaining > 0) {
-      hasCalledOnTimeout = false; // Reset since we're starting an existing timer
-      intervalId = setInterval(() => {
-        calculateState();
-        if (remaining <= 0) {
-          cleanup();
-        }
-      }, 1000);
-    }
-  }, 0);
-
-
+    intervalId = setInterval(() => {
+      calculateState();
+      if (remaining <= 0) {
+        cleanup();
+      }
+    }, 1000);
+  }
 
   return {
     startResend: callback
   };
 }
-

--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -61,10 +61,6 @@ export function createResendControl(
   const callback = async (): Promise<void> => {
     calculateState();
 
-    if (resendLimitReached) {
-      throw new Error('Resend limit has been reached. Please try again later.');
-    }
-
     if (onResend) {
       await onResend();
     } else {

--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -1,4 +1,4 @@
-import type { StartResendOptions } from '../../interfaces/common';
+import type { StartResendOptions, ResendControl } from '../../interfaces/common';
 
 /**
  * Utility function to create resend functionality with timeout management
@@ -6,19 +6,20 @@ import type { StartResendOptions } from '../../interfaces/common';
  * @param resendMethod - The resend method to call when callback is executed
  * @param options - Configuration options for resend functionality
  * @param resendLimitReached - Optional server-side limit indicator (only for phone/email identifier challenge screens)
- * @returns Callback function for resend functionality
+ * @returns ResendControl object with startResend method
  */
 export function createResendControl(
   screenIdentifier: string,
   resendMethod: () => Promise<void>,
   options?: StartResendOptions,
   resendLimitReached?: boolean
-): () => Promise<void> {
-  const { timeoutSeconds = 10, onResend, onStateChange } = options || {};
+): ResendControl {
+  const { timeoutSeconds = 10, onStatusChange, onTimeout } = options || {};
   const storageKey = `acul_resend_timeout_${screenIdentifier}`;
 
   let remaining = 0;
   let disabled = false;
+  let hasCalledOnTimeout = false; // Track if onTimeout has been called
   let intervalId: ReturnType<typeof setInterval> | null = null;
 
   const cleanup = (): void => {
@@ -37,14 +38,21 @@ export function createResendControl(
     remaining = Math.max(0, Math.ceil((timeoutMs - timeElapsed) / 1000));
     disabled = remaining > 0 || !!resendLimitReached;
 
-    // Always call onStateChange if it exists
-    if (onStateChange) {
-      onStateChange(remaining, disabled);
+    // Call onTimeout when countdown reaches 0
+    if (onTimeout && remaining === 0 && !hasCalledOnTimeout) {
+      hasCalledOnTimeout = true;
+      onTimeout();
+    }
+
+    // Always call onStatusChange if it exists
+    if (onStatusChange) {
+      onStatusChange(remaining, disabled);
     }
   };
 
   const startTimer = (): void => {
     localStorage.setItem(storageKey, Date.now().toString());
+    hasCalledOnTimeout = false; // Reset for new timer
     cleanup();
     calculateState();
     intervalId = setInterval(() => {
@@ -58,11 +66,7 @@ export function createResendControl(
   const callback = async (): Promise<void> => {
     calculateState();
     if (disabled) return;
-    if (onResend) {
-      await onResend();
-    } else {
-      await resendMethod();
-    }
+    await resendMethod();
     startTimer();
   };
 
@@ -75,5 +79,9 @@ export function createResendControl(
       }
     }, 1000);
   }
-  return callback;
+  
+  return {
+    startResend: callback
+  };
 }
+

--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -35,7 +35,6 @@ export function createResendControl(
     const timeElapsed = currentTime - lastResendTime;
 
     remaining = Math.max(0, Math.ceil((timeoutMs - timeElapsed) / 1000));
-    // Disabled if either there's a timeout remaining OR server-side limit is reached
     disabled = remaining > 0 || !!resendLimitReached;
 
     // Always call onStateChange if it exists
@@ -45,9 +44,7 @@ export function createResendControl(
   };
 
   const startTimer = (): void => {
-
     localStorage.setItem(storageKey, Date.now().toString());
-
     cleanup();
     calculateState();
     intervalId = setInterval(() => {
@@ -60,18 +57,16 @@ export function createResendControl(
 
   const callback = async (): Promise<void> => {
     calculateState();
-
+    if (disabled) return;
     if (onResend) {
       await onResend();
     } else {
       await resendMethod();
     }
-
     startTimer();
   };
 
   calculateState();
-
   if (remaining > 0) {
     intervalId = setInterval(() => {
       calculateState();
@@ -80,6 +75,5 @@ export function createResendControl(
       }
     }, 1000);
   }
-
   return callback;
 }

--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -1,22 +1,32 @@
-import type { StartResendOptions, ResendControl } from '../../interfaces/common';
+import type { StartResendOptions } from '../../interfaces/common';
 
 /**
  * Utility function to create resend functionality with timeout management
  * @param screenIdentifier - The screen identifier for storage key uniqueness
  * @param resendMethod - The resend method to call when callback is executed
  * @param options - Configuration options for resend functionality
- * @returns Object containing disabled state, remaining time, and callback function
+ * @param resendLimitReached - Optional server-side limit indicator (only for phone/email identifier challenge screens)
+ * @returns Callback function for resend functionality
  */
 export function createResendControl(
   screenIdentifier: string,
   resendMethod: () => Promise<void>,
-  options?: StartResendOptions
-): ResendControl {
-  const { timeoutSeconds = 10, resendCallback } = options || {};
-  const storageKey = `auth0_resend_timeout_${screenIdentifier}`;
+  options?: StartResendOptions,
+  resendLimitReached?: boolean
+): () => Promise<void> {
+  const { timeoutSeconds = 10, onResend, onStateChange } = options || {};
+  const storageKey = `acul_resend_timeout_${screenIdentifier}`;
+
   let remaining = 0;
   let disabled = false;
-  let intervalId: NodeJS.Timeout | null = null;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  const cleanup = (): void => {
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
 
   const calculateState = (): void => {
     const lastResendTime = parseInt(localStorage.getItem(storageKey) || '0', 10);
@@ -25,53 +35,55 @@ export function createResendControl(
     const timeElapsed = currentTime - lastResendTime;
 
     remaining = Math.max(0, Math.ceil((timeoutMs - timeElapsed) / 1000));
-    disabled = remaining > 0;
+    // Disabled if either there's a timeout remaining OR server-side limit is reached
+    disabled = remaining > 0 || !!resendLimitReached;
+
+    // Always call onStateChange if it exists
+    if (onStateChange) {
+      onStateChange(remaining, disabled);
+    }
   };
 
   const startTimer = (): void => {
-    // Save the current time
+
     localStorage.setItem(storageKey, Date.now().toString());
 
-    // Recalculate immediately
+    cleanup();
     calculateState();
-
-    // Clear old timer
-    if (intervalId) clearInterval(intervalId);
-
-    // Start new countdown
     intervalId = setInterval(() => {
       calculateState();
-      if (remaining <= 0 && intervalId) {
-        clearInterval(intervalId);
-        intervalId = null;
+      if (remaining <= 0) {
+        cleanup();
       }
     }, 1000);
   };
 
   const callback = async (): Promise<void> => {
     calculateState();
-    if (disabled) {
-      throw new Error(`Please wait ${remaining}s before resending`);
-    }
-    startTimer();
 
-    if (resendCallback) {
-      await resendCallback();
+    if (resendLimitReached) {
+      throw new Error('Resend limit has been reached. Please try again later.');
+    }
+
+    if (onResend) {
+      await onResend();
     } else {
       await resendMethod();
     }
+
+    startTimer();
   };
 
-  // Calculate state on init
   calculateState();
 
-  return {
-    get disabled(): boolean {
-      return disabled; // ✅ always returns the latest value
-    },
-    get remaining(): number {
-      return remaining; // ✅ always returns the latest countdown
-    },
-    callback,
-  };
+  if (remaining > 0) {
+    intervalId = setInterval(() => {
+      calculateState();
+      if (remaining <= 0) {
+        cleanup();
+      }
+    }, 1000);
+  }
+
+  return callback;
 }

--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -1,0 +1,55 @@
+import type { StartResendOptions, ResendControl } from '../../interfaces/common';
+
+/**
+ * Utility function to create resend functionality with timeout management
+ * @param screenIdentifier - The screen identifier for storage key uniqueness
+ * @param resendMethod - The resend method to call when callback is executed
+ * @param options - Configuration options for resend functionality
+ * @returns Object containing disabled state, remaining time, and callback function
+ */
+export function createResendControl(
+  screenIdentifier: string,
+  resendMethod: () => Promise<void>,
+  options?: StartResendOptions
+): ResendControl {
+  const { timeoutSeconds = 10, resendCallback } = options || {};
+  const storageKey = `auth0_resend_timeout_${screenIdentifier}`;
+  
+  // Get last resend time from storage
+  const lastResendTime = parseInt(localStorage.getItem(storageKey) || '0', 10);
+  const currentTime = Date.now();
+  const timeoutMs = timeoutSeconds * 1000;
+  const timeElapsed = currentTime - lastResendTime;
+  const remaining = Math.max(0, Math.ceil((timeoutMs - timeElapsed) / 1000));
+  const disabled = remaining > 0;
+
+  const callback = async (): Promise<void> => {
+    // Check if resend is currently allowed (recalculate at execution time)
+    const currentLastResendTime = parseInt(localStorage.getItem(storageKey) || '0', 10);
+    const currentTimeNow = Date.now();
+    const currentTimeElapsed = currentTimeNow - currentLastResendTime;
+    const currentRemaining = Math.max(0, Math.ceil((timeoutMs - currentTimeElapsed) / 1000));
+    const currentlyDisabled = currentRemaining > 0;
+      
+    if (currentlyDisabled) {
+      throw new Error(`Please wait ${currentRemaining} seconds before resending`);
+    }
+    
+    // Store current time as last resend time
+    localStorage.setItem(storageKey, Date.now().toString());
+    
+    if (resendCallback) {
+      // Use provided callback
+      await resendCallback();
+    } else {
+      // Use the screen's own resend method
+      await resendMethod();
+    }
+  };
+
+  return {
+    disabled,
+    remaining,
+    callback,
+  };
+}

--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -34,7 +34,7 @@ export function createResendControl(
     const currentTime = Date.now();
     const timeoutMs = timeoutSeconds * 1000;
     const timeElapsed = currentTime - lastResendTime;
-
+  
     const previousRemaining = remaining;
     remaining = Math.max(0, Math.ceil((timeoutMs - timeElapsed) / 1000));
     disabled = remaining > 0 || !!resendLimitReached;
@@ -73,9 +73,7 @@ export function createResendControl(
     startTimer();
   };
 
-  calculateState(); // ensures disabled state is computed immediately
-
-  if (remaining > 0) {
+  if (remaining >= 0) {
     cleanup();
     intervalId = setInterval(() => {
       calculateState();


### PR DESCRIPTION
### PR Description: Add Resend Functionality with Timeout

- Introduced resend functionality with timeout and state management to prevent repeated resending within a cooldown period.  
- Implemented `createResendControl` utility to handle resend logic, including timing, disabling resend during cooldown, and supporting optional callbacks for resend actions and UI state updates.  
- Updated Email and Phone Identifier Challenge screens to integrate the new resend manager, exposing a `resendManager` method that returns a controlled resend callback.  
- Enhanced TypeScript interfaces to include `StartResendOptions` and `ResendControl` for flexible configuration and control of resend behavior.  
- Utilizes localStorage to persist resend state across sessions and ensures consistent behavior even after page reloads.  
- Provides an improved developer experience with clear options to customize timeout duration, resend callback, and UI state change handling.

###
