### PR TITLE
feat: add toggleView method for switching between QR code

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/mfa-otp-enrollment-code.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-otp-enrollment-code.ts
@@ -1,5 +1,6 @@
 import type { BaseMembers } from '../../interfaces/models/base-context';
 import type { ScreenMembers } from '../../interfaces/models/screen';
+import type { CustomOptions } from '../common';
 
 /**
  * Options for continuing with the MFA OTP enrollment code.
@@ -52,6 +53,12 @@ export interface MfaOtpEnrollmentCodeMembers extends BaseMembers {
    * @param payload The options containing the OTP code.
    */
   continue(payload: ContinueOptions): Promise<void>;
+
+  /**
+   * Toggles between QR code view and manual code entry view.
+   * @param payload Optional custom options to include with the request.
+   */
+  toggleView(payload?: CustomOptions): Promise<void>;
 
   /**
    * Allows the user to try another MFA method.

--- a/packages/auth0-acul-js/src/screens/mfa-otp-enrollment-code/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-otp-enrollment-code/index.ts
@@ -64,6 +64,30 @@ export default class MfaOtpEnrollmentCode extends BaseContext implements MfaOtpE
   }
 
   /**
+   * Toggles between QR code view and manual code entry view.
+   *
+   * @param {CustomOptions} [payload] - Optional payload.
+   * @returns {Promise<void>}
+   * @example
+   * ```typescript
+   * import MfaOtpEnrollmentCode from '@auth0/auth0-acul-js/mfa-otp-enrollment-code';
+   *
+   * const mfaOtpEnrollmentCode = new MfaOtpEnrollmentCode();
+   * await mfaOtpEnrollmentCode.toggleView();
+   * ```
+   */
+  async toggleView(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [MfaOtpEnrollmentCode.screenIdentifier, 'toggleView'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({
+      ...payload,
+      action: FormActions.TOGGLE_VIEW,
+    });
+  }
+
+  /**
    * Allows the user to try another MFA method.
    *
    * @param {TryAnotherMethodOptions} [payload] - Optional payload.

--- a/packages/auth0-acul-react/src/screens/mfa-otp-enrollment-code.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-otp-enrollment-code.tsx
@@ -8,6 +8,7 @@ import { registerScreen } from '../state/instance-store';
 import type {
   MfaOtpEnrollmentCodeMembers,
   ContinueOptions,
+  CustomOptions,
   TryAnotherMethodOptions,
 } from '@auth0/auth0-acul-js/mfa-otp-enrollment-code';
 
@@ -33,6 +34,7 @@ export const {
 
 // Submit functions
 export const continueMethod = (payload: ContinueOptions) => withError(instance.continue(payload));
+export const toggleView = (payload?: CustomOptions) => withError(instance.toggleView(payload));
 export const tryAnotherMethod = (payload?: TryAnotherMethodOptions) =>
   withError(instance.tryAnotherMethod(payload));
 


### PR DESCRIPTION


**🎯 Summary**

* Adds the `toggleView` method to the **mfa-otp-enrollment-code** screen to align with the API specification.
* Enables switching between the **QR code view** and the **manual code entry view** during MFA OTP enrollment.
