### PR TITLE
Fix: Handle edge cases in username validation and align identifier type usage

### DIFF
--- a/packages/auth0-acul-js/interfaces/models/transaction.ts
+++ b/packages/auth0-acul-js/interfaces/models/transaction.ts
@@ -45,6 +45,7 @@ interface CountryCode {
 }
 
 export interface UsernamePolicy {
+  isActive?: boolean
   maxLength: number;
   minLength: number;
   allowedFormats?: {

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -61,5 +61,5 @@ export interface LoginIdMembers extends BaseMembers {
   federatedLogin(payload: FederatedLoginOptions): Promise<void>;
   passkeyLogin(payload?: CustomOptions): Promise<void>;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
-  getLoginIdentifiers(): string[] | null;
+  getLoginIdentifiers(): IdentifierType[] | null;
 }

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -100,5 +100,5 @@ export interface LoginMembers extends BaseMembers {
    * @returns An array of active identifier types or null if none are active
    * @utilityFeature
    */
-  getLoginIdentifiers(): string[] | null;
+  getLoginIdentifiers(): IdentifierType[] | null;
 }

--- a/packages/auth0-acul-js/interfaces/screens/reset-password-request.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-request.ts
@@ -29,4 +29,5 @@ export interface ResetPasswordRequestMembers extends BaseMembers {
   transaction: TransactionMembersOnResetPasswordRequest;
   resetPassword(payload: ResetPasswordRequestOptions): Promise<void>;
   backToLogin(payload?: CustomOptions): Promise<void>;
+  getLoginIdentifiers(): IdentifierType[] | null;
 }

--- a/packages/auth0-acul-js/src/shared/transaction.ts
+++ b/packages/auth0-acul-js/src/shared/transaction.ts
@@ -64,10 +64,11 @@ export function getUsernamePolicy(
   transaction: TransactionContext
 ): UsernamePolicy | null {
   const connection = transaction?.connection as DBConnection;
-  const validation = connection?.options?.attributes?.username?.validation;
+  const { signup_status: signupStatus, validation } = connection?.options?.attributes?.username ?? {};
 
   if (validation) {
     return {
+      isActive: ['optional', 'required'].includes(signupStatus as string),
       maxLength: validation.max_length,
       minLength: validation.min_length,
       allowedFormats: {
@@ -77,17 +78,19 @@ export function getUsernamePolicy(
     };
   }
 
-  const legacyValidation = connection?.options?.validation?.username;
+  const { validation: legacyValidation, username_required: usernameRequired} = connection?.options ?? {};
+  const rules = legacyValidation?.username;
 
-  if (legacyValidation) {
+  if (rules) {
     return {
-      maxLength: legacyValidation.max_length,
-      minLength: legacyValidation.min_length
+      isActive: usernameRequired === true,
+      maxLength: rules.max_length,
+      minLength: rules.min_length
     };
   }
 
   return null;
-
+  
 }
 
 /**

--- a/packages/auth0-acul-js/src/utils/validate-username.ts
+++ b/packages/auth0-acul-js/src/utils/validate-username.ts
@@ -37,28 +37,20 @@ const field = Fields.USERNAME;
  */
 export function validateUsername(
   username: string,
-  policy?: UsernamePolicy | null
+  policy: UsernamePolicy | null
 ): UsernameValidationResult {
   const errors: UsernameValidationError[] = [];
 
-  if (!policy) {
+  if (!policy || !policy.isActive) {
     return {
-      isValid: username.trim().length > 0,
-      errors: username.trim().length > 0
-        ? []
-        : [
-            {
-              code: USERNAME_ERROR_CODES.REQUIRED,
-              message: USERNAME_ERROR_MESSAGES.REQUIRED,
-              field
-            },
-          ],
+      isValid: true,
+      errors: []
     };
   }
 
   const {
-    minLength = 1,
-    maxLength = 30,
+    minLength,
+    maxLength,
     allowedFormats: userAllowedFormats = {} as AllowedFormats,
   } = policy;
 

--- a/packages/auth0-acul-js/tests/unit/helpers/validateUsername.test.ts
+++ b/packages/auth0-acul-js/tests/unit/helpers/validateUsername.test.ts
@@ -7,6 +7,7 @@ const getFailedCodes = (result: ReturnType<typeof validateUsername>) =>
 
 describe('validateUsername', () => {
   const basePolicy: UsernamePolicy = {
+    isActive: true,
     minLength: 3,
     maxLength: 15,
     allowedFormats: {
@@ -15,10 +16,10 @@ describe('validateUsername', () => {
     },
   };
 
-  it('returns error when username is empty and no policy', () => {
+  it('returns empty errors when username is empty and no policy', () => {
     const result = validateUsername('', null);
     const failed = getFailedCodes(result);
-    expect(failed).toContain('username-required');
+    expect(failed).toEqual([]);
   });
 
   it('passes validation when username is non-empty and no policy', () => {
@@ -84,6 +85,7 @@ describe('validateUsername', () => {
 
   it('fails multiple rules at once', () => {
     const result = validateUsername('a@b.c', {
+      isActive: true,
       minLength: 10,
       maxLength: 12,
       allowedFormats: {

--- a/packages/auth0-acul-js/tests/unit/shared/transaction.test.ts
+++ b/packages/auth0-acul-js/tests/unit/shared/transaction.test.ts
@@ -62,6 +62,7 @@ describe('Transaction Context Functions', () => {
 
   it('should return the correct username policy', () => {
     const expectedPolicy = {
+      isActive: true,
       maxLength: 20,
       minLength: 5,
       allowedFormats: {

--- a/packages/auth0-acul-react/src/export/getting-started.ts
+++ b/packages/auth0-acul-react/src/export/getting-started.ts
@@ -1,6 +1,6 @@
 /**
  * @module Getting Started
- * @description This module provides an overview of how to get started with the Auth0 SDK.
+ * This module provides an overview of how to get started with the Auth0 SDK.
  *
  * # Auth0 ACUL React SDK
  *

--- a/packages/auth0-acul-react/src/hooks/utility/login-identifiers.ts
+++ b/packages/auth0-acul-react/src/hooks/utility/login-identifiers.ts
@@ -8,7 +8,7 @@ interface WithLoginIdentifiers {
 
 /**
  * Returns a list of active identifier types (such as `'email'`, `'phone'`, or `'username'`)
- * currently in use in the authentication flow or signup process.
+ * currently in use in the authentication flow or login process.
  *
  * @supportedScreens
  * - `login`

--- a/packages/auth0-acul-react/src/hooks/utility/polling-manager.ts
+++ b/packages/auth0-acul-react/src/hooks/utility/polling-manager.ts
@@ -66,7 +66,7 @@ export interface MfaPollingResult {
  * - `mfa-push-challenge-push`
  * - `reset-password-mfa-push-challenge-push`
  *
- * @returns {@link MfaPollingResult} containing:
+ * @returns object {@link MfaPollingResult} containing:
  * - `isRunning` — `true` while polling is active.
  * - `startPolling()` — starts or resumes polling.
  * - `stopPolling()` — stops polling immediately.

--- a/packages/auth0-acul-react/src/screens/login.tsx
+++ b/packages/auth0-acul-react/src/screens/login.tsx
@@ -5,7 +5,12 @@ import { ContextHooks } from '../hooks';
 import { errorManager } from '../hooks';
 import { registerScreen } from '../state/instance-store';
 
-import type { LoginMembers, LoginOptions, FederatedLoginOptions } from '@auth0/auth0-acul-js/login';
+import type {
+  LoginMembers,
+  LoginOptions,
+  FederatedLoginOptions,
+  CustomOptions,
+} from '@auth0/auth0-acul-js/login';
 
 // Register the singleton instance of Login
 const instance = registerScreen<LoginMembers>(Login)!;
@@ -31,6 +36,8 @@ export const {
 export const login = (payload: LoginOptions) => withError(instance.login(payload));
 export const federatedLogin = (payload: FederatedLoginOptions) =>
   withError(instance.federatedLogin(payload));
+export const pickCountryCode = (payload?: CustomOptions) =>
+  withError(instance.pickCountryCode(payload));
 
 // Utility Hooks
 export { useLoginIdentifiers } from '../hooks/utility/login-identifiers';


### PR DESCRIPTION
### Description
This PR includes several updates focused on improving the robustness and consistency of username validation and login identifier handling across the SDK:

### Fixes & Enhancements:
**Username validation:**

- Updated validateUsername to treat inactive or missing UsernamePolicy as valid, preventing false errors.
- Added support for the isActive flag in UsernamePolicy, based on signup_status or legacy username_required.
- Adjusted test cases to match the updated logic and prevent false negatives.

**Transaction context:**

- Enhanced getUsernamePolicy to correctly determine policy activation using both modern and legacy connection settings.

**Identifier support:**

- Unified return types of getLoginIdentifiers() methods in interfaces from string[] to strongly typed IdentifierType[].
- Extended useLoginIdentifiers utility to include support for the reset-password-request screen.

**Docs & Comments:**

- Removed unsupported @description tags per TSDoc standards.

### Testing
1. Generated React SDK and tested with `universal-login-samples`

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
