### PR TITLE
feat(mfa-login-options): add returnToPrevious for back navigation 

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/mfa-login-options.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-login-options.ts
@@ -1,4 +1,5 @@
 import type { MfaLoginFactorType } from '../../src/constants';
+import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
 
@@ -39,4 +40,14 @@ export interface MfaLoginOptionsMembers extends BaseMembers {
    * ```
    */
   enroll(payload: LoginEnrollOptions): Promise<void>;
+  /**
+   * Returns to the previous screen in the authentication flow
+   * @param payload Optional custom options
+   * @example
+   * ```typescript
+   * const mfaLoginOptions = new MfaLoginOptions();
+   * await mfaLoginOptions.returnToPrevious();
+   * ```
+   */
+  returnToPrevious(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/mfa-login-options/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-login-options/index.ts
@@ -1,9 +1,10 @@
-import { type MfaLoginFactorType, ScreenIds } from '../../constants';
+import { type MfaLoginFactorType, ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
 import { ScreenOverride } from './screen-override';
 
+import type { CustomOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { MfaLoginOptionsMembers, LoginEnrollOptions, ScreenMembersOnMfaLoginOptions } from '../../../interfaces/screens/mfa-login-options';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
@@ -45,6 +46,21 @@ export default class MfaLoginOptions extends BaseContext implements MfaLoginOpti
       telemetry: [MfaLoginOptions.screenIdentifier, 'enroll'],
     };
     await new FormHandler(options).submitData<LoginEnrollOptions>(payload);
+  }
+
+  /**
+   * @example
+   * import MfaLoginOptions from '@auth0/auth0-acul-js/mfa-login-options';
+   *
+   * const mfaLoginOptions = new MfaLoginOptions();
+   * mfaLoginOptions.returnToPrevious();
+   */
+  async returnToPrevious(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [MfaLoginOptions.screenIdentifier, 'returnToPrevious'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
   }
 }
 

--- a/packages/auth0-acul-react/src/screens/mfa-login-options.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-login-options.tsx
@@ -8,6 +8,7 @@ import { registerScreen } from '../state/instance-store';
 import type {
   MfaLoginOptionsMembers,
   LoginEnrollOptions,
+  CustomOptions,
 } from '@auth0/auth0-acul-js/mfa-login-options';
 
 // Register the singleton instance of MfaLoginOptions
@@ -32,6 +33,8 @@ export const {
 
 // Submit functions
 export const enroll = (payload: LoginEnrollOptions) => withError(instance.enroll(payload));
+export const returnToPrevious = (payload?: CustomOptions) =>
+  withError(instance.returnToPrevious(payload));
 
 // Common hooks
 export {


### PR DESCRIPTION

---

🔄 **Add `returnToPrevious` Support to MFA Login Options Screen**

This PR adds a `returnToPrevious` method to the MFA Login Options screen, enabling users to navigate back in the auth flow, consistent with other screens like Email Identifier Challenge.

**Changes:**

* Updated `index.ts` and `mfa-login-options.ts` with method.


**Testing:**

* ✅ Builds and compiles successfully.
* ✅ Matches existing navigation patterns.

---


