### PR TITLE
feat: add screenIdentifier properties and resendManager to screens

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/login-passwordless-email-code.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-passwordless-email-code.ts
@@ -1,7 +1,7 @@
 import type { TransactionMembers } from '../../interfaces/models';
 import type { BaseMembers } from '../../interfaces/models/base-context';
 import type { ScreenMembers } from '../../interfaces/models/screen';
-import type { CustomOptions } from '../common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../common';
 
 export interface ScreenMembersOnLoginPasswordlessEmailCode extends ScreenMembers {
   editIdentifierLink: string | null;
@@ -28,4 +28,5 @@ export interface LoginPasswordlessEmailCodeMembers extends BaseMembers {
   transaction: TransactionMembersOnLoginPasswordlessEmailCode;
   submitCode(payload: SubmitCodeOptions): Promise<void>;
   resendCode(payload?: CustomOptions): Promise<void>;
+  resendManager(options?: StartResendOptions): ResendControl;
 }

--- a/packages/auth0-acul-js/src/constants/enums.ts
+++ b/packages/auth0-acul-js/src/constants/enums.ts
@@ -45,6 +45,7 @@ export const ScreenIds = {
   CUSTOMIZED_CONSENT: 'customized-consent',
   MFA_PHONE_ENROLLMENT: 'mfa-phone-enrollment',
   MFA_VOICE_ENROLLMENT: 'mfa-voice-enrollment',
+  MFA_VOICE_CHALLENGE: 'mfa-voice-challenge',
   MFA_RECOVERY_CODE_CHALLENGE: 'mfa-recovery-code-challenge',
   DEVICE_CODE_ACTIVATION_ALLOWED: 'device-code-activation-allowed',
   DEVICE_CODE_ACTIVATION_DENIED: 'device-code-activation-denied',

--- a/packages/auth0-acul-js/src/screens/login-passwordless-email-code/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-passwordless-email-code/index.ts
@@ -1,11 +1,12 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { createResendControl } from '../../utils/resend-utils';
 
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, StartResendOptions, ResendControl } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -66,6 +67,39 @@ export default class LoginPasswordlessEmailCode extends BaseContext implements L
     };
 
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.RESEND });
+  }
+
+  /**
+   * Creates a resend control manager for handling email code resend operations.
+   * 
+   * @param options Configuration options for the resend control
+   * @returns A ResendControl object with resend functionality and state management
+   * 
+   * @example
+   * ```typescript
+   * import LoginPasswordlessEmailCode from '@auth0/auth0-acul-js/login-passwordless-email-code';
+   * 
+   * const loginPasswordlessEmailCode = new LoginPasswordlessEmailCode();
+   * const { startResend } = loginPasswordlessEmailCode.resendManager({
+   *   timeoutSeconds: 60,
+   *   onStatusChange: (remainingSeconds, isDisabled) => {
+   *     console.log(`Resend available in ${remainingSeconds}s, disabled: ${isDisabled}`);
+   *   },
+   *   onTimeout: () => {
+   *     console.log('Resend is now available');
+   *   }
+   * });
+   * 
+   * // Call startResend when user clicks resend button
+   * startResend();
+   * ```
+   */
+  resendManager(options?: StartResendOptions): ResendControl {
+    return createResendControl(
+      LoginPasswordlessEmailCode.screenIdentifier,
+      () => this.resendCode(),
+      options
+    );
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/mfa-otp-enrollment-code/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-otp-enrollment-code/index.ts
@@ -1,4 +1,4 @@
-import { FormActions } from '../../../src/constants';
+import { FormActions, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
@@ -19,6 +19,10 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen is displayed when the user needs to enter the OTP code received during MFA enrollment.
  */
 export default class MfaOtpEnrollmentCode extends BaseContext implements MfaOtpEnrollmentCodeMembers {
+  /**
+   * Screen identifier for validation and telemetry
+   */
+  static screenIdentifier: string = ScreenIds.MFA_OTP_ENROLLMENT_CODE;
   /**
    * The screen properties for the mfa-otp-enrollment-code screen.
    */

--- a/packages/auth0-acul-js/src/screens/mfa-otp-enrollment-qr/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-otp-enrollment-qr/index.ts
@@ -1,4 +1,4 @@
-import { FormActions } from '../../../src/constants';
+import { FormActions, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
@@ -17,6 +17,10 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Class implementing the mfa-otp-enrollment-qr screen functionality
  */
 export default class MfaOtpEnrollmentQr extends BaseContext implements MfaOtpEnrollmentQrMembers {
+  /**
+   * Screen identifier for validation and telemetry
+   */
+  static screenIdentifier: string = ScreenIds.MFA_OTP_ENROLLMENT_QR;
   screen: ScreenOptions;
 
   /**

--- a/packages/auth0-acul-js/src/screens/mfa-voice-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-voice-challenge/index.ts
@@ -1,4 +1,4 @@
-import { FormActions } from '../../constants';
+import { FormActions, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 import { createResendControl } from '../../utils/resend-utils';
@@ -24,6 +24,11 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * as part of a multi-factor authentication flow.
  */
 export default class MfaVoiceChallenge extends BaseContext implements MfaVoiceChallengeMembers {
+  /**
+   * Screen identifier for validation and telemetry
+   */
+  static screenIdentifier: string = ScreenIds.MFA_VOICE_CHALLENGE;
+
   /**
    * Screen-specific properties and data.
    */

--- a/packages/auth0-acul-js/src/screens/organization-picker/index.ts
+++ b/packages/auth0-acul-js/src/screens/organization-picker/index.ts
@@ -1,3 +1,4 @@
+import { ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
@@ -10,6 +11,10 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen allows users to select an organization from a list of available organizations.
  */
 export default class OrganizationPicker extends BaseContext implements OrganizationPickerMembers {
+  /**
+   * Screen identifier for validation and telemetry
+   */
+  static screenIdentifier: string = ScreenIds.ORGANIZATION_PICKER;
   /**
    * Creates an instance of OrganizationPicker screen manager.
    */

--- a/packages/auth0-acul-js/src/screens/organization-selection/index.ts
+++ b/packages/auth0-acul-js/src/screens/organization-selection/index.ts
@@ -1,4 +1,4 @@
-import { FormActions } from '../../../src/constants';
+import { FormActions, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
@@ -15,6 +15,10 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * This screen allows users to select an organization to continue with.
  */
 export default class OrganizationSelection extends BaseContext implements OrganizationSelectionMembers {
+  /**
+   * Screen identifier for validation and telemetry
+   */
+  static screenIdentifier: string = ScreenIds.ORGANIZATION_SELECTION;
   screen: ScreenOptions;
 
   /**

--- a/packages/auth0-acul-js/src/screens/reset-password-mfa-otp-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-mfa-otp-challenge/index.ts
@@ -1,4 +1,4 @@
-import { FormActions } from '../../../src/constants';
+import { FormActions, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
@@ -14,6 +14,10 @@ import type { FormOptions } from '../../../interfaces/utils/form-handler';
  * Class implementing the reset-password-mfa-otp-challenge screen functionality
  */
 export default class ResetPasswordMfaOtpChallenge extends BaseContext implements ResetPasswordMfaOtpChallengeMembers {
+  /**
+   * Screen identifier for validation and telemetry
+   */
+  static screenIdentifier: string = ScreenIds.RESET_PASSWORD_MFA_OTP_CHALLENGE;
   /**
    * Creates an instance of ResetPasswordMfaOtpChallenge screen manager
    */

--- a/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
@@ -1,19 +1,21 @@
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import EmailIdentifierChallenge from '../../../../src/screens/email-identifier-challenge';
-import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
-import { EmailChallengeOptions } from 'interfaces/screens/email-identifier-challenge';
-import { CustomOptions } from 'interfaces/common';
-import { ScreenIds } from '../../../../src//constants';
-import { FormActions } from '../../../../src/constants';
+import { createResendControl } from '../../../../src/utils/resend-utils';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from 'interfaces/common';
+import type { EmailChallengeOptions } from 'interfaces/screens/email-identifier-challenge';
 
 jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/resend-utils');
 
 describe('EmailIdentifierChallenge', () => {
   let emailIdentifierChallenge: EmailIdentifierChallenge;
   let mockFormHandler: { submitData: jest.Mock };
 
   beforeEach(() => {
-    global.window = Object.create(window);
+    global.window = Object.create(window) as unknown as Window & typeof globalThis;
     baseContextData.screen.name = ScreenIds.EMAIL_IDENTIFIER_CHALLENGE;
     window.universal_login_context = baseContextData;
 
@@ -133,6 +135,145 @@ describe('EmailIdentifierChallenge', () => {
       await expect(
         emailIdentifierChallenge.returnToPrevious(payload)
       ).rejects.toThrow('Mocked reject');
+    });
+  });
+
+  describe('class properties and constructor', () => {
+    it('should have correct screen identifier', () => {
+      expect(EmailIdentifierChallenge.screenIdentifier).toBe('email-identifier-challenge');
+    });
+
+    it('should create instance successfully', () => {
+      const instance = new EmailIdentifierChallenge();
+      expect(instance).toBeInstanceOf(EmailIdentifierChallenge);
+    });
+  });
+
+  describe('resendManager method', () => {
+    let mockStartResend: jest.Mock;
+
+    beforeEach(() => {
+      mockStartResend = jest.fn();
+      (createResendControl as jest.Mock).mockReturnValue({
+        startResend: mockStartResend,
+      });
+    });
+
+    it('should call createResendControl with correct screen identifier and resend function', () => {
+      emailIdentifierChallenge.resendManager();
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-identifier-challenge',
+        expect.any(Function),
+        undefined,
+        false
+      );
+    });
+
+    it('should call createResendControl with provided options', () => {
+      const options = {
+        timeoutSeconds: 15,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn(),
+      };
+
+      emailIdentifierChallenge.resendManager(options);
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-identifier-challenge',
+        expect.any(Function),
+        options,
+        false
+      );
+    });
+
+    it('should return the result from createResendControl', () => {
+      const expectedResult = { startResend: mockStartResend };
+      (createResendControl as jest.Mock).mockReturnValue(expectedResult);
+
+      const result = emailIdentifierChallenge.resendManager();
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should pass resendCode method as callback to createResendControl', () => {
+      emailIdentifierChallenge.resendManager();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const resendCallback = (createResendControl as jest.Mock).mock.calls[0][1] as () => Promise<void>;
+      expect(typeof resendCallback).toBe('function');
+    });
+
+    it('should provide a function that calls resendCode when invoked', async () => {
+      emailIdentifierChallenge.resendManager();
+
+      // Verify that createResendControl was called with the correct parameters
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-identifier-challenge',
+        expect.any(Function),
+        undefined,
+        false
+      );
+
+      // Get the callback function from the mock and call it to improve coverage
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+      const callbackArg = (createResendControl as jest.Mock).mock.calls[0][1];
+      expect(typeof callbackArg).toBe('function');
+      
+      // Execute the callback to cover the arrow function line
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+      const result = callbackArg();
+      
+      // Verify that it returns a promise (since resendCode is async)
+      expect(result).toBeInstanceOf(Promise);
+      
+      // Wait for the promise to resolve to complete coverage
+      await result;
+    });
+
+    it('should pass callback options to createResendControl', () => {
+      const onStatusChange = jest.fn();
+      const onTimeout = jest.fn();
+      const options = {
+        timeoutSeconds: 20,
+        onStatusChange,
+        onTimeout,
+      };
+
+      emailIdentifierChallenge.resendManager(options);
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-identifier-challenge',
+        expect.any(Function),
+        expect.objectContaining({
+          timeoutSeconds: 20,
+          onStatusChange,
+          onTimeout,
+        }),
+        false
+      );
+    });
+
+    it('should handle startResend method from returned control object', () => {
+      const result = emailIdentifierChallenge.resendManager();
+
+      result.startResend();
+
+      expect(mockStartResend).toHaveBeenCalled();
+    });
+
+    it('should pass resendLimitReached status to createResendControl', () => {
+      // Mock screen data to have resendLimitReached
+      emailIdentifierChallenge.screen.data = { resendLimitReached: true };
+
+      emailIdentifierChallenge.resendManager();
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-identifier-challenge',
+        expect.any(Function),
+        undefined,
+        true
+      );
     });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-otp-challenge/index.test.ts
@@ -1,18 +1,20 @@
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import EmailOTPChallenge from '../../../../src/screens/email-otp-challenge';
-import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
-import { CustomOptions } from 'interfaces/common';
-import { ScreenIds } from '../../../../src/constants';
-import { FormActions } from '../../../../src/constants';
+import { createResendControl } from '../../../../src/utils/resend-utils';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from 'interfaces/common';
 
 jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/resend-utils');
 
 describe('EmailOTPChallenge', () => {
   let emailOTPChallenge: EmailOTPChallenge;
   let mockFormHandler: { submitData: jest.Mock };
 
   beforeEach(() => {
-    global.window = Object.create(window);
+    global.window = Object.create(window) as unknown as Window & typeof globalThis;
     baseContextData.screen.name = ScreenIds.EMAIL_OTP_CHALLENGE;
     window.universal_login_context = baseContextData;
     emailOTPChallenge = new EmailOTPChallenge();
@@ -20,6 +22,17 @@ describe('EmailOTPChallenge', () => {
       submitData: jest.fn(),
     };
     (FormHandler as jest.Mock).mockImplementation(() => mockFormHandler);
+  });
+
+  describe('class properties and constructor', () => {
+    it('should have correct screen identifier', () => {
+      expect(EmailOTPChallenge.screenIdentifier).toBe('email-otp-challenge');
+    });
+
+    it('should create instance successfully', () => {
+      const instance = new EmailOTPChallenge();
+      expect(instance).toBeInstanceOf(EmailOTPChallenge);
+    });
   });
 
   describe('submitCode method', () => {
@@ -90,6 +103,118 @@ describe('EmailOTPChallenge', () => {
       await expect(emailOTPChallenge.resendCode()).rejects.toThrow(
         'Mocked reject'
       );
+    });
+  });
+
+  describe('resendManager method', () => {
+    let mockStartResend: jest.Mock;
+
+    beforeEach(() => {
+      mockStartResend = jest.fn();
+      (createResendControl as jest.Mock).mockReturnValue({
+        startResend: mockStartResend,
+      });
+    });
+
+    it('should call createResendControl with correct screen identifier and resend function', () => {
+      emailOTPChallenge.resendManager();
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-otp-challenge',
+        expect.any(Function),
+        undefined
+      );
+    });
+
+    it('should call createResendControl with provided options', () => {
+      const options = {
+        timeoutSeconds: 15,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn(),
+      };
+
+      emailOTPChallenge.resendManager(options);
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-otp-challenge',
+        expect.any(Function),
+        options
+      );
+    });
+
+    it('should return the result from createResendControl', () => {
+      const expectedResult = { startResend: mockStartResend };
+      (createResendControl as jest.Mock).mockReturnValue(expectedResult);
+
+      const result = emailOTPChallenge.resendManager();
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should pass resendCode method as callback to createResendControl', () => {
+      emailOTPChallenge.resendManager();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const resendCallback = (createResendControl as jest.Mock).mock.calls[0][1] as () => Promise<void>;
+      expect(typeof resendCallback).toBe('function');
+    });
+
+    it('should provide a function that calls resendCode when invoked', async () => {
+      // Call resendManager
+      emailOTPChallenge.resendManager();
+
+      // Verify that createResendControl was called with the correct parameters
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-otp-challenge',
+        expect.any(Function),
+        undefined
+      );
+
+      // Get the callback function from the mock
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+      const callbackArg = (createResendControl as jest.Mock).mock.calls[0][1];
+      expect(typeof callbackArg).toBe('function');
+      
+      // Execute the callback to cover the arrow function line
+      // This will call the arrow function () => this.resendCode()
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+      const result = callbackArg();
+      
+      // Verify that it returns a promise (since resendCode is async)
+      expect(result).toBeInstanceOf(Promise);
+      
+      // Wait for the promise to resolve to complete coverage
+      await result;
+    });
+
+    it('should pass callback options to createResendControl', () => {
+      const onStatusChange = jest.fn();
+      const onTimeout = jest.fn();
+      const options = {
+        timeoutSeconds: 20,
+        onStatusChange,
+        onTimeout,
+      };
+
+      emailOTPChallenge.resendManager(options);
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'email-otp-challenge',
+        expect.any(Function),
+        expect.objectContaining({
+          timeoutSeconds: 20,
+          onStatusChange,
+          onTimeout,
+        })
+      );
+    });
+
+    it('should handle startResend method from returned control object', () => {
+      const result = emailOTPChallenge.resendManager();
+
+      result.startResend();
+
+      expect(mockStartResend).toHaveBeenCalled();
     });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/login-passwordless-email-code/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-passwordless-email-code/index.test.ts
@@ -1,19 +1,21 @@
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import LoginPasswordlessEmailCode from '../../../../src/screens/login-passwordless-email-code';
-import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
-import { SubmitCodeOptions } from 'interfaces/screens/login-passwordless-email-code';
-import { CustomOptions } from 'interfaces/common';
-import { ScreenIds } from '../../../../src//constants';
-import { FormActions } from '../../../../src/constants';
+import { createResendControl } from '../../../../src/utils/resend-utils';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from 'interfaces/common';
+import type { SubmitCodeOptions } from 'interfaces/screens/login-passwordless-email-code';
 
 jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/resend-utils');
 
 describe('LoginPasswordlessEmailCode', () => {
   let loginPasswordlessEmailCode: LoginPasswordlessEmailCode;
   let mockFormHandler: { submitData: jest.Mock };
 
   beforeEach(() => {
-    global.window = Object.create(window);
+    global.window = Object.create(window) as Window & typeof globalThis;
     baseContextData.screen.name = ScreenIds.LOGIN_PASSWORDLESS_EMAIL_CODE;
     window.universal_login_context = baseContextData;
 
@@ -108,6 +110,109 @@ describe('LoginPasswordlessEmailCode', () => {
       await expect(
         loginPasswordlessEmailCode.resendCode(payload)
       ).rejects.toThrow('Mocked reject');
+    });
+  });
+
+  describe('resendManager method', () => {
+    let mockResendControl: { startResend: jest.Mock };
+
+    beforeEach(() => {
+      mockResendControl = {
+        startResend: jest.fn(),
+      };
+      (createResendControl as jest.Mock).mockReturnValue(mockResendControl);
+    });
+
+    it('should create resend control with correct parameters', () => {
+      const options = {
+        timeoutSeconds: 30,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn(),
+      };
+
+      const result = loginPasswordlessEmailCode.resendManager(options);
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'login-passwordless-email-code',
+        expect.any(Function),
+        options
+      );
+      expect(result).toBe(mockResendControl);
+    });
+
+    it('should create resend control without options', () => {
+      const result = loginPasswordlessEmailCode.resendManager();
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'login-passwordless-email-code',
+        expect.any(Function),
+        undefined
+      );
+      expect(result).toBe(mockResendControl);
+    });
+
+    it('should pass resendCode method as callback to createResendControl', async () => {
+      loginPasswordlessEmailCode.resendManager();
+
+      // Get the callback function passed to createResendControl
+      const callArgs = (createResendControl as jest.Mock).mock.calls[0] as unknown[];
+      const resendCallback = callArgs[1] as () => Promise<void>;
+
+      // Call the callback and verify it calls resendCode
+      await resendCallback();
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        action: FormActions.RESEND,
+      });
+    });
+
+    it('should handle resend callback with custom options', async () => {
+      const options = {
+        timeoutSeconds: 60,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn(),
+      };
+
+      loginPasswordlessEmailCode.resendManager(options);
+
+      // Get the callback function passed to createResendControl
+      const callArgs = (createResendControl as jest.Mock).mock.calls[0] as unknown[];
+      const resendCallback = callArgs[1] as () => Promise<void>;
+
+      // Call the callback
+      await resendCallback();
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        action: FormActions.RESEND,
+      });
+    });
+
+    it('should return ResendControl with startResend method', () => {
+      const result = loginPasswordlessEmailCode.resendManager();
+
+      expect(result).toHaveProperty('startResend');
+      expect(typeof result.startResend).toBe('function');
+    });
+
+    it('should call startResend method from returned control', () => {
+      const result = loginPasswordlessEmailCode.resendManager();
+
+      result.startResend();
+
+      expect(mockResendControl.startResend).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle resend callback rejection', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Resend failed'));
+
+      loginPasswordlessEmailCode.resendManager();
+
+      // Get the callback function passed to createResendControl
+      const callArgs = (createResendControl as jest.Mock).mock.calls[0] as unknown[];
+      const resendCallback = callArgs[1] as () => Promise<void>;
+
+      // The callback should propagate the error
+      await expect(resendCallback()).rejects.toThrow('Resend failed');
     });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-email-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-email-challenge/index.test.ts
@@ -1,19 +1,20 @@
-import { ScreenIds } from '../../../../src//constants';
-import { FormActions } from '../../../../src/constants';
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import MfaEmailChallenge from '../../../../src/screens/mfa-email-challenge';
 import { FormHandler } from '../../../../src/utils/form-handler';
+import { createResendControl } from '../../../../src/utils/resend-utils';
 import { baseContextData } from '../../../data/test-data';
 
 import type { ContinueOptions, ResendCodeOptions } from '../../../../interfaces/screens/mfa-email-challenge';
 
 jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/resend-utils');
 
 describe('MfaEmailChallenge', () => {
   let mfaEmailChallenge: MfaEmailChallenge;
   let mockFormHandler: { submitData: jest.Mock };
 
   beforeEach(() => {
-    global.window = Object.create(window);
+    global.window = Object.create(window) as unknown as Window & typeof globalThis;
     baseContextData.screen.name = ScreenIds.MFA_EMAIL_CHALLENGE;
     window.universal_login_context = baseContextData;
     mfaEmailChallenge = new MfaEmailChallenge();
@@ -61,6 +62,30 @@ describe('MfaEmailChallenge', () => {
         rememberDevice: true,
       };
       await expect(mfaEmailChallenge.continue(payload)).rejects.toThrow('Mocked reject');
+    });
+
+    it('should handle continue with undefined payload correctly', async () => {
+      // Test the payload || {} branch
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      await mfaEmailChallenge.continue(undefined as any);
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: FormActions.DEFAULT,
+        })
+      );
+    });
+
+    it('should handle continue with null payload correctly', async () => {
+      // Test the payload || {} branch with null
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      await mfaEmailChallenge.continue(null as any);
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: FormActions.DEFAULT,
+        })
+      );
     });
   });
 
@@ -129,6 +154,270 @@ describe('MfaEmailChallenge', () => {
         someOption: 'value',
       };
       await expect(mfaEmailChallenge.tryAnotherMethod(payload)).rejects.toThrow('Mocked reject');
+    });
+  });
+
+  describe('pickEmail method', () => {
+    it('should handle pickEmail with valid payload correctly', async () => {
+      const payload: ResendCodeOptions = {
+        someOption: 'value',
+      };
+      await mfaEmailChallenge.pickEmail(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...payload,
+          action: FormActions.PICK_EMAIL,
+        })
+      );
+    });
+
+    it('should handle pickEmail without payload correctly', async () => {
+      await mfaEmailChallenge.pickEmail();
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: FormActions.PICK_EMAIL,
+        })
+      );
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
+      const payload: ResendCodeOptions = {
+        someOption: 'value',
+      };
+      await expect(mfaEmailChallenge.pickEmail(payload)).rejects.toThrow('Mocked reject');
+    });
+  });
+
+  describe('class properties and constructor', () => {
+    it('should have correct screen identifier', () => {
+      expect(MfaEmailChallenge.screenIdentifier).toBe('mfa-email-challenge');
+    });
+
+    it('should create instance successfully', () => {
+      const instance = new MfaEmailChallenge();
+      expect(instance).toBeInstanceOf(MfaEmailChallenge);
+    });
+
+    it('should initialize screen and untrustedData properties', () => {
+      expect(mfaEmailChallenge.screen).toBeDefined();
+      expect(mfaEmailChallenge.untrustedData).toBeDefined();
+    });
+  });
+
+  describe('screen override functionality', () => {
+    it('should handle screen data when available', () => {
+      // Access the screen data through the screen instance
+      expect(mfaEmailChallenge.screen.data).toBeDefined();
+    });
+
+    it('should handle screen data when null', () => {
+      // Create a new instance with null screen data
+      const originalScreenData = baseContextData.screen.data;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      baseContextData.screen.data = null as any;
+      
+      const instance = new MfaEmailChallenge();
+      expect(instance.screen.data).toBeNull();
+      
+      // Restore original data
+      baseContextData.screen.data = originalScreenData;
+    });
+
+    it('should transform screen data correctly', () => {
+      // Mock screen context with various data types
+      const originalScreenData = baseContextData.screen.data;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      baseContextData.screen.data = {
+        email: 'user@example.com',
+        show_remember_device: false,
+        other_field: 'ignored',
+      } as any;
+      
+      const instance = new MfaEmailChallenge();
+      expect(instance.screen.data?.email).toBe('user@example.com');
+      expect(instance.screen.data?.showRememberDevice).toBe(false);
+      
+      // Restore original data
+      baseContextData.screen.data = originalScreenData;
+    });
+  });
+
+  describe('untrusted data override functionality', () => {
+    it('should handle submitted form data when available', () => {
+      // Mock untrusted data context with submitted form data
+      const originalUntrustedData = baseContextData.untrusted_data;
+      baseContextData.untrusted_data = {
+        submitted_form_data: {
+          code: '123456',
+          remember_device: true,
+        },
+      };
+      
+      const instance = new MfaEmailChallenge();
+      expect(instance.untrustedData.submittedFormData).toBeDefined();
+      expect(instance.untrustedData.submittedFormData?.rememberDevice).toBe(true);
+      
+      // Restore original data
+      baseContextData.untrusted_data = originalUntrustedData;
+    });
+
+    it('should handle submitted form data when null', () => {
+      // Mock untrusted data context with null submitted form data
+      const originalUntrustedData = baseContextData.untrusted_data;
+      baseContextData.untrusted_data = {
+        submitted_form_data: null,
+      };
+      
+      const instance = new MfaEmailChallenge();
+      expect(instance.untrustedData.submittedFormData).toBeNull();
+      
+      // Restore original data
+      baseContextData.untrusted_data = originalUntrustedData;
+    });
+
+    it('should transform remember_device to rememberDevice', () => {
+      const originalUntrustedData = baseContextData.untrusted_data;
+      baseContextData.untrusted_data = {
+        submitted_form_data: {
+          remember_device: false,
+          other_field: 'preserved',
+        },
+      };
+      
+      const instance = new MfaEmailChallenge();
+      expect(instance.untrustedData.submittedFormData?.rememberDevice).toBe(false);
+      
+      // Restore original data
+      baseContextData.untrusted_data = originalUntrustedData;
+    });
+
+    it('should default rememberDevice to false when remember_device is undefined', () => {
+      const originalUntrustedData = baseContextData.untrusted_data;
+      baseContextData.untrusted_data = {
+        submitted_form_data: {
+          other_field: 'preserved',
+          // remember_device is undefined
+        },
+      };
+      
+      const instance = new MfaEmailChallenge();
+      expect(instance.untrustedData.submittedFormData?.rememberDevice).toBe(false);
+      
+      // Restore original data
+      baseContextData.untrusted_data = originalUntrustedData;
+    });
+  });
+
+  describe('resendManager method', () => {
+    let mockStartResend: jest.Mock;
+
+    beforeEach(() => {
+      mockStartResend = jest.fn();
+      (createResendControl as jest.Mock).mockReturnValue({
+        startResend: mockStartResend,
+      });
+    });
+
+    it('should call createResendControl with correct screen identifier and resend function', () => {
+      mfaEmailChallenge.resendManager();
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'mfa-email-challenge',
+        expect.any(Function),
+        undefined
+      );
+    });
+
+    it('should call createResendControl with provided options', () => {
+      const options = {
+        timeoutSeconds: 15,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn(),
+      };
+
+      mfaEmailChallenge.resendManager(options);
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'mfa-email-challenge',
+        expect.any(Function),
+        options
+      );
+    });
+
+    it('should return the result from createResendControl', () => {
+      const expectedResult = { startResend: mockStartResend };
+      (createResendControl as jest.Mock).mockReturnValue(expectedResult);
+
+      const result = mfaEmailChallenge.resendManager();
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should pass resendCode method as callback to createResendControl', () => {
+      mfaEmailChallenge.resendManager();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const resendCallback = (createResendControl as jest.Mock).mock.calls[0][1] as () => Promise<void>;
+      expect(typeof resendCallback).toBe('function');
+    });
+
+    it('should provide a function that calls resendCode when invoked', async () => {
+      mfaEmailChallenge.resendManager();
+
+      // Verify that createResendControl was called with the correct parameters
+      expect(createResendControl).toHaveBeenCalledWith(
+        'mfa-email-challenge',
+        expect.any(Function),
+        undefined
+      );
+
+      // Get the callback function from the mock and call it to improve coverage
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+      const callbackArg = (createResendControl as jest.Mock).mock.calls[0][1];
+      expect(typeof callbackArg).toBe('function');
+      
+      // Execute the callback to cover the arrow function line
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+      const result = callbackArg();
+      
+      // Verify that it returns a promise (since resendCode is async)
+      expect(result).toBeInstanceOf(Promise);
+      
+      // Wait for the promise to resolve to complete coverage
+      await result;
+    });
+
+    it('should pass callback options to createResendControl', () => {
+      const onStatusChange = jest.fn();
+      const onTimeout = jest.fn();
+      const options = {
+        timeoutSeconds: 20,
+        onStatusChange,
+        onTimeout,
+      };
+
+      mfaEmailChallenge.resendManager(options);
+
+      expect(createResendControl).toHaveBeenCalledWith(
+        'mfa-email-challenge',
+        expect.any(Function),
+        expect.objectContaining({
+          timeoutSeconds: 20,
+          onStatusChange,
+          onTimeout,
+        })
+      );
+    });
+
+    it('should handle startResend method from returned control object', () => {
+      const result = mfaEmailChallenge.resendManager();
+
+      result.startResend();
+
+      expect(mockStartResend).toHaveBeenCalled();
     });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-otp-enrollment-code/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-otp-enrollment-code/index.test.ts
