### PR TITLE
feat: Introduce validateUsername and useUsernameValidation for TS and React SDK respectively 

### DIFF
--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,4 +1,4 @@
-export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordRuleValidation, IdentifierType as ScreenIdentifierType } from '../models/screen';
+export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, Identifier, PasswordRuleValidation, IdentifierType as ScreenIdentifierType, UsernameValidationResult, UsernameValidationError } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
 export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme } from '../common/index';

--- a/packages/auth0-acul-js/interfaces/models/screen.ts
+++ b/packages/auth0-acul-js/interfaces/models/screen.ts
@@ -91,3 +91,13 @@ export type PasswordRuleValidation = {
   isValid: boolean;
   code: string;
 };
+
+export interface UsernameValidationError {
+  code: string;
+  message: string;
+}
+
+export interface UsernameValidationResult {
+  isValid: boolean;
+  errors: UsernameValidationError[];
+}

--- a/packages/auth0-acul-js/interfaces/screens/signup-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-id.ts
@@ -1,7 +1,7 @@
 import type { IdentifierType } from '../../src/constants';
 import type { CustomOptions } from '../common';
 import type { BaseContext, BaseMembers } from '../models/base-context';
-import type { Identifier, ScreenContext, ScreenMembers } from '../models/screen';
+import type { Identifier, ScreenContext, ScreenMembers, UsernameValidationResult } from '../models/screen';
 import type { TransactionMembers, UsernamePolicy } from '../models/transaction';
 import type { UntrustedDataContext } from '../models/untrusted-data';
 interface ExtendedScreenContext extends ScreenContext {
@@ -55,4 +55,5 @@ export interface SignupIdMembers extends BaseMembers {
   federatedSignup(payload: FederatedSignupOptions): Promise<void>;
   getEnabledIdentifiers(): Identifier[] | null;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
+  validateUsername(username: string): UsernameValidationResult;
 }

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -1,4 +1,4 @@
-import type { Identifier, PasswordRuleValidation } from '../../interfaces/models/screen'
+import type { Identifier, PasswordRuleValidation, UsernameValidationResult } from '../../interfaces/models/screen'
 import type { IdentifierType } from '../../src/constants';
 import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
@@ -38,4 +38,5 @@ export interface SignupMembers extends BaseMembers {
   pickCountryCode(payload?: CustomOptions): Promise<void>;
   validatePassword(password: string): PasswordRuleValidation[];
   getEnabledIdentifiers(): Identifier[] | null;
+  validateUsername(username: string): UsernameValidationResult;
 }

--- a/packages/auth0-acul-js/src/helpers/validateUsername.ts
+++ b/packages/auth0-acul-js/src/helpers/validateUsername.ts
@@ -6,6 +6,36 @@ type AllowedFormats = {
   usernameInPhoneFormat?: boolean;
 };
 
+
+/**
+ * Validates a username string against a given username policy.
+ *
+ * This function checks the username for:
+ * - Presence (if no policy is provided)
+ * - Minimum and maximum length
+ * - Email format restrictions
+ * - Phone number format restrictions
+ *
+ * If no policy is provided, it defaults to checking whether the username is non-empty.
+ *
+ * @param {string} username - The username to validate.
+ * @param {UsernamePolicy | null} [policy] - Optional validation policy defining length limits and allowed formats.
+ * 
+ * @returns {UsernameValidationResult} An object containing:
+ *  - `isValid`: A boolean indicating if the username passed all validations.
+ *  - `errors`: An array of validation errors, if any.
+ *
+ * @example
+ * const result = validateUsername('john.doe@example.com', {
+ *   minLength: 5,
+ *   maxLength: 20,
+ *   allowedFormats: { usernameInEmailFormat: false },
+ * });
+ * 
+ * if (!result.isValid) {
+ *   console.log(result.errors);
+ * }
+ */
 export function validateUsername(
   username: string,
   policy?: UsernamePolicy | null

--- a/packages/auth0-acul-js/src/helpers/validateUsername.ts
+++ b/packages/auth0-acul-js/src/helpers/validateUsername.ts
@@ -1,0 +1,82 @@
+import type { UsernameValidationError, UsernameValidationResult } from '../../interfaces/models/screen';
+import type { UsernamePolicy } from '../../interfaces/models/transaction';
+
+type AllowedFormats = {
+  usernameInEmailFormat?: boolean;
+  usernameInPhoneFormat?: boolean;
+};
+
+export function validateUsername(
+  username: string,
+  policy?: UsernamePolicy | null
+): UsernameValidationResult {
+  const errors: UsernameValidationError[] = [];
+
+  if (!policy) {
+    return {
+      isValid: username.trim().length > 0,
+      errors: username.trim().length > 0
+        ? []
+        : [{ code: 'username-required', message: 'Username is required.' }],
+    };
+  }
+
+  const {
+    minLength = 1,
+    maxLength = 30,
+    allowedFormats: userAllowedFormats = {} as AllowedFormats,
+  } = policy;
+
+  const allowedFormats = {
+    usernameInEmailFormat:
+      userAllowedFormats.usernameInEmailFormat !== undefined
+        ? userAllowedFormats.usernameInEmailFormat
+        : true,
+    usernameInPhoneFormat:
+      userAllowedFormats.usernameInPhoneFormat !== undefined
+        ? userAllowedFormats.usernameInPhoneFormat
+        : true,
+  };
+
+  // 1. Check minimum length
+  if (username.length < minLength) {
+    errors.push({
+      code: 'username-too-short',
+      message: `Username must be at least ${minLength} characters long.`,
+    });
+  }
+
+  // 2. Check maximum length
+  if (username.length > maxLength) {
+    errors.push({
+      code: 'username-too-long',
+      message: `Username must be no more than ${maxLength} characters.`,
+    });
+  }
+
+  // 3. Disallow email format if not allowed
+  const isEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(username);
+  if (!allowedFormats.usernameInEmailFormat && isEmail) {
+    errors.push({
+      code: 'username-email-not-allowed',
+      message: 'Usernames in email format are not allowed.',
+    });
+  }
+
+  // 4. Disallow phone format if not allowed
+  const normalizedUsername = username.replace(/\s+/g, '');
+  const isPhone = /^\+?\d{7,15}$/.test(normalizedUsername);
+  if (!allowedFormats.usernameInPhoneFormat && isPhone) {
+    errors.push({
+      code: 'username-phone-not-allowed',
+      message: 'Usernames in phone number format are not allowed.',
+    });
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+export default validateUsername;

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -1,5 +1,6 @@
 import { ScreenIds, FormActions } from '../../constants';
 import coreGetIdentifier from '../../helpers/getEnabledIdentifiers';
+import coreValidateUsername from '../../helpers/validateUsername';
 import { BaseContext } from '../../models/base-context';
 import { getBrowserCapabilities } from '../../utils/browser-capabilities';
 import { FormHandler } from '../../utils/form-handler';
@@ -7,7 +8,7 @@ import { FormHandler } from '../../utils/form-handler';
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
-import type { Identifier } from '../../../interfaces/models/screen';
+import type { Identifier, UsernameValidationResult } from '../../../interfaces/models/screen';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -144,6 +145,23 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
       action: FormActions.PICK_COUNTRY_CODE,
     });
   }
+
+  /**
+     * Validates a given username against the current username policy
+     * defined in the transaction context.
+     *
+     * @param username - The username string to validate.
+     * @returns Result object indicating whether the username is valid and why.
+     *
+     * @example
+     * const signupIdManager = new SignupId();
+     * const result = signupIdManager.validateUsername('myusername');
+     * // result => { valid: true, errors: [] }
+     */
+    validateUsername(username: string): UsernameValidationResult {
+      const usernameValidationConfig = this.transaction.usernamePolicy;
+      return coreValidateUsername(username, usernameValidationConfig);
+    }
 }
 
 export {

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -1,6 +1,7 @@
 import { ScreenIds, FormActions } from '../../constants';
 import coreGetIdentifier from '../../helpers/getEnabledIdentifiers';
 import coreValidatePassword from '../../helpers/validatePassword';
+import coreValidateUsername from '../../helpers/validateUsername';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
@@ -9,7 +10,7 @@ import { TransactionOverride } from './transaction-override';
 
 import type { Identifier } from '../../../interfaces/models/screen';
 import type { ScreenContext } from '../../../interfaces/models/screen';
-import type { PasswordRuleValidation } from '../../../interfaces/models/screen';
+import type { PasswordRuleValidation, UsernameValidationResult } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
   SignupMembers,
@@ -137,9 +138,26 @@ export default class Signup extends BaseContext implements SignupMembers {
       errors: this.transaction.errors ?? undefined, // convert `null` to `undefined`
     };
     return coreGetIdentifier(transaction.requiredIdentifiers ?? [], transaction.optionalIdentifiers ?? [], transaction.connectionStrategy);
-  } 
+  }
+
+  /**
+   * Validates a given username against the current username policy
+   * defined in the transaction context.
+   *
+   * @param username - The username string to validate.
+   * @returns Result object indicating whether the username is valid and why.
+   *
+   * @example
+   * const signup = new Signup();
+   * const result = signup.validateUsername('myusername');
+   * // result => { valid: true, errors: [] }
+   */
+  validateUsername(username: string): UsernameValidationResult {
+    const usernameValidationConfig = this.transaction.usernamePolicy;
+    return coreValidateUsername(username, usernameValidationConfig);
+  }
 }
 
