### PR TITLE
feat: add support for flexible password policy

### DIFF
--- a/packages/auth0-acul-js/interfaces/models/transaction.ts
+++ b/packages/auth0-acul-js/interfaces/models/transaction.ts
@@ -61,6 +61,16 @@ export interface PasswordPolicy {
   passwordSecurityInfo?: PasswordComplexityRule[];
 }
 
+
+export interface PasswordComplexityPolicy {
+  character_type_rule: "all" | "at_least";
+  character_types: Array<"uppercase" | "lowercase" | "number" | "special">;
+  min_length: number;
+  identical_characters: "block" | "allow";
+  sequential_characters: "block" | "allow";
+  max_length_exceeded: "error" | "allow";
+}
+
 export interface DBConnection extends Connection {
   options: {
     signup_enabled: boolean;
@@ -105,6 +115,9 @@ export interface DBConnection extends Connection {
       passkey: {
         enabled: boolean;
       };
+    };
+    password_options: {
+      complexity: PasswordComplexityPolicy;
     };
   };
 }

--- a/packages/auth0-acul-js/interfaces/screens/reset-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password.ts
@@ -1,6 +1,6 @@
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers, ScreenData } from '../models/screen';
-import type { TransactionMembers, PasswordPolicy } from '../models/transaction';
+import type { TransactionMembers, PasswordPolicy, PasswordComplexityPolicy } from '../models/transaction';
 import type { PasswordValidationResult } from '../utils/validate-password';
 
 export interface ResetPasswordOptions {
@@ -18,6 +18,7 @@ export interface ScreenMembersOnResetPassword extends ScreenMembers {
 }
 export interface TransactionMembersOnResetPassword extends TransactionMembers {
   passwordPolicy: PasswordPolicy | null;
+  passwordComplexityPolicy: PasswordComplexityPolicy | null;
 }
 export interface ResetPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnResetPassword;

--- a/packages/auth0-acul-js/interfaces/screens/signup-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-password.ts
@@ -2,7 +2,7 @@ import type { PasswordValidationResult } from '../../interfaces/utils/validate-p
 import type { IdentifierType } from '../../src/constants';
 import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers } from '../models/screen';