@@ -14,7 +14,13 @@ describe('MfaOtpEnrollmentCode', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
-    window.universal_login_context = baseContextData;
+    window.universal_login_context = {
+      ...baseContextData,
+      screen: {
+        ...baseContextData.screen,
+        name: 'mfa-otp-enrollment-code',
+      }
+    };
     mfaOtpEnrollmentCode = new MfaOtpEnrollmentCode();
     mockFormHandler = {
       submitData: jest.fn(),

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-otp-enrollment-qr/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-otp-enrollment-qr/index.test.ts
@@ -2,7 +2,7 @@ import MfaOtpEnrollmentQr from '../../../../src/screens/mfa-otp-enrollment-qr';
 import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
 import { CustomOptions } from 'interfaces/common';
-import { FormActions } from '../../../../src/constants';
+import { FormActions, ScreenIds } from '../../../../src/constants';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -12,12 +12,22 @@ describe('MfaOtpEnrollmentQr', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
-    window.universal_login_context = baseContextData;
+    window.universal_login_context = {
+      ...baseContextData,
+      screen: {
+        ...baseContextData.screen,
+        name: 'mfa-otp-enrollment-qr',
+      }
+    };
     mfaOtpEnrollmentQr = new MfaOtpEnrollmentQr();
     mockFormHandler = {
       submitData: jest.fn(),
     };
     (FormHandler as jest.Mock).mockImplementation(() => mockFormHandler);
+  });
+
+  it('should have the correct screenIdentifier', () => {
+    expect(MfaOtpEnrollmentQr.screenIdentifier).toBe(ScreenIds.MFA_OTP_ENROLLMENT_QR);
   });
 
   describe('toggleView method', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-otp-enrollment-qr/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-otp-enrollment-qr/index.test.ts
@@ -1,8 +1,10 @@
-import MfaOtpEnrollmentQr from '../../../../src/screens/mfa-otp-enrollment-qr';
-import { baseContextData } from '../../../data/test-data';
-import { FormHandler } from '../../../../src/utils/form-handler';
-import { CustomOptions } from 'interfaces/common';
+
 import { FormActions, ScreenIds } from '../../../../src/constants';
+import MfaOtpEnrollmentQr from '../../../../src/screens/mfa-otp-enrollment-qr';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from 'interfaces/common';
 
 jest.mock('../../../../src/utils/form-handler');
 

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-voice-challenge/index.test.ts
@@ -1,12 +1,14 @@
 import { FormActions } from '../../../../src/constants';
 import MfaVoiceChallenge from '../../../../src/screens/mfa-voice-challenge';
 import { FormHandler } from '../../../../src/utils/form-handler';
+import { createResendControl } from '../../../../src/utils/resend-utils';
 import { baseContextData } from '../../../data/test-data';
 
 import type { CustomOptions } from '../../../../interfaces/common';
 import type { MfaVoiceChallengeContinueOptions } from '../../../../interfaces/screens/mfa-voice-challenge';
 
 jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/resend-utils');
 
 describe('MfaVoiceChallenge', () => {
   let mfaVoiceChallenge: MfaVoiceChallenge;
@@ -228,6 +230,80 @@ describe('MfaVoiceChallenge', () => {
       await expect(mfaVoiceChallenge.tryAnotherMethod()).rejects.toThrow(
         'Mocked reject'
       );
+    });
+  });
+
+  describe('resendManager method', () => {
+    let mockCreateResendControl: jest.Mock;
+    let mockStartResend: jest.Mock;
+    let mockResendControl: { startResend: jest.Mock };
+
+    beforeEach(() => {
+      mockStartResend = jest.fn();
+      mockResendControl = { startResend: mockStartResend };
+      mockCreateResendControl = createResendControl as jest.Mock;
+      mockCreateResendControl.mockReturnValue(mockResendControl);
+    });
+
+    it('should call createResendControl with correct screen identifier and resend function', () => {
+      mfaVoiceChallenge.resendManager();
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        'mfa-voice-challenge',
+        expect.any(Function),
+        undefined
+      );
+    });
+
+    it('should call createResendControl with provided options', () => {
+      const options = {
+        timeoutSeconds: 15,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn(),
+      };
+
+      mfaVoiceChallenge.resendManager(options);
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        'mfa-voice-challenge',
+        expect.any(Function),
+        options
+      );
+    });
+
+    it('should return the resend control object', () => {
+      const result = mfaVoiceChallenge.resendManager();
+
+      expect(result).toBe(mockResendControl);
+    });
+
+   
+
+    it('should work correctly with callback options', () => {
+      const onStatusChange = jest.fn();
+      const onTimeout = jest.fn();
+      const options = {
+        timeoutSeconds: 20,
+        onStatusChange,
+        onTimeout,
+      };
+
+      const result = mfaVoiceChallenge.resendManager(options);
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        'mfa-voice-challenge',
+        expect.any(Function),
+        options
+      );
+      expect(result).toBe(mockResendControl);
+    });
+
+    it('should call startResend method when returned control is used', () => {
+      const { startResend } = mfaVoiceChallenge.resendManager();
+      
+      startResend();
+
+      expect(mockStartResend).toHaveBeenCalledWith();
     });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/organization-picker/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/organization-picker/index.test.ts
@@ -1,7 +1,10 @@
-import { baseContextData } from '../../../data/test-data';
-import { FormHandler } from '../../../../src/utils/form-handler';
-import { CustomOptions } from 'interfaces/common';
+
+import { ScreenIds } from '../../../../src/constants';
 import OrganizationPicker from '../../../../src/screens/organization-picker';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from 'interfaces/common';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -11,12 +14,22 @@ describe('OrganizationPicker', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
-    window.universal_login_context = baseContextData;
+    window.universal_login_context = {
+      ...baseContextData,
+      screen: {
+        ...baseContextData.screen,
+        name: 'organization-picker',
+      }
+    };
     organizationPicker = new OrganizationPicker();
     mockFormHandler = {
       submitData: jest.fn(),
     };
     (FormHandler as jest.Mock).mockImplementation(() => mockFormHandler);
+  });
+
+  it('should have the correct screenIdentifier', () => {
+    expect(OrganizationPicker.screenIdentifier).toBe(ScreenIds.ORGANIZATION_PICKER);
   });
 
   describe('selectOrganization method', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
@@ -1,18 +1,21 @@
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import PhoneIdentifierChallenge from '../../../../src/screens/phone-identifier-challenge';
-import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
-import { PhoneChallengeOptions } from 'interfaces/screens/phone-identifier-challenge';
-import { CustomOptions } from 'interfaces/common';
-import { ScreenIds } from '../../../../src//constants';
-import { FormActions } from '../../../../src/constants';
+import { createResendControl } from '../../../../src/utils/resend-utils';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from 'interfaces/common';
+import type { PhoneChallengeOptions } from 'interfaces/screens/phone-identifier-challenge';
 
 jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/resend-utils');
 
 describe('PhoneIdentifierChallenge', () => {
   let phoneIdentifierChallenge: PhoneIdentifierChallenge;
   let mockFormHandler: { submitData: jest.Mock };
 
   beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     global.window = Object.create(window);
     baseContextData.screen.name = ScreenIds.PHONE_IDENTIFIER_CHALLENGE;
     window.universal_login_context = baseContextData;
@@ -133,6 +136,129 @@ describe('PhoneIdentifierChallenge', () => {
       await expect(
         phoneIdentifierChallenge.returnToPrevious(payload)
       ).rejects.toThrow('Mocked reject');
+    });
+  });
+
+  describe('resendManager method', () => {
+    let mockCreateResendControl: jest.Mock;
+    let mockResendControl: { startResend: jest.Mock };
+
+    beforeEach(() => {
+      mockResendControl = {
+        startResend: jest.fn(),
+      };
+      mockCreateResendControl = createResendControl as jest.Mock;
+      mockCreateResendControl.mockReturnValue(mockResendControl);
+    });
+
+    it('should call createResendControl with correct screen identifier and resend function', () => {
+      phoneIdentifierChallenge.resendManager();
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.PHONE_IDENTIFIER_CHALLENGE,
+        expect.any(Function),
+        undefined,
+        false
+      );
+    });
+
+    it('should call createResendControl with provided options', () => {
+      const options = { timeoutSeconds: 30 };
+      phoneIdentifierChallenge.resendManager(options);
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.PHONE_IDENTIFIER_CHALLENGE,
+        expect.any(Function),
+        options,
+        false
+      );
+    });
+
+    it('should return the result from createResendControl', () => {
+      const result = phoneIdentifierChallenge.resendManager();
+
+      expect(result).toBe(mockResendControl);
+    });
+
+    it('should pass resendCode method as callback to createResendControl', () => {
+      phoneIdentifierChallenge.resendManager();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const callback = mockCreateResendControl.mock.calls[0][1];
+      expect(typeof callback).toBe('function');
+    });
+
+    it('should provide a function that calls resendCode when invoked', async () => {
+      phoneIdentifierChallenge.resendManager();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const callback = mockCreateResendControl.mock.calls[0][1];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      await callback();
+
+      // Verify that FormHandler.submitData was called as expected by resendCode
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: FormActions.RESEND_CODE,
+        })
+      );
+    });
+
+    it('should pass callback options to createResendControl', () => {
+      const options = {
+        timeoutSeconds: 15,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn()
+      };
+      phoneIdentifierChallenge.resendManager(options);
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.PHONE_IDENTIFIER_CHALLENGE,
+        expect.any(Function),
+        options,
+        false
+      );
+    });
+
+    it('should handle startResend method from returned control object', () => {
+      const result = phoneIdentifierChallenge.resendManager();
+      result.startResend();
+
+      expect(mockResendControl.startResend).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass resendLimitReached from screen data to createResendControl', () => {
+      // Mock screen data with resendLimitReached
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      phoneIdentifierChallenge.screen = {
+        data: { resendLimitReached: true }
+      } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      phoneIdentifierChallenge.resendManager();
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.PHONE_IDENTIFIER_CHALLENGE,
+        expect.any(Function),
+        undefined,
+        true
+      );
+    });
+
+    it('should handle null screen data gracefully', () => {
+      // Mock screen data as null
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      phoneIdentifierChallenge.screen = {
+        data: null
+      } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      phoneIdentifierChallenge.resendManager();
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.PHONE_IDENTIFIER_CHALLENGE,
+        expect.any(Function),
+        undefined,
+        false
+      );
     });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/screen-override.test.ts
