### PR TITLE
Expose email on reset-password-email screen data

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/reset-password-email.ts
+++ b/packages/auth0-acul-js/interfaces/screens/reset-password-email.ts
@@ -8,11 +8,13 @@ export interface ResetPasswordEmailOptions {
 
 export interface ScreenDataOptions extends ScreenData {
   username?: string;
+  email?: string;
 }
 
 export interface ScreenMembersOnResetPasswordEmail extends ScreenMembers {
   data: {
     username?: string;
+    email?: string;
   } | null;
 }
 

--- a/packages/auth0-acul-js/src/screens/reset-password-email/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-email/screen-override.ts
@@ -15,6 +15,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     return {
       ...data,
       username: data.username,
+      email: data.email,
     } as OverrideOptions['data'];
   };
 }


### PR DESCRIPTION
### Description
This PR exposes the email field on the reset-password-email screen so it is accessible to frontend consumers via `useScreen().data.email`.

After submitting an email on the reset-password-request screen, the server correctly returns the submitted email address in the screenContext.data for the subsequent reset-password-email screen. However, this value was not accessible from the frontend SDK because:

- reset-password-email/screen-override did not explicitly map the email field into the screen data. (it did this implicitly)
- The ScreenMembersOnResetPasswordEmail interface did not expose email, preventing TypeScript consumers from referencing it.

In practice, username is often unset for this screen, while email contains the relevant value needed to render confirmation UI (e.g. “We sent an email to…”).

### Changes
- Expose email in ScreenMembersOnResetPasswordEmail and ScreenDataOptions
- Map email from screenContext.data in the reset-password-email screen override

This brings the frontend SDK in line with the data already provided by the server and matches developer expectations.

### Impact

- No breaking changes
- Enables access to existing server-provided data
- Improves developer experience when building custom UIs for password reset flows


### References
Related issue:
- https://github.com/auth0/universal-login/issues/328

### Testing
- Manually verified by submitting an email on the reset-password-request screen and accessing useScreen().data.email on the reset-password-email screen.
- No existing tests were modified; this change only exposes already-available data.

### Environment

@auth0/auth0-acul-react: 1.0.0
Browser: Chrome


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
