### PR TITLE
chore: rely on OIDC when publishing to npm

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -3,8 +3,7 @@ name: Publish release to npm
 inputs:
   node-version:
     required: true
-  npm-token:
-    required: true
+  
   version:
     required: true
   require-build:
@@ -27,7 +26,10 @@ runs:
         node-version: 22
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
-        token: ${{ inputs.npm-token }}
+
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@11.10.0
 
     - name: Install dependencies
       shell: bash
@@ -45,7 +47,6 @@ runs:
     - name: Publish release to NPM
       working-directory: packages/${{ inputs.release-directory }}
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}
       run: |
         if [[ "${VERSION}" == *"beta"* ]]; then
@@ -55,5 +56,5 @@ runs:
         else
           TAG="latest"
         fi
-        npm publish --provenance --access public --tag $TAG
+        npm publish --access public --tag $TAG
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: write
-  id-token: write
+  id-token: write # For trusted publishing to npm
 
 jobs:
   release:
@@ -80,13 +80,10 @@ jobs:
         uses: ./.github/actions/npm-publish
         with:
            node-version: 22
-           npm-token: ${{ secrets.NPM_TOKEN }}
            version: ${{ steps.meta.outputs.version }}
            require-build: true
            package: ${{ steps.meta.outputs.dir }}
            release-directory: ${{ steps.meta.outputs.dir }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: ./.github/actions/release-create


### PR DESCRIPTION
## Description

Drop reliance on an NPM token and use **OIDC** instead for publishing SDKs by configuring **trusted publishers**.

## References

* [https://docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers)

## Testing

* This change adds test coverage for new, changed, or fixed functionality.

## Checklist

* [ ] I have added documentation for new or changed functionality in this PR or on **auth0.com/docs**
* [ ] All active GitHub checks for tests, formatting, and security are passing
* [ ] The correct base branch is being used (if not the default branch)

