### PR TITLE
Chore: Updated useLoginIdentifiers and added support for reset-password-request screen

### DIFF
--- a/packages/auth0-acul-js/src/screens/login-id/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/transaction-override.ts
@@ -3,10 +3,10 @@ import { Transaction } from '../../../src/models/transaction';
 import {
   isUsernameRequired,
   getUsernamePolicy,
-  getAllowedIdentifiers,
   isSignupEnabled,
   isForgotPasswordEnabled,
   isPasskeyEnabled,
+  getActiveIdentifiers,
 } from '../../shared/transaction';
 
 import type { TransactionContext } from '../../../interfaces/models/transaction';
@@ -33,6 +33,6 @@ export class TransactionOverride extends Transaction implements OverrideMembers 
   static getAllowedIdentifiers(transactionContext: TransactionContext, connectionStrategy: string | null): OverrideMembers['allowedIdentifiers'] {
     if (connectionStrategy === ConnectionStrategy.SMS) return [Identifiers.PHONE];
     if (connectionStrategy === ConnectionStrategy.EMAIL) return [Identifiers.EMAIL];
-    return getAllowedIdentifiers(transactionContext);
+    return getActiveIdentifiers(transactionContext);
   }
 }

--- a/packages/auth0-acul-js/src/screens/login/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/login/transaction-override.ts
@@ -1,6 +1,6 @@
 import { ConnectionStrategy, Identifiers } from '../../../src/constants';
 import { Transaction } from '../../models/transaction';
-import { isSignupEnabled, isForgotPasswordEnabled, isPasskeyEnabled, getPasswordPolicy, getAllowedIdentifiers } from '../../shared/transaction';
+import { isSignupEnabled, isForgotPasswordEnabled, isPasskeyEnabled, getPasswordPolicy, getActiveIdentifiers } from '../../shared/transaction';
 
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type { TransactionMembersOnLogin as OverrideOptions } from '../../../interfaces/screens/login';
@@ -27,6 +27,6 @@ export class TransactionOverride extends Transaction implements OverrideOptions 
   static getAllowedIdentifiers(transactionContext: TransactionContext, connectionStrategy: string | null): OverrideOptions['allowedIdentifiers'] {
     if (connectionStrategy === ConnectionStrategy.SMS) return [Identifiers.PHONE];
     if (connectionStrategy === ConnectionStrategy.EMAIL) return [Identifiers.EMAIL];
-    return getAllowedIdentifiers(transactionContext);
+    return getActiveIdentifiers(transactionContext);
   }
 }

--- a/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
@@ -1,6 +1,7 @@
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { getLoginIdentifiers as _getLoginIdentifiers } from '../../utils/login-identifiers';
 
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
@@ -15,6 +16,7 @@ import type {
   TransactionMembersOnResetPasswordRequest as TransactionOptions,
 } from '../../../interfaces/screens/reset-password-request';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { IdentifierType } from 'interfaces/utils';
 
 export default class ResetPasswordRequest extends BaseContext implements ResetPasswordRequestMembers {
   static screenIdentifier: string = ScreenIds.RESET_PASSWORD_REQUEST;
@@ -59,6 +61,21 @@ export default class ResetPasswordRequest extends BaseContext implements ResetPa
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK_TO_LOGIN });
   }
