### PR TITLE
feat: added continue method for MFA push enrollment QR

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/mfa-push-enrollment-qr.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-push-enrollment-qr.ts
@@ -18,6 +18,9 @@ export interface ScreenMembersOnMfaPushEnrollmentQr extends ScreenMembers {
   } | null;
 }
 
+export interface WithRememberOptions extends CustomOptions {
+  rememberDevice?: boolean;
+}
 /**
  * Interface defining the available methods and properties for the mfa-push-enrollment-qr screen
  */
@@ -28,6 +31,8 @@ export interface MfaPushEnrollmentQrMembers extends BaseMembers {
    * @param payload Optional custom options to include with the request
    */
   pickAuthenticator(payload?: CustomOptions): Promise<void>;
+
+  continue(payload?: WithRememberOptions): Promise<void>;
 
   pollingManager(options: MfaPollingOptions): MfaPushPollingControl;
   

--- a/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-push-enrollment-qr/index.ts
@@ -9,6 +9,7 @@ import type { CustomOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   MfaPushEnrollmentQrMembers,
+  WithRememberOptions,
   ScreenMembersOnMfaPushEnrollmentQr as ScreenOptions,
 } from '../../../interfaces/screens/mfa-push-enrollment-qr';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
@@ -27,6 +28,23 @@ export default class MfaPushEnrollmentQr extends BaseContext implements MfaPushE
     this.screen = new ScreenOverride(screenContext);
   }
 
+  async continue(payload?: WithRememberOptions): Promise<void> {
+      const options: FormOptions = {
+        state: this.transaction.state,
+        telemetry: [MfaPushEnrollmentQr.screenIdentifier, "continue"],
+      };
+  
+      const { rememberDevice, ...restPayload } = payload || {};
+      const submitPayload: Record<string, string | number | boolean> = {
+        ...restPayload,
+        action: FormActions.CONTINUE,
+      };
+  
+      if (rememberDevice) {
+        submitPayload.rememberBrowser = true;
+      }
+      await new FormHandler(options).submitData(submitPayload);
+    }
   /**
    * Navigates to the authenticator selection screen.
    * @param payload Optional custom options to include with the request
@@ -97,7 +115,8 @@ export default class MfaPushEnrollmentQr extends BaseContext implements MfaPushE
 }
 
 export { 
-  MfaPushEnrollmentQrMembers, 
+  MfaPushEnrollmentQrMembers,
+  WithRememberOptions, 
   ScreenOptions as ScreenMembersOnMfaPushEnrollmentQr, 
   MfaPollingOptions,
   MfaPushPollingControl

--- a/packages/auth0-acul-react/src/screens/mfa-push-enrollment-qr.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-push-enrollment-qr.tsx
@@ -8,6 +8,7 @@ import { registerScreen } from '../state/instance-store';
 import type {
   MfaPushEnrollmentQrMembers,
   CustomOptions,
+  WithRememberOptions,
 } from '@auth0/auth0-acul-js/mfa-push-enrollment-qr';
 
 // Register the singleton instance of MfaPushEnrollmentQr
@@ -33,6 +34,8 @@ export const {
 // Submit functions
 export const pickAuthenticator = (payload?: CustomOptions) =>
   withError(instance.pickAuthenticator(payload));
+export const continueMethod = (payload?: WithRememberOptions) =>
+  withError(instance.continue(payload));
 
 // Utility Hooks
 export { useMfaPolling } from '../hooks/utility/polling-manager';


### PR DESCRIPTION
## Description
Adding continue method for mfa-push-enrollment-qr so it moves to next once we approve from device.