### PR TITLE
feat: Add useResend hook to various screens

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/login-passwordless-email-code.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-passwordless-email-code.ts
@@ -1,7 +1,7 @@
 import type { TransactionMembers } from '../../interfaces/models';
 import type { BaseMembers } from '../../interfaces/models/base-context';
 import type { ScreenMembers } from '../../interfaces/models/screen';
-import type { CustomOptions } from '../common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
 
 export interface ScreenMembersOnLoginPasswordlessEmailCode extends ScreenMembers {
   editIdentifierLink: string | null;
@@ -28,4 +28,5 @@ export interface LoginPasswordlessEmailCodeMembers extends BaseMembers {
   transaction: TransactionMembersOnLoginPasswordlessEmailCode;
   submitCode(payload: SubmitCodeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
+  resendManager(options?: StartResendOptions): ResendControl;
 }

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-email.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-email.ts
@@ -1,4 +1,4 @@
-import type { CustomOptions } from '../common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers, ScreenData } from '../models/screen';
 
@@ -19,4 +19,5 @@ export interface ScreenMembersOnResetPasswordEmail extends ScreenMembers {
 export interface ResetPasswordEmailMembers extends BaseMembers {
   screen: ScreenMembersOnResetPasswordEmail;
   resendEmail(payload?: CustomOptions): Promise<void>;
+  resendManager(options?: StartResendOptions): ResendControl;
 }

--- a/packages/auth0-acul-js/src/screens/login-passwordless-email-code/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-passwordless-email-code/index.ts
@@ -1,11 +1,12 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -66,6 +67,39 @@ export default class LoginPasswordlessEmailCode extends BaseContext implements L
     };
 
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.RESEND });
+  }
+
+  /**
+   * Creates a resend control manager for handling email code resend operations.
+   * 
+   * @param options Configuration options for the resend control
+   * @returns A ResendControl object with resend functionality and state management
+   * 
+   * @example
+   * ```typescript
+   * import LoginPasswordlessEmailCode from '@auth0/auth0-acul-js/login-passwordless-email-code';
+   * 
+   * const loginPasswordlessEmailCode = new LoginPasswordlessEmailCode();
+   * const { startResend } = loginPasswordlessEmailCode.resendManager({
+   *   timeoutSeconds: 60,
+   *   onStatusChange: (remainingSeconds, isDisabled) => {
+   *     console.log(`Resend available in ${remainingSeconds}s, disabled: ${isDisabled}`);
+   *   },
+   *   onTimeout: () => {
+   *     console.log('Resend is now available');
+   *   }
+   * });
+   * 
+   * // Call startResend when user clicks resend button
+   * startResend();
+   * ```
+   */
+  resendManager(options?: StartResendOptions): ResendControl {
+    return createResendControl(
+      LoginPasswordlessEmailCode.screenIdentifier,
+      () => this.resendCode(),
+      options
+    );
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/reset-password-email/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-email/index.ts
@@ -1,10 +1,11 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   ResetPasswordEmailMembers,
@@ -35,6 +36,39 @@ export default class ResetPasswordEmail extends BaseContext implements ResetPass
       telemetry: [ResetPasswordEmail.screenIdentifier, 'resendEmail'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.RESEND_EMAIL });
+  }
+
+  /**
+   * Creates a resend control manager for handling email resend operations.
+   * 
+   * @param options Configuration options for the resend control
+   * @returns A ResendControl object with resend functionality and state management
+   * 
+   * @example
+   * ```typescript
+   * import ResetPasswordEmail from '@auth0/auth0-acul-js/reset-password-email';
+   * 
+   * const resetPasswordEmail = new ResetPasswordEmail();
+   * const { startResend } = resetPasswordEmail.resendManager({
+   *   timeoutSeconds: 60,
+   *   onStatusChange: (remainingSeconds, isDisabled) => {
+   *     console.log(`Resend available in ${remainingSeconds}s, disabled: ${isDisabled}`);
+   *   },
+   *   onTimeout: () => {
+   *     console.log('Resend is now available');
+   *   }
+   * });
+   * 
+   * // Call startResend when user clicks resend button
+   * startResend();
+   * ```
+   */
+  resendManager(options?: StartResendOptions): ResendControl {
+    return createResendControl(
+      ResetPasswordEmail.screenIdentifier,
+      () => this.resendEmail(),
+      options
+    );
   }
 }
 export { ResetPasswordEmailMembers, ResetPasswordEmailOptions, ScreenOptions as ScreenMembersOnResetPasswordEmail };

--- a/packages/auth0-acul-react/src/screens/email-identifier-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/email-identifier-challenge.tsx
@@ -36,7 +36,41 @@ export const submitEmailChallenge = (payload: EmailChallengeOptions) => getInsta
 export const resendCode = (payload?: CustomOptions) => getInstance().resendCode(payload);
 export const returnToPrevious = (payload?: CustomOptions) => getInstance().returnToPrevious(payload);
 
