### PR TITLE
feat: add optional rpId to PasskeyRead and update passkey autofill

### DIFF
--- a/packages/auth0-acul-js/interfaces/models/screen.ts
+++ b/packages/auth0-acul-js/interfaces/models/screen.ts
@@ -18,6 +18,7 @@ export interface PasskeyRead {
   public_key: {
     challenge: Base64URLString;
     allowCredentials?: AllowCredential[];
+    rpId?: string;
   };
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -1,7 +1,7 @@
 import type { IdentifierType } from '../../src/constants';
 import type { CustomOptions } from '../common';
 import type { BaseContext, BaseMembers } from '../models/base-context';
-import type { ScreenContext, ScreenMembers, PasskeyRead } from '../models/screen';
+import type { ScreenContext, ScreenMembers } from '../models/screen';
 import type { TransactionContext, TransactionMembers, DBConnection, PasswordPolicy } from '../models/transaction';
 /**
  * Extended screen context interface for the login screen
@@ -10,9 +10,6 @@ export interface ScreenContextOnLogin extends ScreenContext {
   links: {
     signup: string;
     reset_password: string;
-  };
-  data?: {
-    passkey?: PasskeyRead;
   };
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -1,7 +1,7 @@
 import type { IdentifierType } from '../../src/constants';
 import type { CustomOptions } from '../common';
 import type { BaseContext, BaseMembers } from '../models/base-context';
-import type { ScreenContext, ScreenMembers } from '../models/screen';
+import type { ScreenContext, ScreenMembers, PasskeyRead } from '../models/screen';
 import type { TransactionContext, TransactionMembers, DBConnection, PasswordPolicy } from '../models/transaction';
 /**
  * Extended screen context interface for the login screen
@@ -10,6 +10,9 @@ export interface ScreenContextOnLogin extends ScreenContext {
   links: {
     signup: string;
     reset_password: string;
+  };
+  data?: {
+    passkey?: PasskeyRead;
   };
 }
 

--- a/packages/auth0-acul-js/src/utils/passkeys.ts
+++ b/packages/auth0-acul-js/src/utils/passkeys.ts
@@ -176,7 +176,7 @@ export async function registerPasskeyAutofill({
   const request: CredentialRequestOptions = {
     publicKey: {
       challenge,
-      rpId: window.location.hostname,
+      rpId: publicKey.rpId ?? window.location.hostname,
       allowCredentials: [],
       userVerification: 'preferred',
       timeout: DEFAULT_TIMEOUT

--- a/packages/auth0-acul-js/src/utils/passkeys.ts
+++ b/packages/auth0-acul-js/src/utils/passkeys.ts
@@ -68,6 +68,7 @@ export async function getPasskeyCredentials(
   const credential = (await navigator.credentials.get({
     publicKey: {
       challenge,
+      ...(publicKey.rpId ? { rpId: publicKey.rpId } : {}),
       allowCredentials: publicKey.allowCredentials?.length
       ? publicKey.allowCredentials.map((c) => ({
           id: base64UrlToUint8Array(c.id),
@@ -176,7 +177,7 @@ export async function registerPasskeyAutofill({
   const request: CredentialRequestOptions = {
     publicKey: {
       challenge,
-      rpId: publicKey.rpId ?? window.location.hostname,
+      ...(publicKey.rpId ? { rpId: publicKey.rpId } : {}),
       allowCredentials: [],
       userVerification: 'preferred',
       timeout: DEFAULT_TIMEOUT

--- a/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
@@ -387,6 +387,25 @@ describe('registerPasskeyAutofill', () => {
     );
   });
 
+  it('should fall back to window.location.hostname when rpId is not provided', async () => {
+    const mockCredential = { id: 'mock-credential' };
+    mockGet.mockResolvedValue(mockCredential);
+
+    await registerPasskeyAutofill({
+      publicKey: { challenge: 'mock-challenge' },
+      onResolve,
+      onReject,
+    });
+
+    await Promise.resolve();
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: expect.objectContaining({ rpId: window.location.hostname }),
+      })
+    );
+  });
+
   it('should ignore AbortError exceptions', async () => {
     const abortError = new DOMException('Aborted', 'AbortError');
     mockGet.mockRejectedValue(abortError);

--- a/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
@@ -368,6 +368,25 @@ describe('registerPasskeyAutofill', () => {
     expect(onReject).toHaveBeenCalledWith(error);
   });
 
+  it('should use rpId from publicKey when provided', async () => {
+    const mockCredential = { id: 'mock-credential' };
+    mockGet.mockResolvedValue(mockCredential);
+
+    await registerPasskeyAutofill({
+      publicKey: { challenge: 'mock-challenge', rpId: 'custom.example.com' },
+      onResolve,
+      onReject,
+    });
+
+    await Promise.resolve();
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: expect.objectContaining({ rpId: 'custom.example.com' }),
+      })
+    );
+  });
+
   it('should ignore AbortError exceptions', async () => {
     const abortError = new DOMException('Aborted', 'AbortError');
     mockGet.mockRejectedValue(abortError);

--- a/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
@@ -101,6 +101,53 @@ describe('getPasskeyCredentials', () => {
       Errors.PASSKEY_EXPECTED_ASSERTION_RESPONSE
     );
   });
+
+  it('should forward rpId to navigator.credentials.get when provided', async () => {
+    (isWebAuthPlatformAvailable as jest.Mock).mockResolvedValue(true);
+    const mockCredential = {
+      id: 'mock-id',
+      rawId: new Uint8Array([1, 2, 3]).buffer,
+      type: 'public-key',
+      authenticatorAttachment: 'platform',
+      response: {
+        clientDataJSON: new Uint8Array([4, 5, 6]).buffer,
+        authenticatorData: new Uint8Array([7, 8, 9]).buffer,
+        signature: new Uint8Array([10, 11, 12]).buffer,
+        userHandle: null,
+      },
+    };
+    navigatorGetSpy.mockResolvedValue(mockCredential);
+
+    await getPasskeyCredentials({ challenge: 'mock-challenge', rpId: 'custom.example.com' } as PasskeyRead['public_key']);
+
+    expect(navigatorGetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: expect.objectContaining({ rpId: 'custom.example.com' }),
+      })
+    );
+  });
+
+  it('should omit rpId from navigator.credentials.get when not provided', async () => {
+    (isWebAuthPlatformAvailable as jest.Mock).mockResolvedValue(true);
+    const mockCredential = {
+      id: 'mock-id',
+      rawId: new Uint8Array([1, 2, 3]).buffer,
+      type: 'public-key',
+      authenticatorAttachment: 'platform',
+      response: {
+        clientDataJSON: new Uint8Array([4, 5, 6]).buffer,
+        authenticatorData: new Uint8Array([7, 8, 9]).buffer,
+        signature: new Uint8Array([10, 11, 12]).buffer,
+        userHandle: null,
+      },
+    };
+    navigatorGetSpy.mockResolvedValue(mockCredential);
+
+    await getPasskeyCredentials({ challenge: 'mock-challenge' } as PasskeyRead['public_key']);
+
+    const callArg = navigatorGetSpy.mock.calls[0][0];
+    expect(callArg.publicKey).not.toHaveProperty('rpId');
+  });
 });
 
 describe('createPasskeyCredentials', () => {
@@ -387,7 +434,7 @@ describe('registerPasskeyAutofill', () => {
     );
   });
 
-  it('should fall back to window.location.hostname when rpId is not provided', async () => {
+  it('should omit rpId from the request when rpId is not provided', async () => {
     const mockCredential = { id: 'mock-credential' };
     mockGet.mockResolvedValue(mockCredential);
 
@@ -399,11 +446,8 @@ describe('registerPasskeyAutofill', () => {
 
     await Promise.resolve();
 
-    expect(mockGet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        publicKey: expect.objectContaining({ rpId: window.location.hostname }),
-      })
-    );
+    const callArg = mockGet.mock.calls[0][0];
+    expect(callArg.publicKey).not.toHaveProperty('rpId');
   });
 
   it('should ignore AbortError exceptions', async () => {


### PR DESCRIPTION

## Changes

Adds optional `rpId` to `PasskeyRead.public_key` so the server-supplied Relying Party ID is forwarded to `navigator.credentials.get()` instead of always falling back to `window.location.hostname`.

This field is only present on passkey read screens when the `passkey_rpid` flag is enabled and the tenant has an rpId configured for the domain.