@@ -1,5 +1,6 @@
-import { ScreenOverride } from '../../../../src/screens/phone-identifier-challenge/screen-override';
 import { Screen } from '../../../../src/models/screen';
+import { ScreenOverride } from '../../../../src/screens/phone-identifier-challenge/screen-override';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 jest.mock('../../../../src/models/screen');
@@ -20,42 +21,221 @@ describe('ScreenOverride', () => {
     screenOverride = new ScreenOverride(screenContext);
   });
 
-  it('should initialize data correctly', () => {
-    expect(screenOverride.data).toEqual({
-      phone_number: '+1234567890',
-      message_type: 'sms',
-      phone: '+1234567890',
-      messageType: 'sms',
+  describe('constructor', () => {
+    it('should initialize data correctly with valid screen context', () => {
+      expect(screenOverride.data).toEqual({
+        phone_number: '+1234567890',
+        message_type: 'sms',
+        phone: '+1234567890',
+        messageType: 'sms',
+      });
+    });
+
+    it('should call getScreenData with correct screenContext', () => {
+      const getScreenDataSpy = jest.spyOn(ScreenOverride, 'getScreenData');
+
+      screenOverride = new ScreenOverride(screenContext);
+
+      expect(getScreenDataSpy).toHaveBeenCalledWith(screenContext);
+    });
+
+    it('should create an instance of Screen', () => {
+      expect(screenOverride).toBeInstanceOf(Screen);
+    });
+
+    it('should handle null screen context data', () => {
+      const nullDataContext = {
+        name: 'phone-identifier-challenge',
+        data: null
+      } as unknown as ScreenContext;
+
+      const screenOverrideWithNull = new ScreenOverride(nullDataContext);
+
+      expect(screenOverrideWithNull.data).toBeNull();
+    });
+
+    it('should handle undefined screen context data', () => {
+      const undefinedDataContext = {
+        name: 'phone-identifier-challenge',
+        data: undefined
+      } as ScreenContext;
+
+      const screenOverrideWithUndefined = new ScreenOverride(undefinedDataContext);
+
+      expect(screenOverrideWithUndefined.data).toBeNull();
     });
   });
 
-  it('should call getScreenData with correct screenContext', () => {
-    const getScreenDataSpy = jest.spyOn(ScreenOverride, 'getScreenData');
+  describe('getScreenData static method', () => {
+    it('should map phone_number to phone and message_type to messageType', () => {
+      const result = ScreenOverride.getScreenData(screenContext);
 
-    screenOverride = new ScreenOverride(screenContext);
+      expect(result).toEqual({
+        phone_number: '+1234567890',
+        message_type: 'sms',
+        phone: '+1234567890',
+        messageType: 'sms',
+      });
+    });
 
-    expect(getScreenDataSpy).toHaveBeenCalledWith(screenContext);
-  });
+    it('should return null when screenContext.data is undefined', () => {
+      const emptyContext = {} as ScreenContext;
+      const result = ScreenOverride.getScreenData(emptyContext);
 
-  it('should return null for data when screenContext.data is undefined', () => {
-    const emptyContext = {} as ScreenContext;
-    const result = ScreenOverride.getScreenData(emptyContext);
+      expect(result).toBeNull();
+    });
 
-    expect(result).toBeNull();
-  });
+    it('should return null when screenContext.data is null', () => {
+      const nullContext = {
+        name: 'phone-identifier-challenge',
+        data: null
+      } as unknown as ScreenContext;
+      const result = ScreenOverride.getScreenData(nullContext);
 
-  it('should map phone_number to phone and message_type to messageType', () => {
-    const result = ScreenOverride.getScreenData(screenContext);
+      expect(result).toBeNull();
+    });
 
-    expect(result).toEqual({
-      phone_number: '+1234567890',
-      message_type: 'sms',
-      phone: '+1234567890',
-      messageType: 'sms',
+    it('should handle partial data transformation', () => {
+      const partialContext = {
+        name: 'phone-identifier-challenge',
+        data: {
+          phone_number: '+9876543210',
+          // message_type is missing
+          customField: 'customValue'
+        }
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(partialContext);
+
+      expect(result).toEqual({
+        phone_number: '+9876543210',
+        customField: 'customValue',
+        phone: '+9876543210',
+        messageType: undefined
+      });
+    });
+
+    it('should handle empty data object', () => {
+      const emptyDataContext = {
+        name: 'phone-identifier-challenge',
+        data: {}
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(emptyDataContext);
+
+      expect(result).toEqual({
+        phone: undefined,
+        messageType: undefined
+      });
+    });
+
+    it('should preserve all original fields while adding transformed fields', () => {
+      const complexContext = {
+        name: 'phone-identifier-challenge',
+        data: {
+          phone_number: '+5555555555',
+          message_type: 'voice',
+          custom_field: 'custom_value',
+          extra_field: 'extra_value'
+        }
+      } as unknown as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(complexContext);
+
+      expect(result).toEqual({
+        phone_number: '+5555555555',
+        message_type: 'voice',
+        custom_field: 'custom_value',
+        extra_field: 'extra_value',
+        phone: '+5555555555',
+        messageType: 'voice'
+      });
+    });
+
+    it('should handle falsy but valid phone_number values', () => {
+      const falsyPhoneContext = {
+        name: 'phone-identifier-challenge',
+        data: {
+          phone_number: '',
+          message_type: 'sms'
+        }
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(falsyPhoneContext);
+
+      expect(result).toEqual({
+        phone_number: '',
+        message_type: 'sms',
+        phone: '',
+        messageType: 'sms'
+      });
+    });
+
+    it('should handle falsy but valid message_type values', () => {
+      const falsyMessageContext = {
+        name: 'phone-identifier-challenge',
+        data: {
+          phone_number: '+1234567890',
+          message_type: ''
+        }
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(falsyMessageContext);
+
+      expect(result).toEqual({
+        phone_number: '+1234567890',
+        message_type: '',
+        phone: '+1234567890',
+        messageType: ''
+      });
     });
   });
 
-  it('should create an instance of Screen', () => {
-    expect(screenOverride).toBeInstanceOf(Screen);
+  describe('field transformation edge cases', () => {
+    it('should correctly map various phone number formats', () => {
+      const testCases = [
+        '+1234567890',
+        '+44 123 456 7890',
+        '555-123-4567',
+        '(555) 123-4567',
+        ''
+      ];
+
+      testCases.forEach(phoneNumber => {
+        const context = {
+          name: 'phone-identifier-challenge',
+          data: {
+            phone_number: phoneNumber
+          }
+        } as ScreenContext;
+
+        const result = ScreenOverride.getScreenData(context);
+
+        expect(result?.phone).toBe(phoneNumber);
+      });
+    });
+
+    it('should correctly map various message types', () => {
+      const testCases = [
+        'sms',
+        'voice',
+        'email',
+        'push',
+        ''
+      ];
+
+      testCases.forEach(messageType => {
+        const context = {
+          name: 'phone-identifier-challenge',
+          data: {
+            message_type: messageType
+          }
+        } as ScreenContext;
+
+        const result = ScreenOverride.getScreenData(context);
+
+        expect(result?.messageType).toBe(messageType);
+      });
+    });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-otp-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-otp-challenge/index.test.ts
@@ -1,8 +1,10 @@
-import { baseContextData } from '../../../data/test-data';
-import { FormHandler } from '../../../../src/utils/form-handler';
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import ResetPasswordMfaOtpChallenge from '../../../../src/screens/reset-password-mfa-otp-challenge';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
 import type { ContinueOptions } from '../../../../interfaces/screens/reset-password-mfa-otp-challenge';
-import { FormActions } from '../../../../src/constants';
+
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -12,12 +14,22 @@ describe('ResetPasswordMfaOtpChallenge', () => {
 
   beforeEach(() => {
     global.window = Object.create(window);
-    window.universal_login_context = baseContextData;
+    window.universal_login_context = {
+      ...baseContextData,
+      screen: {
+        ...baseContextData.screen,
+        name: 'reset-password-mfa-otp-challenge',
+      }
+    };
     resetPasswordMfaOtpChallenge = new ResetPasswordMfaOtpChallenge();
     mockFormHandler = {
       submitData: jest.fn(),
     };
     (FormHandler as jest.Mock).mockImplementation(() => mockFormHandler);
+  });
+
+  it('should have the correct screenIdentifier', () => {
+    expect(ResetPasswordMfaOtpChallenge.screenIdentifier).toBe(ScreenIds.RESET_PASSWORD_MFA_OTP_CHALLENGE);
   });
 
   describe('continue method', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-sms-challenge/screen-override.test.ts
@@ -1,5 +1,6 @@
-import { ScreenOverride } from '../../../../src/screens/reset-password-mfa-sms-challenge/screen-override';
 import { Screen } from '../../../../src/models/screen';
+import { ScreenOverride } from '../../../../src/screens/reset-password-mfa-sms-challenge/screen-override';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 describe('ScreenOverride', () => {
@@ -26,6 +27,28 @@ describe('ScreenOverride', () => {
     const screenOverride = new ScreenOverride(screenContext);
 
     expect(screenOverride.data).toBeNull();
+  });
+
+  it('should handle null data in getScreenData', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-sms-challenge',
+      data: null
+    } as unknown as ScreenContext;
+
+    const result = ScreenOverride.getScreenData(screenContext);
+
+    expect(result).toBeNull();
+  });
+
+  it('should handle undefined data in getScreenData', () => {
+    const screenContext: ScreenContext = {
+      name: 'reset-password-mfa-sms-challenge',
+      data: undefined
+    } as ScreenContext;
+
+    const result = ScreenOverride.getScreenData(screenContext);
+
+    expect(result).toBeNull();
   });
 
   it('should extend Screen class', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/index.test.ts
@@ -1,16 +1,18 @@
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import ResetPasswordMfaVoiceChallenge from '../../../../src/screens/reset-password-mfa-voice-challenge';
-import { baseContextData } from '../../../data/test-data';
 import { FormHandler } from '../../../../src/utils/form-handler';
-import { ScreenIds } from '../../../../src/constants';
-import { FormActions } from '../../../../src/constants';
+import { createResendControl } from '../../../../src/utils/resend-utils';
+import { baseContextData } from '../../../data/test-data';
 
 jest.mock('../../../../src/utils/form-handler');
+jest.mock('../../../../src/utils/resend-utils');
 
 describe('ResetPasswordMfaVoiceChallenge', () => {
   let instance: ResetPasswordMfaVoiceChallenge;
   let mockSubmitData: jest.Mock;
 
   beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     global.window = Object.create(window);
     baseContextData.screen.name = ScreenIds.RESET_PASSWORD_MFA_VOICE_CHALLENGE;
     window.universal_login_context = baseContextData;
@@ -97,6 +99,90 @@ describe('ResetPasswordMfaVoiceChallenge', () => {
       expect(mockSubmitData).toHaveBeenCalledWith({
         action: FormActions.PICK_AUTHENTICATOR,
       });
+    });
+  });
+
+  describe('resendManager method', () => {
+    let mockCreateResendControl: jest.Mock;
+    let mockResendControl: { startResend: jest.Mock };
+
+    beforeEach(() => {
+      mockResendControl = {
+        startResend: jest.fn(),
+      };
+      mockCreateResendControl = createResendControl as jest.Mock;
+      mockCreateResendControl.mockReturnValue(mockResendControl);
+    });
+
+    it('should call createResendControl with correct screen identifier and resend function', () => {
+      instance.resendManager();
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.RESET_PASSWORD_MFA_VOICE_CHALLENGE,
+        expect.any(Function),
+        undefined
+      );
+    });
+
+    it('should call createResendControl with provided options', () => {
+      const options = { timeoutSeconds: 30 };
+      instance.resendManager(options);
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.RESET_PASSWORD_MFA_VOICE_CHALLENGE,
+        expect.any(Function),
+        options
+      );
+    });
+
+    it('should return the result from createResendControl', () => {
+      const result = instance.resendManager();
+
+      expect(result).toBe(mockResendControl);
+    });
+
+    it('should pass resendCode method as callback to createResendControl', () => {
+      instance.resendManager();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const callback = mockCreateResendControl.mock.calls[0][1];
+      expect(typeof callback).toBe('function');
+    });
+
+    it('should provide a function that calls resendCode when invoked', async () => {
+      instance.resendManager();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const callback = mockCreateResendControl.mock.calls[0][1];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      await callback();
+
+      // Verify that FormHandler.submitData was called as expected by resendCode
+      expect(mockSubmitData).toHaveBeenCalledWith({
+        action: FormActions.RESEND_CODE,
+      });
+    });
+
+    it('should pass callback options to createResendControl', () => {
+      const options = {
+        timeoutSeconds: 15,
+        onStatusChange: jest.fn(),
+        onTimeout: jest.fn()
+      };
+      instance.resendManager(options);
+
+      expect(mockCreateResendControl).toHaveBeenCalledWith(
+        ScreenIds.RESET_PASSWORD_MFA_VOICE_CHALLENGE,
+        expect.any(Function),
+        options
+      );
+    });
+
+    it('should handle startResend method from returned control object', () => {
+      const result = instance.resendManager();
+      result.startResend();
+
+      expect(mockResendControl.startResend).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-mfa-voice-challenge/screen-override.test.ts
@@ -1,4 +1,5 @@
 import { ScreenOverride } from '../../../../src/screens/reset-password-mfa-voice-challenge/screen-override';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 describe('ScreenOverride', () => {
@@ -30,47 +31,115 @@ describe('ScreenOverride', () => {
     expect(override.data).toBeNull();
   });
 
+  it('should return null for data if screenContext.data is null', () => {
+    const nullDataContext = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: null
+    } as unknown as ScreenContext;
+    const override = new ScreenOverride(nullDataContext);
+    expect(override.data).toBeNull();
+  });
+
+  it('should handle null data in getScreenData', () => {
+    const nullDataContext = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: null
+    } as unknown as ScreenContext;
+    const result = ScreenOverride.getScreenData(nullDataContext);
+    expect(result).toBeNull();
+  });
+
+  it('should handle undefined data in getScreenData', () => {
+    const undefinedDataContext = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: undefined
+    } as ScreenContext;
+    const result = ScreenOverride.getScreenData(undefinedDataContext);
+    expect(result).toBeNull();
+  });
+
   it('should handle show_link_sms field correctly', () => {
     // Test with explicit true value
     const contextWithShowLinkSmsTrue = {
       name: 'reset-password-mfa-voice-challenge',
-      data: { 
+      data: {
         phone_number: '9999999999',
         show_link_sms: true
       },
     } as ScreenContext;
     let result = ScreenOverride.getScreenData(contextWithShowLinkSmsTrue);
     expect(result?.showLinkSms).toBe(true);
-    
+
     // Test with explicit false value
     const contextWithShowLinkSmsFalse = {
       name: 'reset-password-mfa-voice-challenge',
-      data: { 
+      data: {
         phone_number: '9999999999',
         show_link_sms: false
       },
     } as ScreenContext;
     result = ScreenOverride.getScreenData(contextWithShowLinkSmsFalse);
     expect(result?.showLinkSms).toBe(false);
-    
+
     // Test with missing show_link_sms (should be falsy)
     const contextWithoutShowLinkSms = {
       name: 'reset-password-mfa-voice-challenge',
-      data: { 
+      data: {
         phone_number: '9999999999'
       },
     } as ScreenContext;
     result = ScreenOverride.getScreenData(contextWithoutShowLinkSms);
     expect(result?.showLinkSms).toBe(undefined);
-    
+
     const contextWithTruthyValue = {
       name: 'reset-password-mfa-voice-challenge',
-      data: { 
+      data: {
         phone_number: '9999999999',
         show_link_sms: true
       },
     } as ScreenContext;
     result = ScreenOverride.getScreenData(contextWithTruthyValue);
     expect(result?.showLinkSms).toBe(true);
+  });
+
+  it('should handle phone_number field type checking', () => {
+    // Test with string phone_number (should keep the value)
+    const contextWithStringPhone = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: {
+        phone_number: '1234567890'
+      },
+    } as ScreenContext;
+    let result = ScreenOverride.getScreenData(contextWithStringPhone);
+    expect(result?.phoneNumber).toBe('1234567890');
+
+    // Test with non-string phone_number (should default to empty string)
+    const contextWithNonStringPhone = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: {
+        phone_number: 1234567890 // number instead of string
+      },
+    } as unknown as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithNonStringPhone);
+    expect(result?.phoneNumber).toBe('');
+
+    // Test with null phone_number
+    const contextWithNullPhone = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: {
+        phone_number: null
+      },
+    } as unknown as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithNullPhone);
+    expect(result?.phoneNumber).toBe('');
+
+    // Test with undefined phone_number
+    const contextWithUndefinedPhone = {
+      name: 'reset-password-mfa-voice-challenge',
+      data: {
+      },
+    } as ScreenContext;
+    result = ScreenOverride.getScreenData(contextWithUndefinedPhone);
+    expect(result?.phoneNumber).toBe('');
   });
 });


### PR DESCRIPTION
### Screen Identifier Properties Added
- Introduced `screenIdentifier` properties to various authentication screens for improved identification and tracking.
- Enhanced screens include MFA OTP enrollment, MFA voice challenge, organization picker/selection, reset password MFA challenges, and login passwordless email code.

### Resend Manager Enhancement
- Improved resend manager functionality on the login-passwordless-email-code screen.
- Updated screen interface to better support resend operations.


### Files Modified
- Interfaces: Enhanced type definitions for login-passwordless-email-code.
- Constants: Added new screen identifier enum values.