-// Resend hook
+/**
+ * Hook for managing email resend functionality in email identifier challenge screen.
+ *
+ * This hook provides functionality to resend email identifier challenges 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function EmailIdentifierChallengeForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Email identifier challenge resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend Email Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/email-otp-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/email-otp-challenge.tsx
@@ -34,7 +34,40 @@ export const useTransaction = () => useMemo(() => getInstance().transaction, [])
 export const submitCode = (options: OtpCodeOptions) => getInstance().submitCode(options);
 export const resendCode = (options?: CustomOptions) => getInstance().resendCode(options);
 
-// Resend hook
+/**
+ * Hook for managing OTP code resend functionality in email-otp-challenge screen.
+ *
+ * This hook provides functionality to resend OTP codes with built-in rate limiting
+ * and timeout management. It returns the resend state and controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function EmailOTPChallengeForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/login-email-verification.tsx
+++ b/packages/auth0-acul-react/src/screens/login-email-verification.tsx
@@ -34,7 +34,41 @@ export const useTransaction = () => useMemo(() => getInstance().transaction, [])
 export const continueWithCode = (payload: ContinueWithCodeOptions) => getInstance().continueWithCode(payload);
 export const resendCode = (payload?: ResendCodeOptions) => getInstance().resendCode(payload);
 
-// Resend hook
+/**
+ * Hook for managing email resend functionality in login email verification screen.
+ *
+ * This hook provides functionality to resend email verification during login 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function LoginEmailVerificationForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Login email verification resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend Verification'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/login-passwordless-email-code.tsx
+++ b/packages/auth0-acul-react/src/screens/login-passwordless-email-code.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import LoginPasswordlessEmailCode from '@auth0/auth0-acul-js/login-passwordless-email-code';
 import { ContextHooks } from '../hooks/context-hooks';
+import { resendManager } from '../hooks/utility-hooks';
+import type { UseResendParams, UseResendReturn } from '../interfaces/common';
 
 import type { LoginPasswordlessEmailCodeMembers, SubmitCodeOptions, CustomOptions, ScreenMembersOnLoginPasswordlessEmailCode, TransactionMembersOnLoginPasswordlessEmailCode } from '@auth0/auth0-acul-js/login-passwordless-email-code';
 let instance: LoginPasswordlessEmailCodeMembers | null = null;
@@ -31,6 +33,46 @@ export const useTransaction: () => TransactionMembersOnLoginPasswordlessEmailCod
 // Screen methods
 export const submitCode = (payload: SubmitCodeOptions) => getInstance().submitCode(payload);
 export const resendCode = (payload?: CustomOptions) => getInstance().resendCode(payload);
+
+/**
+ * Hook for managing email code resend functionality in login passwordless email code screen.
+ *
+ * This hook provides functionality to resend email codes during passwordless login 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function LoginPasswordlessEmailCodeForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Passwordless email code resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend Email Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export const useResend = (payload?: UseResendParams): UseResendReturn => {
+  const screenInstance = useMemo(() => getInstance(), []);
+  return resendManager(screenInstance, payload);
+};
 
 export type { ScreenMembersOnLoginPasswordlessEmailCode, TransactionMembersOnLoginPasswordlessEmailCode, SubmitCodeOptions, LoginPasswordlessEmailCodeMembers } from '@auth0/auth0-acul-js/login-passwordless-email-code';
 

--- a/packages/auth0-acul-react/src/screens/login-passwordless-sms-otp.tsx
+++ b/packages/auth0-acul-react/src/screens/login-passwordless-sms-otp.tsx
@@ -34,7 +34,41 @@ export const useTransaction: () => TransactionMembersOnLoginPasswordlessSmsOtp =
 export const submitOTP = (payload: SubmitOTPOptions) => getInstance().submitOTP(payload);
 export const resendOTP = (payload?: CustomOptions) => getInstance().resendOTP(payload);
 
-// Resend hook
+/**
+ * Hook for managing SMS OTP resend functionality in login passwordless SMS OTP screen.
+ *
+ * This hook provides functionality to resend SMS OTP codes during passwordless login 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function LoginPasswordlessSmsOtpForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Passwordless SMS OTP resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend SMS Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/mfa-email-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-email-challenge.tsx
@@ -35,7 +35,40 @@ export const continueMethod = (payload: ContinueOptions) => getInstance().contin
 export const resendCode = (payload?: ResendCodeOptions) => getInstance().resendCode(payload);
 export const tryAnotherMethod = (payload?: TryAnotherMethodOptions) => getInstance().tryAnotherMethod(payload);
 
-// Resend hook
+/**
+ * Hook for managing email resend functionality in MFA email challenge screen.
+ *
+ * This hook provides functionality to resend MFA email challenges with built-in rate limiting
+ * and timeout management. It returns the resend state and controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function MfaEmailChallengeForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('MFA email resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend MFA Email'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/mfa-sms-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-sms-challenge.tsx
@@ -37,7 +37,40 @@ export const resendCode = (payload?: CustomOptions) => getInstance().resendCode(
 export const tryAnotherMethod = (payload?: CustomOptions) => getInstance().tryAnotherMethod(payload);
 export const getACall = (payload?: CustomOptions) => getInstance().getACall(payload);
 
-// Resend hook
+/**
+ * Hook for managing SMS resend functionality in MFA SMS challenge screen.
+ *
+ * This hook provides functionality to resend MFA SMS challenges with built-in rate limiting
+ * and timeout management. It returns the resend state and controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function MfaSmsChallengeForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('MFA SMS resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend SMS Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/mfa-voice-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-voice-challenge.tsx
@@ -37,7 +37,40 @@ export const switchToSms = (payload?: CustomOptions) => getInstance().switchToSm
 export const resendCode = (payload?: CustomOptions) => getInstance().resendCode(payload);
 export const tryAnotherMethod = (payload?: CustomOptions) => getInstance().tryAnotherMethod(payload);
 
-// Resend hook
+/**
+ * Hook for managing voice call resend functionality in MFA voice challenge screen.
+ *
+ * This hook provides functionality to resend MFA voice challenges with built-in rate limiting
+ * and timeout management. It returns the resend state and controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function MfaVoiceChallengeForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 90,
+ *     onTimeout: () => console.log('MFA voice call resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Call again in ${remaining}s` : 'Call Again'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/phone-identifier-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/phone-identifier-challenge.tsx
@@ -35,7 +35,41 @@ export const submitPhoneChallenge = (payload: PhoneChallengeOptions) => getInsta
 export const resendCode = (payload?: CustomOptions) => getInstance().resendCode(payload);
 export const returnToPrevious = (payload?: CustomOptions) => getInstance().returnToPrevious(payload);
 
-// Resend hook
+/**
+ * Hook for managing phone resend functionality in phone identifier challenge screen.
+ *
+ * This hook provides functionality to resend phone identifier challenges 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function PhoneIdentifierChallengeForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Phone identifier challenge resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend SMS Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/reset-password-email.tsx
+++ b/packages/auth0-acul-react/src/screens/reset-password-email.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import ResetPasswordEmail from '@auth0/auth0-acul-js/reset-password-email';
 import { ContextHooks } from '../hooks/context-hooks';
+import { resendManager } from '../hooks/utility-hooks';
+import type { UseResendParams, UseResendReturn } from '../interfaces/common';
 
 import type { ResetPasswordEmailMembers, CustomOptions, ScreenMembersOnResetPasswordEmail } from '@auth0/auth0-acul-js/reset-password-email';
 let instance: ResetPasswordEmailMembers | null = null;
@@ -30,6 +32,46 @@ export const useTransaction = () => useMemo(() => getInstance().transaction, [])
 
 // Screen methods
 export const resendEmail = (payload?: CustomOptions) => getInstance().resendEmail(payload);
+
+/**
+ * Hook for managing email resend functionality in reset password email screen.
+ *
+ * This hook provides functionality to resend reset password emails 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function ResetPasswordEmailForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Reset password email resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend Reset Email'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export const useResend = (payload?: UseResendParams): UseResendReturn => {
+  const screenInstance = useMemo(() => getInstance(), []);
+  return resendManager(screenInstance, payload);
+};
 
 export type { ResetPasswordEmailOptions, ScreenMembersOnResetPasswordEmail, ResetPasswordEmailMembers } from '@auth0/auth0-acul-js/reset-password-email';
 

--- a/packages/auth0-acul-react/src/screens/reset-password-mfa-email-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/reset-password-mfa-email-challenge.tsx
@@ -35,7 +35,41 @@ export const continueMethod = (payload: ContinueOptions) => getInstance().contin
 export const resendCode = (payload?: ResendCodeOptions) => getInstance().resendCode(payload);
 export const tryAnotherMethod = (payload?: TryAnotherMethodOptions) => getInstance().tryAnotherMethod(payload);
 
-// Resend hook
+/**
+ * Hook for managing email resend functionality in reset password MFA email challenge screen.
+ *
+ * This hook provides functionality to resend MFA email challenges during password reset 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function ResetPasswordMfaEmailForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Reset password MFA email resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend Reset Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/reset-password-mfa-sms-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/reset-password-mfa-sms-challenge.tsx
@@ -36,7 +36,41 @@ export const resendCode = (payload?: CustomOptions) => getInstance().resendCode(
 export const tryAnotherMethod = (payload?: CustomOptions) => getInstance().tryAnotherMethod(payload);
 export const getACall = (payload?: CustomOptions) => getInstance().getACall(payload);
 
-// Resend hook
+/**
+ * Hook for managing SMS resend functionality in reset password MFA SMS challenge screen.
+ *
+ * This hook provides functionality to resend MFA SMS challenges during password reset 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function ResetPasswordMfaSmsForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 60,
+ *     onTimeout: () => console.log('Reset password MFA SMS resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Resend in ${remaining}s` : 'Resend SMS Code'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);

--- a/packages/auth0-acul-react/src/screens/reset-password-mfa-voice-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/reset-password-mfa-voice-challenge.tsx
@@ -36,7 +36,41 @@ export const switchToSms = (payload?: CustomOptions) => getInstance().switchToSm
 export const resendCode = (payload?: CustomOptions) => getInstance().resendCode(payload);
 export const tryAnotherMethod = (payload?: CustomOptions) => getInstance().tryAnotherMethod(payload);
 
-// Resend hook
+/**
+ * Hook for managing voice call resend functionality in reset password MFA voice challenge screen.
+ *
+ * This hook provides functionality to resend MFA voice challenges during password reset 
+ * with built-in rate limiting and timeout management. It returns the resend state and 
+ * controls for user interaction.
+ *
+ * @param {UseResendParams} [payload] - Optional configuration for the resend behavior
+ * @param {number} [payload.timeoutSeconds] - Custom timeout duration in seconds
+ * @param {OnTimeoutCallback} [payload.onTimeout] - Callback function executed when timeout expires
+ * 
+ * @returns {UseResendReturn} Object containing:
+ *  - `remaining`: number of seconds remaining before resend is available
+ *  - `disabled`: boolean indicating if resend is currently disabled
+ *  - `startResend`: function to trigger the resend operation
+ *
+ * @example
+ * ```tsx
+ * function ResetPasswordMfaVoiceForm() {
+ *   const { remaining, disabled, startResend } = useResend({
+ *     timeoutSeconds: 90,
+ *     onTimeout: () => console.log('Reset password MFA voice call resend available')
+ *   });
+ *   
+ *   return (
+ *     <button 
+ *       onClick={startResend} 
+ *       disabled={disabled}
+ *     >
+ *       {disabled ? `Call again in ${remaining}s` : 'Call Again'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
 export const useResend = (payload?: UseResendParams): UseResendReturn => {
   const screenInstance = useMemo(() => getInstance(), []);
   return resendManager(screenInstance, payload);


### PR DESCRIPTION
### 🚀 Add `useResend` Hook Integration for OTP and Challenge Screens

### 📝 Summary
This PR introduces a new `useResend` hook that provides a standardized way to handle resend functionality across various authentication screens that require OTP or challenge verification. The hook manages resend countdown timers, disabled states, and callbacks in a consistent manner.

### 🔧 Changes

#### 🧩 New Hook Implementation
- ➕ Added `useResend` hook in `index.tsx`
- ⚙️ Provides a generic interface for managing resend functionality
- ⏱️ Handles countdown timers and disabled states
- 🛠️ Accepts configurable timeout seconds and callback functions
- 🔁 Returns remaining time, disabled state, and `startResend` function

#### 📐 Type Definitions
- 🆕 Added new interfaces in `common.ts`:
  - `UseResendReturn`: Return type with `remaining`, `disabled`, and `startResend` properties
  - `UseResendParams`: Parameters including optional `timeoutSeconds` and `onTimeout` callback
  - `ScreenWithResendManager`: Generic interface for screens with resend functionality

#### 🖥️ Screen Integration
The `useResend` hook has been integrated into the following authentication screens:

##### 🔐 Login Flows:
- `login-passwordless-sms-otp.tsx`
- `login-email-verification.tsx`

##### 🛡️ MFA Challenge Screens:
- `mfa-email-challenge.tsx`
- `mfa-sms-challenge.tsx`
- `mfa-voice-challenge.tsx`

##### 🔑 Reset Password MFA Screens:
- `reset-password-mfa-email-challenge.tsx`
- `reset-password-mfa-sms-challenge.tsx`
- `reset-password-mfa-voice-challenge.tsx`

##### 🆔 Identifier Challenge Screens:
- `email-identifier-challenge.tsx`
- `phone-identifier-challenge.tsx`
- `email-otp-challenge.tsx`

### ✅ Benefits
- 🧩 **Consistency**: Standardizes resend behavior across all relevant screens  
- ♻️ **Reusability**: Single hook implementation reduces code duplication  
- 🛠️ **Maintainability**: Centralized logic makes updates and bug fixes easier  
- 🔐 **Type Safety**: Full TypeScript support with proper interfaces  
- 🧰 **Flexibility**: Configurable timeout and callback options  