-export { PasswordRuleValidation, Identifier, SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
+export { PasswordRuleValidation, UsernameValidationResult, Identifier, SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/tests/unit/helpers/validateUsername.test.ts
+++ b/packages/auth0-acul-js/tests/unit/helpers/validateUsername.test.ts
@@ -1,0 +1,98 @@
+import validateUsername from '../../../src/helpers/validateUsername';
+import type { UsernamePolicy } from '../../../interfaces/models/transaction';
+
+// Helper to extract failed error codes
+const getFailedCodes = (result: ReturnType<typeof validateUsername>) =>
+  result.errors.map((e) => e.code);
+
+describe('validateUsername', () => {
+  const basePolicy: UsernamePolicy = {
+    minLength: 3,
+    maxLength: 15,
+    allowedFormats: {
+      usernameInEmailFormat: false,
+      usernameInPhoneFormat: false,
+    },
+  };
+
+  it('returns error when username is empty and no policy', () => {
+    const result = validateUsername('', null);
+    const failed = getFailedCodes(result);
+    expect(failed).toContain('username-required');
+  });
+
+  it('passes validation when username is non-empty and no policy', () => {
+    const result = validateUsername('anyuser', null);
+    expect(result.isValid).toBe(true);
+    expect(result.errors.length).toBe(0);
+  });
+
+  it('fails when username is shorter than minLength', () => {
+    const result = validateUsername('ab', basePolicy);
+    const failed = getFailedCodes(result);
+    expect(failed).toContain('username-too-short');
+  });
+
+  it('fails when username is longer than maxLength', () => {
+    const result = validateUsername('averyverylongusername', basePolicy);
+    const failed = getFailedCodes(result);
+    expect(failed).toContain('username-too-long');
+  });
+
+  it('fails when username is in email format and email not allowed', () => {
+    const result = validateUsername('test@example.com', basePolicy);
+    const failed = getFailedCodes(result);
+    expect(failed).toContain('username-email-not-allowed');
+  });
+
+  it('fails when username is in phone number format and phone not allowed', () => {
+    const result = validateUsername('+1234567890', basePolicy);
+    const failed = getFailedCodes(result);
+    expect(failed).toContain('username-phone-not-allowed');
+  });
+
+  it('passes all rules with valid username', () => {
+    const result = validateUsername('validUser123', basePolicy);
+    expect(result.isValid).toBe(true);
+    expect(result.errors.length).toBe(0);
+  });
+
+  it('passes with email format if email is allowed', () => {
+    const policy = {
+      minLength: 1,
+      maxLength: 30,
+      allowedFormats: {
+        usernameInEmailFormat: true,
+        usernameInPhoneFormat: false,
+      },
+    };
+    const username = 'test@example.com';
+    const result = validateUsername(username, policy);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('passes with phone number format if phone is allowed', () => {
+    const result = validateUsername('+1234567890', {
+      ...basePolicy,
+      allowedFormats: {
+        ...basePolicy.allowedFormats,
+        usernameInPhoneFormat: true,
+      },
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('fails multiple rules at once', () => {
+    const result = validateUsername('a@b.c', {
+      minLength: 10,
+      maxLength: 12,
+      allowedFormats: {
+        usernameInEmailFormat: false,
+        usernameInPhoneFormat: false,
+      },
+    });
+    const failed = getFailedCodes(result);
+    expect(failed).toContain('username-too-short');
+    expect(failed).toContain('username-email-not-allowed');
+  });
+});

--- a/packages/auth0-acul-react/src/classes.ts
+++ b/packages/auth0-acul-react/src/classes.ts
@@ -658,7 +658,7 @@ export namespace ResetPassword {
   export const resetPassword = resetPassword_ResetPassword;
 }
 
-import { useSignupId as useSignupId_SignupId, useScreen as useScreen_SignupId, useTransaction as useTransaction_SignupId, signup as signup_SignupId, federatedSignup as federatedSignup_SignupId, useEnabledIdentifiers as useEnabledIdentifiers_SignupId, pickCountryCode as pickCountryCode_SignupId } from './screens/signup-id';
+import { useSignupId as useSignupId_SignupId, useScreen as useScreen_SignupId, useTransaction as useTransaction_SignupId, signup as signup_SignupId, federatedSignup as federatedSignup_SignupId, useEnabledIdentifiers as useEnabledIdentifiers_SignupId, pickCountryCode as pickCountryCode_SignupId, useUsernameValidation as useUsernameValidation_SignupId } from './screens/signup-id';
 export namespace SignupId {
   export const useSignupId = useSignupId_SignupId;
   export const useScreen = useScreen_SignupId;
@@ -667,6 +667,7 @@ export namespace SignupId {
   export const federatedSignup = federatedSignup_SignupId;
   export const useEnabledIdentifiers = useEnabledIdentifiers_SignupId;
   export const pickCountryCode = pickCountryCode_SignupId;
+  export const useUsernameValidation = useUsernameValidation_SignupId;
 }
 
 import { useSignupPassword as useSignupPassword_SignupPassword, useScreen as useScreen_SignupPassword, useTransaction as useTransaction_SignupPassword, signup as signup_SignupPassword, federatedSignup as federatedSignup_SignupPassword, usePasswordValidation as usePasswordValidation_SignupPassword } from './screens/signup-password';
@@ -679,7 +680,7 @@ export namespace SignupPassword {
   export const usePasswordValidation = usePasswordValidation_SignupPassword;
 }
 
-import { useSignup as useSignup_Signup, useScreen as useScreen_Signup, useTransaction as useTransaction_Signup, signup as signup_Signup, federatedSignup as federatedSignup_Signup, pickCountryCode as pickCountryCode_Signup, usePasswordValidation as usePasswordValidation_Signup, useEnabledIdentifiers as useEnabledIdentifiers_Signup } from './screens/signup';
+import { useSignup as useSignup_Signup, useScreen as useScreen_Signup, useTransaction as useTransaction_Signup, signup as signup_Signup, federatedSignup as federatedSignup_Signup, pickCountryCode as pickCountryCode_Signup, usePasswordValidation as usePasswordValidation_Signup, useEnabledIdentifiers as useEnabledIdentifiers_Signup, useUsernameValidation as useUsernameValidation_Signup } from './screens/signup';
 export namespace Signup {
   export const useSignup = useSignup_Signup;
   export const useScreen = useScreen_Signup;
@@ -689,6 +690,7 @@ export namespace Signup {
   export const pickCountryCode = pickCountryCode_Signup;
   export const usePasswordValidation = usePasswordValidation_Signup;
   export const useEnabledIdentifiers = useEnabledIdentifiers_Signup;
+  export const useUsernameValidation = useUsernameValidation_Signup;
 }
 
 import { useCurrentScreen as use_currentScreen, useAuth0Themes as use_Auth0Themes, useErrors as use_Errors } from '../src/hooks/common-hooks';

--- a/packages/auth0-acul-react/src/screens/signup-id.tsx
+++ b/packages/auth0-acul-react/src/screens/signup-id.tsx
@@ -33,6 +33,7 @@ export const signup = (payload: SignupOptions) => getInstance().signup(payload);
 export const federatedSignup = (payload: FederatedSignupOptions) => getInstance().federatedSignup(payload);
 export const useEnabledIdentifiers = () => getInstance().getEnabledIdentifiers();
 export const pickCountryCode = (payload?: CustomOptions) => getInstance().pickCountryCode(payload);
+export const useUsernameValidation = (username: string) => getInstance().validateUsername(username);
 
 export type { ScreenMembersOnSignupId, TransactionMembersOnSignupId, FederatedSignupOptions, SignupOptions, SignupIdMembers } from '@auth0/auth0-acul-js/signup-id';
 

--- a/packages/auth0-acul-react/src/screens/signup.tsx
+++ b/packages/auth0-acul-react/src/screens/signup.tsx
@@ -34,6 +34,7 @@ export const federatedSignup = (payload: FederatedSignupOptions) => getInstance(
 export const pickCountryCode = (payload?: CustomOptions) => getInstance().pickCountryCode(payload);
 export const usePasswordValidation = (password: string) => getInstance().validatePassword(password);
 export const useEnabledIdentifiers = () => getInstance().getEnabledIdentifiers();
+export const useUsernameValidation = (username: string) => getInstance().validateUsername(username);
 
 export type { SignupOptions, FederatedSignupOptions, ScreenMembersOnSignup, TransactionMembersOnSignup, SignupMembers } from '@auth0/auth0-acul-js/signup';
 


### PR DESCRIPTION
### Description

This PR introduces a new helper method `validateUsername` that validates a username string against a given username policy.

🔧 **Changes Introduced:**

**validateUsername/useUsernamevalidation**:

Validates a username string against a given username policy.

🧪 **Screens Affected**:
- signup
- signup-id


### Testing

Tested and validated these changes with sample react app via universal-login-samples screen examples.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
