### PR TITLE
feat: Add switching methods to OTP/PASSWORD

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
@@ -23,4 +23,9 @@ export interface EmailIdentifierChallengeMembers extends BaseMembers {
   resendCode(payload?: CustomOptions): Promise<void>;
   resendManager(payload?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
+  /**
+   * Switches from OTP/code authentication to password authentication.
+   * When called, the screen will re-render to the password authentication screen.
+   */
+  switchToPasswordAuth(): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/login-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-password.ts
@@ -61,4 +61,9 @@ export interface LoginPasswordMembers extends BaseMembers {
   login(payload: LoginPasswordOptions): Promise<void>;
   federatedLogin(payload: FederatedLoginOptions): Promise<void>;
   switchConnection(payload: SwitchConnectionOptions): Promise<void>;
+  /**
+   * Switches from password authentication to OTP authentication.
+   * When called, the screen will re-render to the OTP authentication screen.
+   */
+  switchToOtpAuth(): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
@@ -41,4 +41,9 @@ export interface PhoneIdentifierChallengeMembers extends BaseMembers {
   returnToPrevious(payload?: CustomOptions): Promise<void>;
   switchToVoice(payload?: CustomOptions): Promise<void>;
   switchToText(payload?: CustomOptions): Promise<void>;
+  /**
+   * Switches from OTP/code authentication to password authentication.
+   * When called, the screen will re-render to the password authentication screen.
+   */
+  switchToPasswordAuth(): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/constants/form-actions.ts
+++ b/packages/auth0-acul-js/src/constants/form-actions.ts
@@ -30,4 +30,8 @@ export const FormActions = {
   TRY_AGAIN: 'tryagain' as const,
   USE_PASSWORD: 'use-password' as const,
   CHANGE_LANGUAGE: 'change-language' as const,
+  // actions for login-password screen
+  SWITCH_TO_OTP_AUTH: 'switch-to-otp-auth' as const,
+  // actions for email-identifier-challenge screen
+  SWITCH_TO_PASSWORD_AUTH: 'switch-to-password-auth' as const,
 } as const;

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
@@ -109,6 +109,31 @@ export default class EmailIdentifierChallenge extends BaseContext implements Ema
       !!this.screen.data?.resendLimitReached
     );
   }
+
+  /**
+   * @remarks
+   * This method switches from OTP/code authentication to password authentication.
+   * When called, the screen will re-render to the password authentication screen.
+   *
+   * @example
+   * import EmailIdentifierChallenge from '@auth0/auth0-acul-js/email-identifier-challenge';
+   *
+   * const emailIdentifierChallenge = new EmailIdentifierChallenge();
+   *
+   * // Switch to password authentication
+   * emailIdentifierChallenge.switchToPasswordAuth();
+   */
+  async switchToPasswordAuth(): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [EmailIdentifierChallenge.screenIdentifier, 'switchToPasswordAuth'],
+    };
+
+    await new FormHandler(options).submitData({
+      code: '',
+      action: FormActions.SWITCH_TO_PASSWORD_AUTH,
+    });
+  }
 }
 
 export { EmailIdentifierChallengeMembers, ScreenOptions as ScreenMembersOnEmailIdentifierChallenge, EmailChallengeOptions };

--- a/packages/auth0-acul-js/src/screens/login-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/index.ts
@@ -1,4 +1,4 @@
-import { ScreenIds } from '../../constants';
+import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { getBrowserCapabilities } from '../../utils/browser-capabilities';
 import { FormHandler } from '../../utils/form-handler';
@@ -109,6 +109,30 @@ export default class LoginPassword extends BaseContext implements LoginPasswordM
     };
 
     await new FormHandler(options).submitData<SwitchConnectionOptions>(payload);
+  }
+
+  /**
+   * @remarks
+   * This method switches from password authentication to OTP authentication.
+   * When called, the screen will re-render to the OTP authentication screen.
+   *
+   * @example
+   * import LoginPassword from "@auth0/auth0-acul-js/login-password";
+   *
+   * const loginPasswordManager = new LoginPassword();
+   *
+   * // Switch to OTP authentication
+   * loginPasswordManager.switchToOtpAuth();
+   */
+  async switchToOtpAuth(): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [LoginPassword.screenIdentifier, 'switchToOtpAuth'],
+    };
+
+    await new FormHandler(options).submitData({
+      action: FormActions.SWITCH_TO_OTP_AUTH,
+    });
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -141,6 +141,31 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
       !!this.screen.data?.resendLimitReached
     );
   }
+
+  /**
+   * @remarks
+   * This method switches from OTP/code authentication to password authentication.
+   * When called, the screen will re-render to the password authentication screen.
+   *
+   * @example
+   * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
+   *
+   * const phoneIdentifierChallenge = new PhoneIdentifierChallenge();
+   *
+   * // Switch to password authentication
+   * phoneIdentifierChallenge.switchToPasswordAuth();
+   */
+  async switchToPasswordAuth(): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'switchToPasswordAuth'],
+    };
+
+    await new FormHandler(options).submitData({
+      code: '',
+      action: FormActions.SWITCH_TO_PASSWORD_AUTH,
+    });
+  }
 }
 
 export { PhoneIdentifierChallengeMembers, PhoneChallengeOptions, ScreenOptions as ScreenMembersOnPhoneIdentifierChallenge };


### PR DESCRIPTION
### Changes

#### New Form Action Constants
- `SWITCH_TO_OTP_AUTH` (`switch-to-otp-auth`)
- `SWITCH_TO_PASSWORD_AUTH` (`switch-to-password-auth`)

#### `login-password` screen
- Added `switchToOtpAuth()` — switches from password authentication to OTP authentication (sends `{ action: 'switch-to-otp-auth' }`)

#### `email-identifier-challenge` screen
- Added `switchToPasswordAuth()` — switches from email OTP/code authentication to password authentication (sends `{ code: '', action: 'switch-to-password-auth' }`)

#### `phone-identifier-challenge` screen
- Added `switchToPasswordAuth()` — switches from phone OTP/code authentication to password authentication (sends `{ code: '', action: 'switch-to-password-auth' }`)
