### PR TITLE
fix: update peerDependencies for React compatibility

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/mfa-email-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-email-challenge.ts
@@ -1,3 +1,4 @@
+import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
 import type { UntrustedDataMembers } from '../models/untrusted-data';
@@ -74,6 +75,12 @@ export interface MfaEmailChallengeMembers extends BaseMembers {
    * @param payload Optional custom options to include with the request
    */
   tryAnotherMethod(payload?: TryAnotherMethodOptions): Promise<void>;
+
+  /**
+   * Submits the action to pick a different Email configuration, if available
+   * @param payload Optional custom options to include with the request
+   */
+  pickEmail(payload?: CustomOptions): Promise<void>;
 
   /**
    * Gets resend functionality with timeout management for this screen

--- a/packages/auth0-acul-react/package.json
+++ b/packages/auth0-acul-react/package.json
@@ -23,7 +23,8 @@
     "type": "git"
   },
   "peerDependencies": {
-    "react": "^18.3.1"
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "exports": {
     ".": {

--- a/packages/auth0-acul-react/src/screens/mfa-email-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-email-challenge.tsx
@@ -10,6 +10,7 @@ import type {
   ContinueOptions,
   ResendCodeOptions,
   TryAnotherMethodOptions,
+  CustomOptions,
 } from '@auth0/auth0-acul-js/mfa-email-challenge';
 
 // Register the singleton instance of MfaEmailChallenge
@@ -37,6 +38,7 @@ export const continueMethod = (payload: ContinueOptions) => withError(instance.c
 export const resendCode = (payload?: ResendCodeOptions) => withError(instance.resendCode(payload));
 export const tryAnotherMethod = (payload?: TryAnotherMethodOptions) =>
   withError(instance.tryAnotherMethod(payload));
+export const pickEmail = (payload?: CustomOptions) => withError(instance.pickEmail(payload));
 
 // Utility Hooks
 export { useResend } from '../hooks/utility/resend-manager';


### PR DESCRIPTION
---

##  Summary

This PR includes the following updates:

* ✅ **Added** a new `pickEmail` method to support multiple email configuration strategies.
* 🔧 **Updated** `peerDependencies` for `react` and `react-dom` to require version `>=18.0.0`, ensuring compatibility with React 18+.

---


