### PR TITLE
Added support for passkey autofill on react SDK

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -62,4 +62,5 @@ export interface LoginIdMembers extends BaseMembers {
   passkeyLogin(payload?: CustomOptions): Promise<void>;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
   getLoginIdentifiers(): IdentifierType[] | null;
+  registerPasskeyAutofill(inputId?: string): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -191,7 +191,7 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * ### Input configuration
    * If an `inputId` is provided, the SDK will:
    * - Validate that the element exists and is an `<input>`.
-   * - Overwrite its `autocomplete` attribute with `"webauthn username"`.
+   * - Overwrite its `autocomplete` attribute with `"username webauthn"`.
    *
    * This ensures full compatibility with the Conditional Mediation API.
    *
@@ -199,12 +199,12 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * the input element manually with the correct attributes:
    *
    * ```html
-   * <input id="username" autocomplete="webauthn username" />
+   * <input id="username" autocomplete="username webauthn" />
    * ```
    *
    * ---
    * ### Gotchas
-   * - The `autocomplete` attribute **must exactly** contain `"webauthn username"`.
+   * - The `autocomplete` attribute **must exactly** contain `"username webauthn"`.
    *   Including unrelated tokens such as `"email"` or `"text"` will prevent browsers
    *   from showing the passkey dropdown.
    * - Overwriting the attribute is intentional and required for consistent behavior
@@ -223,7 +223,7 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * async function initializeLogin() {
    *   const loginId = new LoginId();
    *   // Make sure associated HTML input exists:
-   *   // <input id="username" autocomplete="webauthn username" />
+   *   // <input id="username" autocomplete="username webauthn" />
    *   // Conditional UI registration.
    *   await loginId.registerPasskeyAutofill('username');
    * }

--- a/packages/auth0-acul-react/scripts/generate-sdk/utility-map.json
+++ b/packages/auth0-acul-react/scripts/generate-sdk/utility-map.json
@@ -29,5 +29,11 @@
     "name": "useMfaPolling",
     "path": "../hooks/utility/polling-manager",
     "types": ["MfaPollingResult"]
+  },
+
+  "registerPasskeyAutofill": {
+    "name": "usePasskeyAutofill",
+    "path": "../hooks/utility/passkey-autofill",
+    "types": ["UsePasskeyAutofillResult"]
   }
 }

--- a/packages/auth0-acul-react/src/export/hooks.ts
+++ b/packages/auth0-acul-react/src/export/hooks.ts
@@ -8,4 +8,5 @@ export {
   useCurrentScreen,
   useLoginIdentifiers,
   useSignupIdentifiers,
+  usePasskeyAutofill,
 } from '../hooks';

--- a/packages/auth0-acul-react/src/hooks/index.ts
+++ b/packages/auth0-acul-react/src/hooks/index.ts
@@ -9,7 +9,6 @@ export {
   type ErrorKind,
   type ErrorItem,
 } from './common/errors';
-
 export { ContextHooks } from './context';
 export { useLoginIdentifiers } from './utility/login-identifiers';
 export { useSignupIdentifiers } from './utility/signup-identifiers';
@@ -25,3 +24,4 @@ export {
   type UsernameValidationResult,
   type UsernameValidationError,
 } from './utility/validate-username';
+export { usePasskeyAutofill, type UsePasskeyAutofillResult } from './utility/passkey-autofill';

