### PR TITLE
Make 'verify()' auto select the passkey.

### DIFF
--- a/packages/auth0-acul-js/interfaces/models/screen.ts
+++ b/packages/auth0-acul-js/interfaces/models/screen.ts
@@ -7,6 +7,11 @@ export interface CaptchaContext {
 export interface PasskeyRead {
   public_key: {
     challenge: string;
+    allowCredentials?: {
+      type: string;
+      id: string;
+      transports: string[];
+    }[];
   };
 }
 
@@ -31,6 +36,7 @@ export interface PasskeyCreate {
     authenticatorSelection: {
       residentKey: string;
       userVerification: string;
+      authenticatorAttachment?: string;
     };
   };
 }

--- a/packages/auth0-acul-js/src/utils/passkeys.ts
+++ b/packages/auth0-acul-js/src/utils/passkeys.ts
@@ -1,17 +1,26 @@
-import { Errors } from '../constants';
+import { Errors } from "../constants";
 
-import { isWebAuthPlatformAvailable } from './browser-capabilities';
-import { base64UrlToUint8Array, uint8ArrayToBase64Url } from './codec';
+import { isWebAuthPlatformAvailable } from "./browser-capabilities";
+import { base64UrlToUint8Array, uint8ArrayToBase64Url } from "./codec";
 
-import type { PasskeyRead, PasskeyCreate } from '../../interfaces/models/screen';
-import type { PasskeyCreateResponse, PasskeyCredentialResponse } from '../../interfaces/utils/passkeys';
+import type {
+  PasskeyRead,
+  PasskeyCreate,
+} from "../../interfaces/models/screen";
+import type {
+  PasskeyCreateResponse,
+  PasskeyCredentialResponse,
+} from "../../interfaces/utils/passkeys";
 
 function safeBase64Url(buffer: ArrayBuffer | null): string | null {
   return buffer ? uint8ArrayToBase64Url(buffer) : null;
 }
 
