### PR TITLE
Refactor: Rename Login Password Policy Methods

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/login-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-password.ts
@@ -28,9 +28,9 @@ export interface TransactionMembersOnLoginPassword extends TransactionMembers {
   isSignupEnabled: boolean;
   isForgotPasswordEnabled: boolean;
   isPasskeyEnabled: boolean;
-  passwordPolicy(): PasswordPolicy | null;
-  usernamePolicy(): UsernamePolicy | null;
-  allowedIdentifiers(): IdentifierType[] | null;
+  passwordPolicy: PasswordPolicy | null;
+  usernamePolicy: UsernamePolicy | null;
+  allowedIdentifiers: IdentifierType[] | null;
 }
 
 export interface LoginPassword extends BaseContext {

--- a/packages/auth0-acul-js/src/screens/login-password/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/transaction-override.ts
@@ -18,9 +18,9 @@ export class TransactionOverride extends Transaction implements OverrideMembers 
     this.isSignupEnabled = isSignupEnabled(transactionContext);
     this.isForgotPasswordEnabled = isForgotPasswordEnabled(transactionContext);
     this.isPasskeyEnabled = isPasskeyEnabled(transactionContext);
-    this.passwordPolicy = (): ReturnType<OverrideMembers['passwordPolicy']> => getPasswordPolicy(transactionContext);
-    this.usernamePolicy = (): ReturnType<OverrideMembers['usernamePolicy']> => getUsernamePolicy(transactionContext);
-    this.allowedIdentifiers = (): ReturnType<OverrideMembers['allowedIdentifiers']> => getAllowedIdentifiers(transactionContext);
+    this.passwordPolicy = getPasswordPolicy(transactionContext);
+    this.usernamePolicy = getUsernamePolicy(transactionContext);
+    this.allowedIdentifiers = getAllowedIdentifiers(transactionContext);
   }
 
   isSignupEnabled: boolean;

--- a/packages/auth0-acul-js/tests/unit/screens/login-password/transaction-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-password/transaction-override.test.ts
@@ -43,15 +43,15 @@ describe('TransactionOverride', () => {
   });
 
   it('should return correct password policy', () => {
-    expect(transactionOverride.passwordPolicy()).toBe('mockPasswordPolicy');
+    expect(transactionOverride.passwordPolicy).toBe('mockPasswordPolicy');
   });
 
   it('should return correct username policy', () => {
-    expect(transactionOverride.usernamePolicy()).toBe('mockUsernamePolicy');
+    expect(transactionOverride.usernamePolicy).toBe('mockUsernamePolicy');
   });
 
   it('should return correct allowed identifiers', () => {
-    expect(transactionOverride.allowedIdentifiers()).toEqual(['email']);
+    expect(transactionOverride.allowedIdentifiers).toEqual(['email']);
   });
 
   it('should call shared functions with correct transactionContext', () => {
@@ -76,8 +76,8 @@ describe('TransactionOverride', () => {
     expect(emptyTransactionOverride.isSignupEnabled).toBeUndefined();
     expect(emptyTransactionOverride.isForgotPasswordEnabled).toBeUndefined();
     expect(emptyTransactionOverride.isPasskeyEnabled).toBeUndefined();
-    expect(emptyTransactionOverride.passwordPolicy()).toBeUndefined();
-    expect(emptyTransactionOverride.usernamePolicy()).toBeUndefined();
-    expect(emptyTransactionOverride.allowedIdentifiers()).toBeUndefined();
+    expect(emptyTransactionOverride.passwordPolicy).toBeUndefined();
+    expect(emptyTransactionOverride.usernamePolicy).toBeUndefined();
+    expect(emptyTransactionOverride.allowedIdentifiers).toBeUndefined();
   });
 });


### PR DESCRIPTION
**🔄 Refactor: Rename Login Password Policy Methods**
**📋 Summary**
Refactored the `LoginPassword` transaction interface method names to follow a more concise naming convention by removing the `get` prefix from simple accessor methods.

**⚙️ Changes & ⚠ Breaking Changes**

**Modified Methods:**

* `getPasswordPolicy` → `passwordPolicy`
* `getUsernamePolicy` → `usernamePolicy`
* `getAllowedIdentifiers` → `allowedIdentifiers`

**Files Changed:**

* `login-password.ts`

  * Renamed interface methods in `TransactionMembersOnLoginPassword`.
* `transaction-override.ts`

  * Updated `TransactionOverride` class to implement the renamed methods.
  * Updated all type references to match new method names.
* `transaction-override.test.ts`

  * Updated all test cases to use the new method names.