-import type { PasswordPolicy, TransactionMembers } from '../models/transaction';
+import type { PasswordPolicy, PasswordComplexityPolicy ,TransactionMembers } from '../models/transaction';
 
 export interface ScreenContextOnSignupPassword extends ScreenContext {
   links: {
@@ -39,6 +39,7 @@ export interface ScreenMembersOnSignupPassword extends ScreenMembers {
 export interface TransactionMembersOnSignupPassword extends TransactionMembers {
   isPasskeyEnabled: boolean;
   passwordPolicy: PasswordPolicy | null;
+  passwordComplexityPolicy: PasswordComplexityPolicy | null;
   requiredIdentifiers: IdentifierType[] | null;
   optionalIdentifiers: IdentifierType[] | null;
 }

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -4,7 +4,7 @@ import type { IdentifierType } from '../../src/constants';
 import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
-import type { TransactionMembers, UsernamePolicy, PasswordPolicy } from '../models/transaction';
+import type { TransactionMembers, UsernamePolicy, PasswordPolicy, PasswordComplexityPolicy } from '../models/transaction';
 import type { Identifier } from '../utils/signup-identifiers';
 export interface SignupOptions {
   email?: string;
@@ -30,6 +30,7 @@ export interface TransactionMembersOnSignup extends TransactionMembers {
   requiredIdentifiers: IdentifierType[] | null;
   optionalIdentifiers: IdentifierType[] | null;
   passwordPolicy: PasswordPolicy | null;
+  passwordComplexityPolicy: PasswordComplexityPolicy | null;
 }
 
 export interface SignupMembers extends BaseMembers {

--- a/packages/auth0-acul-js/src/screens/reset-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password/index.ts
@@ -1,7 +1,7 @@
 import { ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
-import { validatePassword as _validatePassword } from '../../utils/validate-password';
+import { validatePassword as _validatePassword, validateWithComplexityPolicy as _validateFlexiblePassword } from '../../utils/validate-password';
 
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
@@ -54,7 +54,8 @@ export default class ResetPassword extends BaseContext implements ResetPasswordM
    */
   validatePassword(password: string): PasswordValidationResult {
     const passwordPolicy = this.transaction?.passwordPolicy;
-    return _validatePassword(password, passwordPolicy);
+    const passwordComplexityPolicy = this.transaction?.passwordComplexityPolicy;
+    return passwordComplexityPolicy ? _validateFlexiblePassword(password, passwordComplexityPolicy) : _validatePassword(password, passwordPolicy);
   }
 }
 export { ResetPasswordMembers, ResetPasswordOptions, ScreenOptions as ScreenMembersOnResetPassword, TransactionOverride as TransactionMembersOnResetPassword };

--- a/packages/auth0-acul-js/src/screens/reset-password/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password/transaction-override.ts
@@ -1,14 +1,16 @@
 import { Transaction } from '../../models/transaction';
-import { getPasswordPolicy } from '../../shared/transaction';
+import { getPasswordPolicy, getPasswordComplexityPolicy } from '../../shared/transaction';
 
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type { TransactionMembersOnResetPassword as OverrideOptions } from '../../../interfaces/screens/reset-password';
 
 export class TransactionOverride extends Transaction implements OverrideOptions {
   passwordPolicy: OverrideOptions['passwordPolicy'];
+  passwordComplexityPolicy: OverrideOptions['passwordComplexityPolicy'];
 
   constructor(transactionContext: TransactionContext) {
     super(transactionContext);
     this.passwordPolicy = getPasswordPolicy(transactionContext);
+    this.passwordComplexityPolicy = getPasswordComplexityPolicy(transactionContext);
   }
 }

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -1,7 +1,7 @@
 import { ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
-import { validatePassword as _validatePassword } from '../../utils/validate-password';
+import { validatePassword as _validatePassword, validateWithComplexityPolicy as _validateFlexiblePassword } from '../../utils/validate-password';
 
 
 import { ScreenOverride } from './screen-override';
@@ -157,7 +157,8 @@ export default class SignupPassword extends BaseContext implements SignupPasswor
   */
   validatePassword(password: string): PasswordValidationResult {
     const passwordPolicy = this.transaction?.passwordPolicy;
-    return _validatePassword(password, passwordPolicy);
+    const passwordComplexityPolicy = this.transaction?.passwordComplexityPolicy;
+    return passwordComplexityPolicy ? _validateFlexiblePassword(password, passwordComplexityPolicy) : _validatePassword(password, passwordPolicy);
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/signup-password/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/transaction-override.ts
@@ -1,6 +1,6 @@
 import { ConnectionStrategy, Identifiers } from '../../../src/constants';
 import { Transaction } from '../../models/transaction';
-import { isPasskeyEnabled, getPasswordPolicy, getRequiredIdentifiers, getOptionalIdentifiers } from '../../shared/transaction';
+import { isPasskeyEnabled, getPasswordPolicy, getPasswordComplexityPolicy, getRequiredIdentifiers, getOptionalIdentifiers } from '../../shared/transaction';
 
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type { TransactionMembersOnSignupPassword as OverrideOptions } from '../../../interfaces/screens/signup-password';
@@ -8,6 +8,7 @@ import type { TransactionMembersOnSignupPassword as OverrideOptions } from '../.
 export class TransactionOverride extends Transaction implements OverrideOptions {
   isPasskeyEnabled: OverrideOptions['isPasskeyEnabled'];
   passwordPolicy: OverrideOptions['passwordPolicy'];
+  passwordComplexityPolicy: OverrideOptions['passwordComplexityPolicy'];
   optionalIdentifiers: OverrideOptions['optionalIdentifiers'];
   requiredIdentifiers: OverrideOptions['requiredIdentifiers'];
 
@@ -15,6 +16,7 @@ export class TransactionOverride extends Transaction implements OverrideOptions 
     super(transactionContext);
     this.isPasskeyEnabled = isPasskeyEnabled(transactionContext);
     this.passwordPolicy = getPasswordPolicy(transactionContext);
+    this.passwordComplexityPolicy = getPasswordComplexityPolicy(transactionContext);
     this.optionalIdentifiers = getOptionalIdentifiers(transactionContext);
     this.requiredIdentifiers = TransactionOverride.getRequiredIdentifiers(transactionContext, this.connectionStrategy);
   }

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -3,7 +3,7 @@ import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 import { getSignupIdentifiers as _getSignupIdentifiers} from '../../utils/signup-identifiers';
-import { validatePassword as _validatePassword} from '../../utils/validate-password';
+import { validatePassword as _validatePassword, validateWithComplexityPolicy as _validateFlexiblePassword} from '../../utils/validate-password';
 import { validateUsername as _validateUsername} from '../../utils/validate-username';
 
 import { ScreenOverride } from './screen-override';
@@ -112,7 +112,8 @@ export default class Signup extends BaseContext implements SignupMembers {
    */
   validatePassword(password: string): PasswordValidationResult {
     const passwordPolicy = this.transaction?.passwordPolicy;
-    return _validatePassword(password, passwordPolicy);
+    const passwordComplexityPolicy = this.transaction?.passwordComplexityPolicy;
+    return passwordComplexityPolicy ?  _validateFlexiblePassword(password, passwordComplexityPolicy) : _validatePassword(password, passwordPolicy);
   }
 
   /**

--- a/packages/auth0-acul-js/src/screens/signup/transaction-override.ts
+++ b/packages/auth0-acul-js/src/screens/signup/transaction-override.ts
@@ -1,6 +1,6 @@
 import { ConnectionStrategy, Identifiers } from '../../../src/constants';
 import { Transaction } from '../../models/transaction';
-import { isPasskeyEnabled, getUsernamePolicy, getRequiredIdentifiers, getOptionalIdentifiers, getPasswordPolicy } from '../../shared/transaction';
+import { isPasskeyEnabled, getUsernamePolicy, getRequiredIdentifiers, getOptionalIdentifiers, getPasswordPolicy, getPasswordComplexityPolicy } from '../../shared/transaction';
 
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type { TransactionMembersOnSignup as OverrideOptions } from '../../../interfaces/screens/signup';
@@ -11,6 +11,7 @@ export class TransactionOverride extends Transaction implements OverrideOptions 
   optionalIdentifiers: OverrideOptions['optionalIdentifiers'];
   requiredIdentifiers: OverrideOptions['requiredIdentifiers'];
   passwordPolicy: OverrideOptions['passwordPolicy'];
+  passwordComplexityPolicy: OverrideOptions['passwordComplexityPolicy'];
 
   constructor(transactionContext: TransactionContext) {
     super(transactionContext);
@@ -19,6 +20,7 @@ export class TransactionOverride extends Transaction implements OverrideOptions 
     this.optionalIdentifiers = getOptionalIdentifiers(transactionContext);
     this.requiredIdentifiers = TransactionOverride.getRequiredIdentifiers(transactionContext, this.connectionStrategy);
     this.passwordPolicy = getPasswordPolicy(transactionContext);
+    this.passwordComplexityPolicy = getPasswordComplexityPolicy(transactionContext);
   }
 
   static getRequiredIdentifiers(transactionContext: TransactionContext, connectionStrategy: string | null): OverrideOptions['requiredIdentifiers'] {

--- a/packages/auth0-acul-js/src/shared/transaction.ts
+++ b/packages/auth0-acul-js/src/shared/transaction.ts
@@ -2,6 +2,7 @@ import type {
   DBConnection,
   UsernamePolicy,
   PasswordPolicy,
+  PasswordComplexityPolicy,
   TransactionContext,
 } from "../../interfaces/models/transaction";
 import type { TransactionMembersOnLoginId } from "../../interfaces/screens/login-id";
@@ -117,6 +118,31 @@ export function getPasswordPolicy(
           ? { ...record, isValid: true }
           : { ...record, isValid: false }
     ),
+  };
+}
+
+/**
+ * Retrieves the password complexity policy configuration from the transaction context.
+ * This includes properties like minimum length and complexity requirements.
+ *
+ * @param transaction - The transaction context from Universal Login
+ * @returns The password complexity policy object or null if not defined
+ */
+export function getPasswordComplexityPolicy(
+  transaction: TransactionContext
+): PasswordComplexityPolicy | null {
+  const connection = transaction?.connection as DBConnection;
+  const passwordComplexityPolicy = connection?.options?.password_options?.complexity;
+
+  if (!passwordComplexityPolicy) return null;
+
+  return {
+    character_type_rule: passwordComplexityPolicy.character_type_rule,
+    character_types: passwordComplexityPolicy.character_types,
+    identical_characters: passwordComplexityPolicy.identical_characters,
+    max_length_exceeded: passwordComplexityPolicy.max_length_exceeded,
+    min_length: passwordComplexityPolicy.min_length,
+    sequential_characters: passwordComplexityPolicy.sequential_characters
   };
 }
 


### PR DESCRIPTION
### Description

Adds support for flexible password complexity policies with granular validation rules. This enhancement allows configuring password requirements based on character types, sequential/identical character restrictions, and length constraints.

###  Changes

  #### New Interfaces & Types

  - Added PasswordComplexityPolicy interface with configurable validation rules:
    - Character type requirements (uppercase, lowercase, numbers, special characters)
    - Minimum length validation
    - Identical character detection and blocking
    - Sequential character detection and blocking
    - Character type rule modes ("all" or "at_least")
  - Extended DBConnection interface to include password_options.complexity configuration

  #### Validation Logic

  - Implemented validateWithComplexityPolicy() function with support for:
    - Minimum length enforcement
    - Repeated character detection (e.g., "aaa")
    - Sequential character detection (e.g., "abc", "123")
    - Character type validation with detailed per-rule feedback
  - Added helper functions hasSequentialChars() and hasIdenticalChars() for pattern detection

  #### Integration

  - Updated signup and signup-password screens to:
    - Expose passwordComplexityPolicy in transaction members
    - Automatically use complexity policy validation when available
    - Fall back to legacy password policy validation for backward compatibility
  - Added getPasswordComplexityPolicy() helper to extract policy from transaction context

  #### Backward Compatibility

  Maintains full backward compatibility by falling back to existing password policy validation when complexity policy is not configured.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