-function decodePublicKey(publicKey: PasskeyCreate['public_key']): PublicKeyCredentialCreationOptions {
-  const { challenge, user, authenticatorSelection, pubKeyCredParams, rp } = publicKey;
+function decodePublicKey(
+  publicKey: PasskeyCreate["public_key"]
+): PublicKeyCredentialCreationOptions {
+  const { challenge, user, authenticatorSelection, pubKeyCredParams, rp } =
+    publicKey;
   const decodedUser: PublicKeyCredentialUserEntity = {
     id: base64UrlToUint8Array(user.id),
     name: user.name,
@@ -23,37 +32,64 @@ function decodePublicKey(publicKey: PasskeyCreate['public_key']): PublicKeyCrede
     user: decodedUser,
     challenge: base64UrlToUint8Array(challenge),
     pubKeyCredParams: pubKeyCredParams.map(({ alg }) => ({
-      type: 'public-key',
+      type: "public-key",
       alg,
     })),
-    authenticatorSelection: {
+    authenticatorSelection: authenticatorSelection && {
       ...authenticatorSelection,
-      residentKey: authenticatorSelection.residentKey as 'required' | 'preferred' | 'discouraged',
-      userVerification: authenticatorSelection.userVerification as 'required' | 'preferred' | 'discouraged' | undefined,
+      residentKey: authenticatorSelection.residentKey as
+        | "required"
+        | "preferred"
+        | "discouraged",
+      userVerification: authenticatorSelection.userVerification as
+        | "required"
+        | "preferred"
+        | "discouraged"
+        | undefined,
+      authenticatorAttachment: authenticatorSelection.authenticatorAttachment as
+        | "platform"
+        | "cross-platform"
+        | undefined,
     },
-    attestation: 'direct',
+    attestation: "direct",
   };
 }
 
-function isAuthenticatorAssertionResponse(response: AuthenticatorResponse): response is AuthenticatorAssertionResponse {
-  return (response as AuthenticatorAssertionResponse).authenticatorData !== undefined;
+function isAuthenticatorAssertionResponse(
+  response: AuthenticatorResponse
+): response is AuthenticatorAssertionResponse {
+  return (
+    (response as AuthenticatorAssertionResponse).authenticatorData !== undefined
+  );
 }
 
-export async function getPasskeyCredentials(publicKey: PasskeyRead['public_key']): Promise<PasskeyCredentialResponse> {
-  if (!publicKey?.challenge) throw new Error(Errors.PASSKEY_PUBLIC_KEY_UNAVAILABLE);
+export async function getPasskeyCredentials(
+  publicKey: PasskeyRead["public_key"]
+): Promise<PasskeyCredentialResponse> {
+  if (!publicKey?.challenge)
+    throw new Error(Errors.PASSKEY_PUBLIC_KEY_UNAVAILABLE);
 
   const hasWebAuthPlatform = await isWebAuthPlatformAvailable();
   const challenge = base64UrlToUint8Array(publicKey.challenge);
 
   const credential = (await navigator.credentials.get({
-    publicKey: { challenge },
+    publicKey: {
+      challenge,
+      allowCredentials: publicKey.allowCredentials?.length
+      ? publicKey.allowCredentials.map((c) => ({
+          id: base64UrlToUint8Array(c.id),
+          type: "public-key" as const,
+          transports: c.transports?.map(t => t as AuthenticatorTransport),
+        }))
+      : undefined
+    },
   })) as PublicKeyCredential | null;
 
   if (!credential) throw new Error(Errors.PASSKEY_CREDENTIALS_UNAVAILABLE);
-  if (!isAuthenticatorAssertionResponse(credential.response)) throw new Error(Errors.PASSKEY_EXPECTED_ASSERTION_RESPONSE);
+  if (!isAuthenticatorAssertionResponse(credential.response))
+    throw new Error(Errors.PASSKEY_EXPECTED_ASSERTION_RESPONSE);
 
   const response = credential.response;
-
   return {
     id: credential.id,
     rawId: safeBase64Url(credential.rawId ?? null),
@@ -69,14 +105,20 @@ export async function getPasskeyCredentials(publicKey: PasskeyRead['public_key']
   };
 }
 
-export async function createPasskeyCredentials(publicKey: PasskeyCreate['public_key']): Promise<PasskeyCreateResponse> {
-  if (!publicKey?.challenge) throw new Error(Errors.PASSKEY_PUBLIC_KEY_UNAVAILABLE);
+export async function createPasskeyCredentials(
+  publicKey: PasskeyCreate["public_key"]
+): Promise<PasskeyCreateResponse> {
+  if (!publicKey?.challenge)
+    throw new Error(Errors.PASSKEY_PUBLIC_KEY_UNAVAILABLE);
 
   const publicKeyDecoded = decodePublicKey(publicKey);
-  const credential = (await navigator.credentials.create({ publicKey: publicKeyDecoded })) as PublicKeyCredential | null;
+  const credential = (await navigator.credentials.create({
+    publicKey: publicKeyDecoded,
+  })) as PublicKeyCredential | null;
   if (!credential) throw new Error(Errors.PASSKEY_CREATE_FAILED);
 
-  const credentialResponse = credential.response as AuthenticatorAttestationResponse;
+  const credentialResponse =
+    credential.response as AuthenticatorAttestationResponse;
   return {
     id: credential.id,
     rawId: uint8ArrayToBase64Url(credential.rawId),
@@ -84,8 +126,13 @@ export async function createPasskeyCredentials(publicKey: PasskeyCreate['public_
     authenticatorAttachment: credential.authenticatorAttachment,
     response: {
       clientDataJSON: uint8ArrayToBase64Url(credentialResponse.clientDataJSON),
-      attestationObject: uint8ArrayToBase64Url(credentialResponse.attestationObject),
-      transports: typeof credentialResponse?.getTransports === 'function' ? credentialResponse.getTransports() : undefined,
+      attestationObject: uint8ArrayToBase64Url(
+        credentialResponse.attestationObject
+      ),
+      transports:
+        typeof credentialResponse?.getTransports === "function"
+          ? credentialResponse.getTransports()
+          : undefined,
     },
   };
 }


### PR DESCRIPTION
### Changes
Improve `getPasskeyCredentials` with safer `allowCredentials` handling. Currently `verify()` method would trigger the Web Authentication prompt on the browser, and the user has to manually pick the correct Passkey. With this PR, it should be automatically selected and trigger a prompt for biometric authentication.

**Description**
This update hardens `getPasskeyCredentials` by safely mapping `allowCredentials` and narrowing its types.

* Skips `allowCredentials` when undefined or empty.
* Decodes credential IDs and casts `transports` to `AuthenticatorTransport[]`.
* Keeps strict challenge check and `isAuthenticatorAssertionResponse` guard.
