### PR TITLE
Chore: Add support for switchToVoice and switchToText in phone-identifier-challenge

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
@@ -13,8 +13,6 @@ export interface ScreenDataOptions extends ScreenData {
   messageType?: 'text' | 'voice';
   phone?: 'string';
   resendLimitReached?: boolean;
-  showLinkSms?: boolean;
-  showLinkVoice?: boolean;
 }
 
 export interface ExtendedScreenContext extends ScreenContext {
@@ -22,8 +20,6 @@ export interface ExtendedScreenContext extends ScreenContext {
     message_type: 'text' | 'voice';
     phone: string;
     resendLimitReached?: boolean;
-    showLinkSms?: boolean;
-    showLinkVoice?: boolean;
   };
 }
 
@@ -43,5 +39,6 @@ export interface PhoneIdentifierChallengeMembers extends BaseMembers {
   resendCode(payload?: CustomOptions): Promise<void>;
   resendManager(options?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
-  switchToVoiceOrText(payload?: CustomOptions): Promise<void>;
+  switchToVoice(payload?: CustomOptions): Promise<void>;
+  switchToText(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/constants/form-actions.ts
+++ b/packages/auth0-acul-js/src/constants/form-actions.ts
@@ -11,6 +11,7 @@ export const FormActions = {
   TOGGLE_VIEW: 'toggle-view' as const,
   ENTER_OTP_CODE: 'enter-otp-code' as const,
   SWITCH_TO_VOICE: 'switch-to-voice' as const,
+  SWITCH_TO_TEXT: 'switch-to-text' as const,
   ABORT_PASSKEY_ENROLLMENT: 'abort-passkey-enrollment' as const,
   BACK_TO_LOGIN: 'back-to-login' as const,
   ACCEPT: 'accept' as const,

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -78,14 +78,29 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
    * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
    *
    * const phoneIdentifierChallenge = new PhoneIdentifierChallenge();
-   * phoneIdentifierChallenge.switchToVoiceOrText();
+   * phoneIdentifierChallenge.switchToVoice();
    */
-  async switchToVoiceOrText(payload?: CustomOptions): Promise<void> {
+  async switchToVoice(payload?: CustomOptions): Promise<void> {
     const options: FormOptions = {
       state: this.transaction.state,
-      telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'switchToVoiceOrText'],
+      telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'switchToVoice'],
     };
     await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.SWITCH_TO_VOICE });
+  }
+
+   /**
+   * @example
+   * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
+   *
+   * const phoneIdentifierChallenge = new PhoneIdentifierChallenge();
+   * phoneIdentifierChallenge.switchToText();
+   */
+  async switchToText(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'switchToText'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.SWITCH_TO_TEXT });
   }
 
   /**

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/screen-override.ts
@@ -20,6 +20,8 @@ export class ScreenOverride extends Screen implements OverrideOptions {
       ...data,
       phone: data?.phone_number,
       messageType: data?.message_type,
+      showLinkSms: data?.show_link_sms,
+      showLinkVoice: data?.show_link_voice,
     } as OverrideOptions['data'];
   }
 }

--- a/packages/auth0-acul-react/src/screens/phone-identifier-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/phone-identifier-challenge.tsx
@@ -37,8 +37,9 @@ export const submitPhoneChallenge = (payload: PhoneChallengeOptions) =>
 export const resendCode = (payload?: CustomOptions) => withError(instance.resendCode(payload));
 export const returnToPrevious = (payload?: CustomOptions) =>
   withError(instance.returnToPrevious(payload));
-export const switchToVoiceOrText = (payload?: CustomOptions) =>
-  withError(instance.switchToVoiceOrText(payload));
+export const switchToVoice = (payload?: CustomOptions) =>
+  withError(instance.switchToVoice(payload));
+export const switchToText = (payload?: CustomOptions) => withError(instance.switchToText(payload));
 
 // Utility Hooks
 export { useResend } from '../hooks/utility/resend-manager';


### PR DESCRIPTION
### Description

This PR introduces two new actions to the phone-identifier-challenge screen:

- `switchToVoice(payload?: CustomOptions)`
- `switchToText(payload?: CustomOptions)`

These methods allow switching the message delivery type between voice and text, providing a better user experience for users with preferences or limitations around message type.

#### Changes

- New Methods Added:
         - switchToVoice and switchToText methods implemented in:
                   - PhoneIdentifierChallenge screen class
                   - Interface: PhoneIdentifierChallengeMembers

#### Constants:

Added new form actions to FormActions:

- SWITCH_TO_VOICE
- SWITCH_TO_TEXT

#### Screen Data:

Extended ScreenMembersOnPhoneIdentifierChallenge and screen override logic to support:

- showLinkVoice
- showLinkSms

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
