### PR TITLE
fix: add PasswordComplexityPolicy export to common interface

### DIFF
--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,5 +1,5 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, AllowCredential, AuthenticatorTransport } from '../models/screen';
-export type { Connection, EnterpriseConnection, PasswordPolicy, UsernamePolicy, Error, Error as ULError, PasswordComplexityRule } from '../models/transaction';
+export type { Connection, EnterpriseConnection, PasswordPolicy, PasswordComplexityPolicy, UsernamePolicy, Error, Error as ULError, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
 export type { CustomOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, LanguageChangeOptions } from '../common/index';
 export type { OnStatusChangeCallback, StartResendOptions, ResendControl } from '../utils/resend-control';


### PR DESCRIPTION
### Description

This PR is to add the interface reference for `PasswordComplexityPolicy` in docs.


### Testing

- Tested with locally generated docs.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