+
+  /**
+     * Gets the active identifier types for the reset-password-request screen
+     * @returns An array of active identifier types or null if none are active
+     * @example
+     * ```typescript
+     * import ResetPasswordRequest from "@auth0/auth0-acul-js/reset-password-request";
+     * const resetPasswordRequest = new ResetPasswordRequest();
+     * resetPasswordRequest.getLoginIdentifiers();
+     * ```
+     * @utilityFeature
+     */
+    getLoginIdentifiers(): IdentifierType[] | null {
+      return _getLoginIdentifiers(this.transaction.allowedIdentifiers);
+    }
 }
 
 /**

--- a/packages/auth0-acul-js/src/screens/reset-password-request/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-request/transaction-override.ts
@@ -1,6 +1,6 @@
 import { ConnectionStrategy, Identifiers } from '../../../src/constants';
 import { Transaction } from '../../../src/models/transaction';
-import { getAllowedIdentifiers, getRequiredIdentifiers, hasFlexibleIdentifier } from '../../shared/transaction';
+import { getActiveIdentifiers, getRequiredIdentifiers, hasFlexibleIdentifier } from '../../shared/transaction';
 
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type { TransactionMembersOnResetPasswordRequest as OverrideMembers } from '../../../interfaces/screens/reset-password-request';
@@ -20,7 +20,7 @@ export class TransactionOverride extends Transaction implements OverrideMembers 
   static getAllowedIdentifiers(transactionContext: TransactionContext, connectionStrategy: string | null): OverrideMembers['allowedIdentifiers'] {
     if (connectionStrategy === ConnectionStrategy.SMS) return [Identifiers.PHONE];
     if (connectionStrategy === ConnectionStrategy.EMAIL) return [Identifiers.EMAIL];
-    return getAllowedIdentifiers(transactionContext);
+    return getActiveIdentifiers(transactionContext);
   }
 
   static getRequiredIdentifiers(transactionContext: TransactionContext, connectionStrategy: string | null): OverrideMembers['requiredIdentifiers'] {

--- a/packages/auth0-acul-js/src/shared/transaction.ts
+++ b/packages/auth0-acul-js/src/shared/transaction.ts
@@ -118,6 +118,39 @@ export function getPasswordPolicy(
 }
 
 /**
+ * Returns the active identifiers (email, username, phone) based on the connection settings.
+ * Active identifiers are those that can be used for login.
+ *
+ * @param transaction - The transaction context from Universal Login
+ * @returns An array of active identifier types or null if none are defined
+ */
+
+export function getActiveIdentifiers(transaction: TransactionContext): IdentifierType[] | null {
+  const connection = transaction?.connection as DBConnection | undefined;
+
+  if (!connection) return null;
+
+  const { attributes, username_required } = connection.options || {};
+
+  if (attributes && Object.keys(attributes).length > 0) {
+    const filteredIdentifiers = Object.entries(attributes)
+      .filter(
+        ([, value]) =>
+          value.identifier_active
+      )
+      .map(([key]) => key as IdentifierType);
+
+    return filteredIdentifiers.length > 0 ? filteredIdentifiers : null;
+  }
+
+  if (username_required) {
+    return ['email', 'username'];
+  }
+
+  return ['email'];
+}
+
+/**
  * Returns the allowed identifiers (email, username, phone) based on the connection settings.
  * This includes both required and optional identifier types.
  *

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/transaction-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/transaction-override.test.ts
@@ -2,7 +2,7 @@ import { TransactionOverride } from '../../../../src/screens/login-id/transactio
 import {
   isUsernameRequired,
   getUsernamePolicy,
-  getAllowedIdentifiers,
+  getActiveIdentifiers,
   isSignupEnabled,
   isForgotPasswordEnabled,
   isPasskeyEnabled,
@@ -25,7 +25,7 @@ describe('TransactionOverride', () => {
     (isPasskeyEnabled as jest.Mock).mockReturnValue(true);
     (isUsernameRequired as jest.Mock).mockReturnValue(true);
     (getUsernamePolicy as jest.Mock).mockReturnValue('strict');
-    (getAllowedIdentifiers as jest.Mock).mockReturnValue(['email', 'phone']);
+    (getActiveIdentifiers as jest.Mock).mockReturnValue(['email', 'phone']);
 
     transactionOverride = new TransactionOverride(transactionContext);
   });
@@ -60,7 +60,7 @@ describe('TransactionOverride', () => {
     expect(isPasskeyEnabled).toHaveBeenCalledWith(transactionContext);
     expect(isUsernameRequired).toHaveBeenCalledWith(transactionContext);
     expect(getUsernamePolicy).toHaveBeenCalledWith(transactionContext);
-    expect(getAllowedIdentifiers).toHaveBeenCalledWith(transactionContext);
+    expect(getActiveIdentifiers).toHaveBeenCalledWith(transactionContext);
   });
 
   describe('getAllowedIdentifiers', () => {
@@ -87,7 +87,7 @@ describe('TransactionOverride', () => {
     (isPasskeyEnabled as jest.Mock).mockReturnValue(undefined);
     (isUsernameRequired as jest.Mock).mockReturnValue(undefined);
     (getUsernamePolicy as jest.Mock).mockReturnValue(undefined);
-    (getAllowedIdentifiers as jest.Mock).mockReturnValue(undefined);
+    (getActiveIdentifiers as jest.Mock).mockReturnValue(undefined);
 
     const emptyTransactionOverride = new TransactionOverride({} as TransactionContext);
 

--- a/packages/auth0-acul-js/tests/unit/screens/login/transaction-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/transaction-override.test.ts
@@ -1,5 +1,5 @@
 import { TransactionOverride } from '../../../../src/screens/login/transaction-override';
-import { isSignupEnabled, isForgotPasswordEnabled, isPasskeyEnabled, getPasswordPolicy, getAllowedIdentifiers } from '../../../../src/shared/transaction';
+import { isSignupEnabled, isForgotPasswordEnabled, isPasskeyEnabled, getPasswordPolicy, getActiveIdentifiers } from '../../../../src/shared/transaction';
 import { Transaction } from '../../../../src/models/transaction';
 import type { TransactionContext } from '../../../../interfaces/models/transaction';
 
@@ -19,7 +19,7 @@ describe('TransactionOverride', () => {
     (isForgotPasswordEnabled as jest.Mock).mockReturnValue(false);
     (isPasskeyEnabled as jest.Mock).mockReturnValue(true);
     (getPasswordPolicy as jest.Mock).mockReturnValue('strong');
-    (getAllowedIdentifiers as jest.Mock).mockReturnValue(['email', 'phone']);
+    (getActiveIdentifiers as jest.Mock).mockReturnValue(['email', 'phone']);
 
     transactionOverride = new TransactionOverride(transactionContext);
   });
@@ -56,8 +56,8 @@ describe('TransactionOverride', () => {
     expect(getPasswordPolicy).toHaveBeenCalledWith(transactionContext);
   });
 
-  it('should call getAllowedIdentifiers with transactionContext', () => {
-    expect(getAllowedIdentifiers).toHaveBeenCalledWith(transactionContext);
+  it('should call getActiveIdentifiers with transactionContext', () => {
+    expect(getActiveIdentifiers).toHaveBeenCalledWith(transactionContext);
   });
 
   describe('getAllowedIdentifiers', () => {
@@ -93,7 +93,7 @@ describe('TransactionOverride', () => {
     (isForgotPasswordEnabled as jest.Mock).mockReturnValue(undefined);
     (isPasskeyEnabled as jest.Mock).mockReturnValue(undefined);
     (getPasswordPolicy as jest.Mock).mockReturnValue(undefined);
-    (getAllowedIdentifiers as jest.Mock).mockReturnValue(undefined);
+    (getActiveIdentifiers as jest.Mock).mockReturnValue(undefined);
   
     const emptyTransactionOverride = new TransactionOverride({} as TransactionContext);
   

--- a/packages/auth0-acul-js/tests/unit/screens/reset-password-request/transaction-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/reset-password-request/transaction-override.test.ts
@@ -1,5 +1,5 @@
 import { TransactionOverride } from '../../../../src/screens/reset-password-request/transaction-override';
-import { getAllowedIdentifiers, getRequiredIdentifiers, hasFlexibleIdentifier } from '../../../../src/shared/transaction';
+import { getActiveIdentifiers, getRequiredIdentifiers, hasFlexibleIdentifier } from '../../../../src/shared/transaction';
 import { Transaction } from '../../../../src/models/transaction';
 import type { TransactionContext } from '../../../../interfaces/models/transaction';
 
@@ -14,7 +14,7 @@ describe('TransactionOverride', () => {
       // Mock required properties if needed
     } as TransactionContext;
 
-    (getAllowedIdentifiers as jest.Mock).mockReturnValue(['email']);
+    (getActiveIdentifiers as jest.Mock).mockReturnValue(['email']);
     (getRequiredIdentifiers as jest.Mock).mockReturnValue(['email']);
     (hasFlexibleIdentifier as jest.Mock).mockReturnValue(true);
 

--- a/packages/auth0-acul-react/src/hooks/utility/login-identifiers.ts
+++ b/packages/auth0-acul-react/src/hooks/utility/login-identifiers.ts
@@ -13,6 +13,7 @@ interface WithLoginIdentifiers {
  * @supportedScreens
  * - `login`
  * - `login-id`
+ * - `reset-password-request`
  *
  * @returns An array of {@link IdentifierType} representing active identifiers.
  *

--- a/packages/auth0-acul-react/src/screens/reset-password-request.tsx
+++ b/packages/auth0-acul-react/src/screens/reset-password-request.tsx
@@ -36,6 +36,9 @@ export const resetPassword = (payload: ResetPasswordRequestOptions) =>
   withError(instance.resetPassword(payload));
 export const backToLogin = (payload?: CustomOptions) => withError(instance.backToLogin(payload));
 
+// Utility Hooks
+export { useLoginIdentifiers } from '../hooks/utility/login-identifiers';
+
 // Common hooks
 export {
   useCurrentScreen,


### PR DESCRIPTION
### Description
This PR updates the internal handling of identifiers in the reset-password-request screen to support dynamic and active login identifiers. Key changes include:

### Enhancements
- Updated transaction-override.ts files in:
     - login-id
     - login
     - reset-password-request
- to use getActiveIdentifiers() instead of getAllowedIdentifiers().

- Added new utility method getActiveIdentifiers() in shared/transaction.ts:
      - Filters identifier types (email, username, phone) based on identifier_active flag.
      - Falls back to defaults when attributes are not defined.

- Exposed getLoginIdentifiers() method in ResetPasswordRequest screen class.
      - Returns the active identifiers derived from the transaction.

- Extended SDK React hook useLoginIdentifiers:
      - Now supports reset-password-request screen.


### Testing
Tested with `universal-login-samples` on reset-password-request and login screen.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
