### PR TITLE
Enhance resend control: prevent timer start when resend limit is reached

### DIFF
--- a/packages/auth0-acul-js/src/utils/resend-utils.ts
+++ b/packages/auth0-acul-js/src/utils/resend-utils.ts
@@ -52,6 +52,11 @@ export function createResendControl(
   };
 
   const startTimer = (): void => {
+    // Don't start timer if resend limit is reached
+    if (resendLimitReached) {
+      return;
+    }
+    
     localStorage.setItem(storageKey, Date.now().toString());
     hasCalledOnTimeout = false; // Reset for new timer
     cleanup();
@@ -76,8 +81,8 @@ export function createResendControl(
   // Initial state calculation without triggering onStatusChange
   calculateState();
 
-  // Resume countdown if there's time remaining from previous session
-  if (remaining > 0) {
+  // Resume countdown if there's time remaining from previous session and resend limit not reached
+  if (remaining > 0 && !resendLimitReached) {
     intervalId = setInterval(() => {
       calculateState();
       if (remaining <= 0) {


### PR DESCRIPTION
### 🛠️ Fix: Prevent timer when resend limit is reached

---

### 🧩 Problem

- Timer was running unnecessarily when `resendLimitReached` is `true`, causing background processing even though resend is permanently disabled.

---

### ✅ Solution

- Skip timer start in `startTimer()` when the limit is reached  
- Skip timer resume on initialization when the limit is reached  
- Button stays disabled, no unnecessary intervals

---

### 📈 Impact

- ✅ Improved performance – no background timers when not needed  
- ✅ Clearer UX – permanent disabled state when limit is reached  

---