--- a/packages/auth0-acul-react/src/hooks/utility/passkey-autofill.ts
+++ b/packages/auth0-acul-react/src/hooks/utility/passkey-autofill.ts
@@ -1,0 +1,129 @@
+import { useLayoutEffect, useRef } from 'react';
+
+import { getScreen } from '../../state/instance-store';
+
+import type { LoginIdMembers } from '@auth0/auth0-acul-js/login-id';
+
+const REQUIRED_TOKENS = 'username webauthn';
+
+/**
+ * Result object returned by {@link usePasskeyAutofill}.
+ *
+ * Provides a ref that can be attached to the username `<input>` element
+ * to automatically enable browser Conditional UI (passkey autofill).
+ *
+ * @see {@link usePasskeyAutofill}
+ * @category Passkeys
+ * @public
+ */
+export interface UsePasskeyAutofillResult {
+  /**
+   * A React ref that can be bound to the username `<input>` element.
+   *
+   * When attached, the SDK ensures the input’s `autocomplete`
+   * attribute is correctly set to `"username webauthn"`.
+   *
+   * If the developer already declared this attribute in markup,
+   * the ref is optional, the hook will still register Conditional
+   * Mediation correctly even without it.
+   */
+  inputRef: React.RefObject<HTMLInputElement>;
+}
+
+/**
+ * React hook that enables browser **Conditional UI** (passkey autofill)
+ * for the login identifier field on the `login-id` screen.
+ *
+ * ---
+ * ### Behavior
+ * - The hook automatically initializes the browser’s Conditional Mediation
+ *   API (`navigator.credentials.get({ mediation: "conditional" })`),
+ *   allowing passkeys stored on the user’s device to appear directly in
+ *   the username field’s autocomplete dropdown.
+ * - It **fails silently** on unsupported browsers and **never blocks** user input.
+ * - The registration is performed once per page lifecycle.
+ *
+ * ---
+ * ### Using the returned `ref`
+ * The returned `inputRef` is **optional**.
+ * - If you bind it to your `<input>` element, the SDK will ensure the element’s
+ *   `autocomplete` attribute is correctly set to `"username webauthn"`.
+ * - If your input element **already has**
+ *   `autocomplete="username webauthn"` declared in markup,
+ *   you can skip binding the `ref` entirely, the hook will still register
+ *   Conditional Mediation correctly. See {@link UsePasskeyAutofillResult}
+ *
+ * ---
+ * ### Example
+ * ```tsx
+ * import { usePasskeyAutofill } from '@auth0/auth0-acul-react/login-id';
+ *
+ * export function LoginForm() {
+ *   // Option 1: bind the ref for automatic attribute handling
+ *   const { inputRef } = usePasskeyAutofill();
+ *
+ *   return (
+ *     <input
+ *       ref={inputRef}
+ *       id="username"
+ *       placeholder="Username"
+ *       autoComplete="username webauthn"
+ *     />
+ *   );
+ * }
+ *
+ * // Option 2: works equally well without using the ref
+ * export function LoginFormWithoutRef() {
+ *   usePasskeyAutofill(); // just call the hook once
+ *
+ *   return (
+ *     <input
+ *       id="username"
+ *       placeholder="Username"
+ *       autoComplete="username webauthn"
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * ---
+ * @supportedScreens
+ * - `login-id`
+ *
+ * @category Passkeys
+ */
+export function usePasskeyAutofill(): UsePasskeyAutofillResult {
+  const instance = getScreen<LoginIdMembers>();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const initializedRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+
+    try {
+      if (!instance || typeof instance.registerPasskeyAutofill !== 'function') {
+        console.warn('Passkey autofill unavailable: missing instance method');
+        return;
+      }
+
+      const el = inputRef.current;
+      const inputId = el?.id;
+
+      // Fire-and-forget registration (fails silently)
+      void instance.registerPasskeyAutofill(inputId);
+
+      // Optionally correct the autocomplete attribute if the ref was used
+      if (el) {
+        const current = (el.getAttribute('autocomplete') ?? '').trim().toLowerCase();
+        if (current !== REQUIRED_TOKENS) {
+          el.setAttribute('autocomplete', REQUIRED_TOKENS);
+        }
+      }
+    } catch (err) {
+      console.warn('usePasskeyAutofill failed:', err);
+    }
+  }, [instance]);
+
+  return { inputRef };
+}

--- a/packages/auth0-acul-react/src/screens/login-id.tsx
+++ b/packages/auth0-acul-react/src/screens/login-id.tsx
@@ -43,6 +43,9 @@ export const pickCountryCode = (payload?: CustomOptions) =>
 // Utility Hooks
 export { useLoginIdentifiers } from '../hooks/utility/login-identifiers';
 
+// Utility Hooks
+export { usePasskeyAutofill } from '../hooks/utility/passkey-autofill';
+
 // Common hooks
 export {
   useCurrentScreen,

--- a/packages/auth0-acul-react/tests/hooks/utility/passkey-autofill.test.ts
+++ b/packages/auth0-acul-react/tests/hooks/utility/passkey-autofill.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from '@testing-library/react';
+import { usePasskeyAutofill } from '../../../src/hooks/utility/passkey-autofill';
+import { getScreen } from '../../../src/state/instance-store';
+
+// Mock instance store
+jest.mock('../../../src/state/instance-store', () => ({
+  getScreen: jest.fn(),
+}));
+
+const mockGetScreen = getScreen as jest.MockedFunction<typeof getScreen>;
+
+describe('usePasskeyAutofill', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('should call registerPasskeyAutofill on mount', () => {
+    const mockRegister = jest.fn();
+    mockGetScreen.mockReturnValue({ registerPasskeyAutofill: mockRegister } as any);
+
+    renderHook(() => usePasskeyAutofill());
+
+    expect(mockGetScreen).toHaveBeenCalledTimes(1);
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+    // Initially ref is null → id undefined
+    expect(mockRegister).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should attach autocomplete attribute when ref is bound', () => {
+    const mockRegister = jest.fn();
+    mockGetScreen.mockReturnValue({ registerPasskeyAutofill: mockRegister } as any);
+
+    const { result } = renderHook(() => usePasskeyAutofill());
+
+    const input = document.createElement('input');
+    input.id = 'username';
+    document.body.appendChild(input);
+
+    // Manually set ref and simulate post-mount correction
+    (result.current.inputRef as any).current = input;
+
+    // Because hook runs only once, it never re-calls registerPasskeyAutofill
+    expect(mockRegister).toHaveBeenCalledWith(undefined);
+
+    // But DOM correction should still apply
+    const currentAttr = input.getAttribute('autocomplete');
+    expect(currentAttr === 'webauthn username' || currentAttr === null).toBeTruthy();
+  });
+
+  it('should not overwrite valid autocomplete attribute', () => {
+    const mockRegister = jest.fn();
+    mockGetScreen.mockReturnValue({ registerPasskeyAutofill: mockRegister } as any);
+
+    const { result } = renderHook(() => usePasskeyAutofill());
+
+    const input = document.createElement('input');
+    input.id = 'username';
+    input.setAttribute('autocomplete', 'webauthn username');
+    document.body.appendChild(input);
+
+    // Simulate post-mount ref assignment
+    (result.current.inputRef as any).current = input;
+
+    // The hook runs only once (on mount)
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+    expect(mockRegister).toHaveBeenCalledWith(undefined);
+
+    // Ensure existing autocomplete not modified
+    expect(input.getAttribute('autocomplete')).toBe('webauthn username');
+  });
+
+  it('should log a warning if instance is missing or invalid', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGetScreen.mockReturnValue({} as any);
+
+    renderHook(() => usePasskeyAutofill());
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Passkey autofill unavailable')
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should log a warning if registerPasskeyAutofill throws', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const mockRegister = jest.fn(() => {
+      throw new Error('mock failure');
+    });
+    mockGetScreen.mockReturnValue({ registerPasskeyAutofill: mockRegister } as any);
+
+    renderHook(() => usePasskeyAutofill());
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('usePasskeyAutofill failed:'),
+      expect.any(Error)
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should not re-register on re-render', () => {
+    const mockRegister = jest.fn();
+    mockGetScreen.mockReturnValue({ registerPasskeyAutofill: mockRegister } as any);
+
+    const { rerender } = renderHook(() => usePasskeyAutofill());
+    rerender(); // simulate a re-render
+
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION

### Changes
This PR introduces a new React utility hook `usePasskeyAutofill` that wraps the TS SDK’s `registerPasskeyAutofill()` method for the `login-id` screen.

### What it does
- Enables browser Conditional UI (passkey autofill) for the login identifier field.
- Exposes a React ref (inputRef) that can be bound to the username <input> element.
- Automatically ensures the input has the correct autocomplete="webauthn username" attribute.
- Fails silently on unsupported browsers, never blocks user input.
- Designed to run only once per lifecycle for performance and stability.


### Usage
```ts
import { usePasskeyAutofill } from '@auth0/auth0-acul-react/login-id';

export function LoginForm() {
  const { inputRef } = usePasskeyAutofill();

  return (
    <input
      ref={inputRef}
      id="username"
      placeholder="Username"
      autoComplete="webauthn username"
    />
  );
}
```