### PR TITLE
feat: Add switchToPassword and switchToOtp methods to identifier challenge screens

### DIFF
--- a/packages/auth0-acul-js/examples/email-identifier-challenge.md
+++ b/packages/auth0-acul-js/examples/email-identifier-challenge.md
@@ -221,14 +221,16 @@ const EmailIdentifierChallengeScreen: React.FC = () => {
               Return to Previous
             </button>
           </form>
-          <form className="space-y-6 mt-4" onSubmit={handleSwitchToPassword}>
-            <button
-              type="submit"
-              className="w-full py-2 px-4 border border-gray-400 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
-            >
-              Switch to Password
-            </button>
-          </form>
+          {emailIdentifierChallenge.screen.data?.showSwitchToPasswordButton && (
+            <form className="space-y-6 mt-4" onSubmit={handleSwitchToPassword}>
+              <button
+                type="submit"
+                className="w-full py-2 px-4 border border-gray-400 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+              >
+                Switch to Password
+              </button>
+            </form>
+          )}
           {error && <div className="text-red-600 text-sm mt-2">{error}</div>}
           {success && <div className="text-green-600 text-sm mt-2">Challenge submitted successfully!</div>}
           {resent && <div className="text-blue-600 text-sm mt-2">Code resent to your email.</div>}

--- a/packages/auth0-acul-js/examples/email-identifier-challenge.md
+++ b/packages/auth0-acul-js/examples/email-identifier-challenge.md
@@ -36,6 +36,17 @@ emailIdentifierChallenge.returnToPrevious();
 ```
 
 
+## switchToPassword
+
+```typescript
+import EmailIdentifierChallenge from '@auth0/auth0-acul-js/email-identifier-challenge';
+
+const emailIdentifierChallenge = new EmailIdentifierChallenge();
+emailIdentifierChallenge.switchToPassword();
+
+```
+
+
 ## resendManager
 
 ```typescript
@@ -78,6 +89,7 @@ const EmailIdentifierChallengeScreen: React.FC = () => {
   const [resent, setResent] = useState(false);
   const [returned, setReturned] = useState(false);
   const [disabled, setDisabled] = useState(false);
+  const [switchedToPassword, setSwitchedToPassword] = useState(false);
 
   const emailIdentifierChallenge = useMemo(() => new EmailIdentifierChallenge(), []);
 
@@ -145,6 +157,17 @@ const EmailIdentifierChallengeScreen: React.FC = () => {
     }
   };
 
+  const handleSwitchToPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await emailIdentifierChallenge.switchToPassword();
+      setSwitchedToPassword(true);
+    } catch {
+      setError('Failed to switch to password. Please try again later.');
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
@@ -198,10 +221,19 @@ const EmailIdentifierChallengeScreen: React.FC = () => {
               Return to Previous
             </button>
           </form>
+          <form className="space-y-6 mt-4" onSubmit={handleSwitchToPassword}>
+            <button
+              type="submit"
+              className="w-full py-2 px-4 border border-gray-400 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            >
+              Switch to Password
+            </button>
+          </form>
           {error && <div className="text-red-600 text-sm mt-2">{error}</div>}
           {success && <div className="text-green-600 text-sm mt-2">Challenge submitted successfully!</div>}
           {resent && <div className="text-blue-600 text-sm mt-2">Code resent to your email.</div>}
           {returned && <div className="text-blue-600 text-sm mt-2">Returned to previous step.</div>}
+          {switchedToPassword && <div className="text-blue-600 text-sm mt-2">Switched to password authentication.</div>}
         </div>
       </div>
     </div>

--- a/packages/auth0-acul-js/examples/login-password.md
+++ b/packages/auth0-acul-js/examples/login-password.md
@@ -18,10 +18,16 @@ loginPasswordManager.login({
 
 ## switchToOtp
 
+The `showSwitchToOtpButton` screen data flag controls whether this option is available. Only render the button when the server enables it.
+
 ```typescript
 import LoginPassword from "@auth0/auth0-acul-js/login-password";
 
 const loginPasswordManager = new LoginPassword();
-loginPasswordManager.switchToOtp();
+
+// Only call when screen.data.showSwitchToOtpButton is true
+if (loginPasswordManager.screen.data?.showSwitchToOtpButton) {
+  loginPasswordManager.switchToOtp();
+}
 
 ```

--- a/packages/auth0-acul-js/examples/login-password.md
+++ b/packages/auth0-acul-js/examples/login-password.md
@@ -14,3 +14,14 @@ loginPasswordManager.login({
 });
 
 ```
+
+
+## switchToOtp
+
+```typescript
+import LoginPassword from "@auth0/auth0-acul-js/login-password";
+
+const loginPasswordManager = new LoginPassword();
+loginPasswordManager.switchToOtp();
+
+```

--- a/packages/auth0-acul-js/examples/phone-identifier-challenge.md
+++ b/packages/auth0-acul-js/examples/phone-identifier-challenge.md
@@ -36,6 +36,17 @@ phoneIdentifierChallenge.returnToPrevious();
 ```
 
 
+## switchToPassword
+
+```typescript
+import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
+
+const phoneIdentifierChallenge = new PhoneIdentifierChallenge();
+phoneIdentifierChallenge.switchToPassword();
+
+```
+
+
 ## resendManager
 
 ```typescript
@@ -78,6 +89,7 @@ const PhoneIdentifierChallengeScreen: React.FC = () => {
   const [resent, setResent] = useState(false);
   const [returned, setReturned] = useState(false);
   const [disabled, setDisabled] = useState(false);
+  const [switchedToPassword, setSwitchedToPassword] = useState(false);
 
   const phoneIdentifierChallenge = useMemo(() => new PhoneIdentifierChallenge(), []);
 
@@ -145,6 +157,17 @@ const PhoneIdentifierChallengeScreen: React.FC = () => {
     }
   };
 
+  const handleSwitchToPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await phoneIdentifierChallenge.switchToPassword();
+      setSwitchedToPassword(true);
+    } catch {
+      setError('Failed to switch to password. Please try again later.');
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
@@ -198,10 +221,19 @@ const PhoneIdentifierChallengeScreen: React.FC = () => {
               Return to Previous
             </button>
           </form>
+          <form className="space-y-6 mt-4" onSubmit={handleSwitchToPassword}>
+            <button
+              type="submit"
+              className="w-full py-2 px-4 border border-gray-400 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            >
+              Switch to Password
+            </button>
+          </form>
           {error && <div className="text-red-600 text-sm mt-2">{error}</div>}
           {success && <div className="text-green-600 text-sm mt-2">Challenge submitted successfully!</div>}
           {resent && <div className="text-blue-600 text-sm mt-2">Code resent to your phone.</div>}
           {returned && <div className="text-blue-600 text-sm mt-2">Returned to previous step.</div>}
+          {switchedToPassword && <div className="text-blue-600 text-sm mt-2">Switched to password authentication.</div>}
         </div>
       </div>
     </div>

--- a/packages/auth0-acul-js/examples/phone-identifier-challenge.md
+++ b/packages/auth0-acul-js/examples/phone-identifier-challenge.md
@@ -221,14 +221,16 @@ const PhoneIdentifierChallengeScreen: React.FC = () => {
               Return to Previous
             </button>
           </form>
-          <form className="space-y-6 mt-4" onSubmit={handleSwitchToPassword}>
-            <button
-              type="submit"
-              className="w-full py-2 px-4 border border-gray-400 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
-            >
-              Switch to Password
-            </button>
-          </form>
+          {phoneIdentifierChallenge.screen.data?.showSwitchToPasswordButton && (
+            <form className="space-y-6 mt-4" onSubmit={handleSwitchToPassword}>
+              <button
+                type="submit"
+                className="w-full py-2 px-4 border border-gray-400 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+              >
+                Switch to Password
+              </button>
+            </form>
+          )}
           {error && <div className="text-red-600 text-sm mt-2">{error}</div>}
           {success && <div className="text-green-600 text-sm mt-2">Challenge submitted successfully!</div>}
           {resent && <div className="text-blue-600 text-sm mt-2">Code resent to your phone.</div>}

--- a/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
@@ -23,4 +23,5 @@ export interface EmailIdentifierChallengeMembers extends BaseMembers {
   resendCode(payload?: CustomOptions): Promise<void>;
   resendManager(payload?: StartResendOptions): ResendControl;
   returnToPrevious(payload?: CustomOptions): Promise<void>;
+  switchToPassword(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/email-identifier-challenge.ts
@@ -14,6 +14,7 @@ export interface ScreenMembersOnEmailIdentifierChallenge extends ScreenMembers {
     messageType?: string;
     email?: string;
     resendLimitReached?: boolean;
+    showSwitchToPasswordButton?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/login-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-password.ts
@@ -18,6 +18,7 @@ export interface ScreenMembersOnLoginPassword extends ScreenMembers {
   editIdentifierLink: string | null;
   data: {
     username: string;
+    showSwitchToOtpButton?: boolean;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/login-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-password.ts
@@ -1,4 +1,5 @@
 import type { IdentifierType } from '../../src/constants';
+import type { CustomOptions } from '../common';
 import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers } from '../models/screen';
 import type { TransactionContext, TransactionMembers, DBConnection, PasswordPolicy, UsernamePolicy } from '../models/transaction';
@@ -55,15 +56,11 @@ export interface SwitchConnectionOptions {
   [key: string]: string | number | boolean;
 }
 
-export interface SwitchToOtpOptions {
-  [key: string]: string | number | boolean;
-}
-
 export interface LoginPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnLoginPassword;
   transaction: TransactionMembersOnLoginPassword;
   login(payload: LoginPasswordOptions): Promise<void>;
   federatedLogin(payload: FederatedLoginOptions): Promise<void>;
   switchConnection(payload: SwitchConnectionOptions): Promise<void>;
-  switchToOtp(): Promise<void>;
+  switchToOtp(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/login-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-password.ts
@@ -55,10 +55,15 @@ export interface SwitchConnectionOptions {
   [key: string]: string | number | boolean;
 }
 
+export interface SwitchToOtpOptions {
+  [key: string]: string | number | boolean;
+}
+
 export interface LoginPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnLoginPassword;
   transaction: TransactionMembersOnLoginPassword;
   login(payload: LoginPasswordOptions): Promise<void>;
   federatedLogin(payload: FederatedLoginOptions): Promise<void>;
   switchConnection(payload: SwitchConnectionOptions): Promise<void>;
+  switchToOtp(): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
+++ b/packages/auth0-acul-js/interfaces/screens/phone-identifier-challenge.ts
@@ -30,6 +30,7 @@ export interface ScreenMembersOnPhoneIdentifierChallenge extends ScreenMembers {
     resendLimitReached?: boolean;
     showLinkSms?: boolean;
     showLinkVoice?: boolean;
+    showSwitchToPasswordButton?: boolean;
   } | null;
 }
 
@@ -41,4 +42,5 @@ export interface PhoneIdentifierChallengeMembers extends BaseMembers {
   returnToPrevious(payload?: CustomOptions): Promise<void>;
   switchToVoice(payload?: CustomOptions): Promise<void>;
   switchToText(payload?: CustomOptions): Promise<void>;
+  switchToPassword(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/constants/form-actions.ts
+++ b/packages/auth0-acul-js/src/constants/form-actions.ts
@@ -30,4 +30,6 @@ export const FormActions = {
   TRY_AGAIN: 'tryagain' as const,
   USE_PASSWORD: 'use-password' as const,
   CHANGE_LANGUAGE: 'change-language' as const,
+  SWITCH_TO_OTP_AUTH: 'switch-to-otp-auth' as const,
+  SWITCH_TO_PASSWORD_AUTH: 'switch-to-password-auth' as const,
 } as const;

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
@@ -111,6 +111,9 @@ export default class EmailIdentifierChallenge extends BaseContext implements Ema
   }
 
   /**
+   * @remarks
+   * Switches the authentication flow from OTP-based to password-based authentication.
+   *
    * @example
    * import EmailIdentifierChallenge from '@auth0/auth0-acul-js/email-identifier-challenge';
    *

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/index.ts
@@ -109,6 +109,21 @@ export default class EmailIdentifierChallenge extends BaseContext implements Ema
       !!this.screen.data?.resendLimitReached
     );
   }
+
+  /**
+   * @example
+   * import EmailIdentifierChallenge from '@auth0/auth0-acul-js/email-identifier-challenge';
+   *
+   * const emailIdentifierChallenge = new EmailIdentifierChallenge();
+   * emailIdentifierChallenge.switchToPassword();
+   */
+  async switchToPassword(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [EmailIdentifierChallenge.screenIdentifier, 'switchToPassword'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.SWITCH_TO_PASSWORD_AUTH });
+  }
 }
 
 export { EmailIdentifierChallengeMembers, ScreenOptions as ScreenMembersOnEmailIdentifierChallenge, EmailChallengeOptions };

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/screen-override.ts
@@ -9,7 +9,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     this.data = ScreenOverride.getScreenData(screenContext);
   }
 
-  static getScreenData = (screenContext: ScreenContext): OverrideOptions['data'] => {
+  static getScreenData(screenContext: ScreenContext): OverrideOptions['data'] {
     const data = screenContext.data;
     if (!data) return null;
 
@@ -21,5 +21,5 @@ export class ScreenOverride extends Screen implements OverrideOptions {
       messageType: message_type,
       showSwitchToPasswordButton: show_switch_to_password_button,
     } as OverrideOptions['data'];
-  };
+  }
 }

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/screen-override.ts
@@ -15,10 +15,13 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     const { message_type, email, ...rest } = data;
 
+    const { show_switch_to_password_button, ...remaining } = rest;
+
     return {
-      ...rest,
+      ...remaining,
       email: email,
       messageType: message_type,
+      showSwitchToPasswordButton: show_switch_to_password_button,
     } as OverrideOptions['data'];
   };
 }

--- a/packages/auth0-acul-js/src/screens/email-identifier-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/email-identifier-challenge/screen-override.ts
@@ -13,9 +13,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     const data = screenContext.data;
     if (!data) return null;
 
-    const { message_type, email, ...rest } = data;
-
-    const { show_switch_to_password_button, ...remaining } = rest;
+    const { message_type, email, show_switch_to_password_button, ...remaining } = data;
 
     return {
       ...remaining,

--- a/packages/auth0-acul-js/src/screens/login-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/index.ts
@@ -1,4 +1,4 @@
-import { ScreenIds } from '../../constants';
+import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { getBrowserCapabilities } from '../../utils/browser-capabilities';
 import { FormHandler } from '../../utils/form-handler';
@@ -14,6 +14,7 @@ import type {
   LoginPasswordMembers,
   FederatedLoginOptions,
   SwitchConnectionOptions,
+  SwitchToOtpOptions,
   TransactionMembersOnLoginPassword as TransactionOptions,
 } from '../../../interfaces/screens/login-password';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
@@ -110,6 +111,27 @@ export default class LoginPassword extends BaseContext implements LoginPasswordM
 
     await new FormHandler(options).submitData<SwitchConnectionOptions>(payload);
   }
+
+  /**
+   * @remarks
+   * Switches the authentication flow from password-based to OTP (one-time password) authentication.
+   *
+   * @example
+   * import LoginPassword from "@auth0/auth0-acul-js/login-password";
+   *
+   * const loginPasswordManager = new LoginPassword();
+   * loginPasswordManager.switchToOtp();
+   */
+  async switchToOtp(): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [LoginPassword.screenIdentifier, 'switchToOtp'],
+    };
+
+    await new FormHandler(options).submitData<SwitchToOtpOptions>({
+      action: FormActions.SWITCH_TO_OTP_AUTH,
+    });
+  }
 }
 
 export {
@@ -117,6 +139,7 @@ export {
   LoginPasswordOptions,
   FederatedLoginOptions,
   SwitchConnectionOptions,
+  SwitchToOtpOptions,
   ScreenOptions as ScreenMembersOnLoginPassword,
   TransactionOptions as TransactionMembersOnLoginPassword,
 };

--- a/packages/auth0-acul-js/src/screens/login-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/index.ts
@@ -6,6 +6,7 @@ import { FormHandler } from '../../utils/form-handler';
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
+import type { CustomOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -14,7 +15,6 @@ import type {
   LoginPasswordMembers,
   FederatedLoginOptions,
   SwitchConnectionOptions,
-  SwitchToOtpOptions,
   TransactionMembersOnLoginPassword as TransactionOptions,
 } from '../../../interfaces/screens/login-password';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
@@ -122,13 +122,14 @@ export default class LoginPassword extends BaseContext implements LoginPasswordM
    * const loginPasswordManager = new LoginPassword();
    * loginPasswordManager.switchToOtp();
    */
-  async switchToOtp(): Promise<void> {
+  async switchToOtp(payload?: CustomOptions): Promise<void> {
     const options: FormOptions = {
       state: this.transaction.state,
       telemetry: [LoginPassword.screenIdentifier, 'switchToOtp'],
     };
 
-    await new FormHandler(options).submitData<SwitchToOtpOptions>({
+    await new FormHandler(options).submitData<CustomOptions>({
+      ...payload,
       action: FormActions.SWITCH_TO_OTP_AUTH,
     });
   }
@@ -139,7 +140,6 @@ export {
   LoginPasswordOptions,
   FederatedLoginOptions,
   SwitchConnectionOptions,
-  SwitchToOtpOptions,
   ScreenOptions as ScreenMembersOnLoginPassword,
   TransactionOptions as TransactionMembersOnLoginPassword,
 };

--- a/packages/auth0-acul-js/src/screens/login-password/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/screen-override.ts
@@ -15,6 +15,16 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     this.signupLink = getSignupLink(screenContext);
     this.resetPasswordLink = getResetPasswordLink(screenContext);
     this.editIdentifierLink = getEditIdentifierLink(screenContext);
-    this.data = Screen.getScreenData(screenContext) as OverrideOptions['data'];
+    this.data = ScreenOverride.getScreenData(screenContext);
+  }
+
+  static getScreenData(screenContext: ScreenContext): OverrideOptions['data'] {
+    const data = screenContext.data;
+    if (!data) return null;
+
+    return {
+      ...data,
+      showSwitchToOtpButton: data.show_switch_to_otp_button,
+    } as OverrideOptions['data'];
   }
 }

--- a/packages/auth0-acul-js/src/screens/login-password/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login-password/screen-override.ts
@@ -24,7 +24,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
     return {
       ...data,
-      showSwitchToOtpButton: data.show_switch_to_otp_button,
+      showSwitchToOtpButton: data?.show_switch_to_otp_button,
     } as OverrideOptions['data'];
   }
 }

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -143,6 +143,9 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
   }
 
   /**
+   * @remarks
+   * Switches the authentication flow from OTP-based to password-based authentication.
+   *
    * @example
    * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
    *

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/index.ts
@@ -141,6 +141,21 @@ export default class PhoneIdentifierChallenge extends BaseContext implements Pho
       !!this.screen.data?.resendLimitReached
     );
   }
+
+  /**
+   * @example
+   * import PhoneIdentifierChallenge from '@auth0/auth0-acul-js/phone-identifier-challenge';
+   *
+   * const phoneIdentifierChallenge = new PhoneIdentifierChallenge();
+   * phoneIdentifierChallenge.switchToPassword();
+   */
+  async switchToPassword(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [PhoneIdentifierChallenge.screenIdentifier, 'switchToPassword'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.SWITCH_TO_PASSWORD_AUTH });
+  }
 }
 
 export { PhoneIdentifierChallengeMembers, PhoneChallengeOptions, ScreenOptions as ScreenMembersOnPhoneIdentifierChallenge };

--- a/packages/auth0-acul-js/src/screens/phone-identifier-challenge/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/phone-identifier-challenge/screen-override.ts
@@ -22,6 +22,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
       messageType: data?.message_type,
       showLinkSms: data?.show_link_sms,
       showLinkVoice: data?.show_link_voice,
+      showSwitchToPasswordButton: data?.show_switch_to_password_button,
     } as OverrideOptions['data'];
   }
 }

--- a/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
@@ -138,6 +138,36 @@ describe('EmailIdentifierChallenge', () => {
     });
   });
 
+  describe('switchToPassword method', () => {
+    it('should submit switch-to-password-auth action', async () => {
+      await emailIdentifierChallenge.switchToPassword();
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'switch-to-password-auth' })
+      );
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: emailIdentifierChallenge.transaction.state,
+        telemetry: [ScreenIds.EMAIL_IDENTIFIER_CHALLENGE, 'switchToPassword'],
+      });
+    });
+
+    it('should merge custom payload with switch-to-password-auth action', async () => {
+      const payload: CustomOptions = { custom: 'value' };
+      await emailIdentifierChallenge.switchToPassword(payload);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ ...payload, action: 'switch-to-password-auth' })
+      );
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Switch failed'));
+
+      await expect(emailIdentifierChallenge.switchToPassword()).rejects.toThrow('Switch failed');
+    });
+  });
+
   describe('class properties and constructor', () => {
     it('should have correct screen identifier', () => {
       expect(EmailIdentifierChallenge.screenIdentifier).toBe('email-identifier-challenge');

--- a/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/index.test.ts
@@ -144,7 +144,7 @@ describe('EmailIdentifierChallenge', () => {
 
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'switch-to-password-auth' })
+        expect.objectContaining({ action: FormActions.SWITCH_TO_PASSWORD_AUTH })
       );
       expect(FormHandler).toHaveBeenCalledWith({
         state: emailIdentifierChallenge.transaction.state,
@@ -157,7 +157,7 @@ describe('EmailIdentifierChallenge', () => {
       await emailIdentifierChallenge.switchToPassword(payload);
 
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({ ...payload, action: 'switch-to-password-auth' })
+        expect.objectContaining({ ...payload, action: FormActions.SWITCH_TO_PASSWORD_AUTH })
       );
     });
 

--- a/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/email-identifier-challenge/screen-override.test.ts
@@ -11,44 +11,73 @@ describe('ScreenOverride', () => {
   beforeEach(() => {
     screenContext = {
       name: 'email-identifier-challenge',
-      data: { email: 'test@example.com', message_type: 'otp' },
+      data: {
+        email: 'test@example.com',
+        message_type: 'otp',
+        show_switch_to_password_button: true,
+      },
     } as ScreenContext;
-
-    (Screen.getScreenData as jest.Mock).mockReturnValue({
-      email: 'test@example.com',
-      messageType: 'otp',
-    });
 
     screenOverride = new ScreenOverride(screenContext);
   });
 
-  it('should initialize data correctly', () => {
-    expect(screenOverride.data).toEqual({
-      email: 'test@example.com',
-      messageType: 'otp',
-    });
-  });
-
-  it('should call Screen.getScreenData with screenContext', () => {
-    expect(Screen.getScreenData).toHaveBeenCalledTimes(1);
-    expect(Screen.getScreenData).toHaveBeenCalledWith(screenContext);
-  });
-
-  it('should return null if screenContext.data is missing', () => {
-    const emptyContext = { name: 'email-identifier-challenge' } as ScreenContext;
-    const result = ScreenOverride.getScreenData(emptyContext);
-    expect(result).toBeNull();
-  });
-
-  it.only('should return transformed data with email and messageType', () => {
-    const result = ScreenOverride.getScreenData(screenContext);
-    expect(result).toEqual({
-      email: 'test@example.com',
-      messageType: 'otp',
-    });
-  });
-
   it('should extend Screen class', () => {
     expect(screenOverride).toBeInstanceOf(Screen);
+  });
+
+  it('should initialize data correctly', () => {
+    expect(screenOverride.data).toEqual(
+      expect.objectContaining({
+        email: 'test@example.com',
+        messageType: 'otp',
+        showSwitchToPasswordButton: true,
+      })
+    );
+  });
+
+  it('should call getScreenData with correct screenContext', () => {
+    const getScreenDataSpy = jest.spyOn(ScreenOverride, 'getScreenData');
+
+    screenOverride = new ScreenOverride(screenContext);
+
+    expect(getScreenDataSpy).toHaveBeenCalledWith(screenContext);
+  });
+
+  describe('getScreenData static method', () => {
+    it('should return null if screenContext.data is missing', () => {
+      const emptyContext = { name: 'email-identifier-challenge' } as ScreenContext;
+      expect(ScreenOverride.getScreenData(emptyContext)).toBeNull();
+    });
+
+    it('should return null if screenContext.data is null', () => {
+      const nullContext = { name: 'email-identifier-challenge', data: null } as unknown as ScreenContext;
+      expect(ScreenOverride.getScreenData(nullContext)).toBeNull();
+    });
+
+    it('should map message_type to messageType', () => {
+      const result = ScreenOverride.getScreenData(screenContext);
+      expect(result?.messageType).toBe('otp');
+    });
+
+    it('should map show_switch_to_password_button to showSwitchToPasswordButton', () => {
+      const result = ScreenOverride.getScreenData(screenContext);
+      expect(result?.showSwitchToPasswordButton).toBe(true);
+    });
+
+    it('should exclude raw snake_case keys from output', () => {
+      const result = ScreenOverride.getScreenData(screenContext) as Record<string, unknown>;
+      expect(result?.message_type).toBeUndefined();
+      expect(result?.show_switch_to_password_button).toBeUndefined();
+    });
+
+    it('should handle data without show_switch_to_password_button', () => {
+      const context = {
+        name: 'email-identifier-challenge',
+        data: { email: 'user@example.com', message_type: 'otp' },
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(context);
+      expect(result?.showSwitchToPasswordButton).toBeUndefined();
+    });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
@@ -267,4 +267,25 @@ describe('LoginPassword', () => {
       );
     });
   });
+
+  describe('switchToOtp method', () => {
+    it('should submit switch-to-otp-auth action', async () => {
+      await loginPassword.switchToOtp();
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'switch-to-otp-auth' })
+      );
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: loginPassword.transaction.state,
+        telemetry: [ScreenIds.LOGIN_PASSWORD, 'switchToOtp'],
+      });
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Switch failed'));
+
+      await expect(loginPassword.switchToOtp()).rejects.toThrow('Switch failed');
+    });
+  });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-password/index.test.ts
@@ -1,4 +1,4 @@
-import { ScreenIds } from '../../../../src/constants';
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import LoginPassword from '../../../../src/screens/login-password';
 import { getBrowserCapabilities } from '../../../../src/utils/browser-capabilities';
 import { FormHandler } from '../../../../src/utils/form-handler';
@@ -274,12 +274,20 @@ describe('LoginPassword', () => {
 
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'switch-to-otp-auth' })
+        expect.objectContaining({ action: FormActions.SWITCH_TO_OTP_AUTH })
       );
       expect(FormHandler).toHaveBeenCalledWith({
         state: loginPassword.transaction.state,
         telemetry: [ScreenIds.LOGIN_PASSWORD, 'switchToOtp'],
       });
+    });
+
+    it('should merge custom payload with switch-to-otp-auth action', async () => {
+      await loginPassword.switchToOtp({ custom: 'value' });
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ custom: 'value', action: FormActions.SWITCH_TO_OTP_AUTH })
+      );
     });
 
     it('should throw error when promise is rejected', async () => {

--- a/packages/auth0-acul-js/tests/unit/screens/login-password/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-password/screen-override.test.ts
@@ -11,12 +11,17 @@ describe('ScreenOverride', () => {
   let screenOverride: ScreenOverride;
 
   beforeEach(() => {
-    screenContext = {} as ScreenContext;
+    screenContext = {
+      name: 'login-password',
+      data: {
+        username: 'testuser@example.com',
+        show_switch_to_otp_button: true,
+      },
+    } as ScreenContext;
 
     (getSignupLink as jest.Mock).mockReturnValue('mockSignupLink');
     (getResetPasswordLink as jest.Mock).mockReturnValue('mockResetPasswordLink');
     (getEditIdentifierLink as jest.Mock).mockReturnValue('mockEditIdentifierLink');
-    (Screen.getScreenData as jest.Mock).mockReturnValue({ mockData: 'mockData' });
 
     screenOverride = new ScreenOverride(screenContext);
   });
@@ -34,27 +39,79 @@ describe('ScreenOverride', () => {
   });
 
   it('should initialize data correctly', () => {
-    expect(screenOverride.data).toEqual({ mockData: 'mockData' });
+    expect(screenOverride.data).toEqual(
+      expect.objectContaining({
+        username: 'testuser@example.com',
+        showSwitchToOtpButton: true,
+      })
+    );
   });
 
   it('should call shared functions with correct screenContext', () => {
     expect(getSignupLink).toHaveBeenCalledWith(screenContext);
     expect(getResetPasswordLink).toHaveBeenCalledWith(screenContext);
     expect(getEditIdentifierLink).toHaveBeenCalledWith(screenContext);
-    expect(Screen.getScreenData).toHaveBeenCalledWith(screenContext);
+  });
+
+  it('should call getScreenData with correct screenContext', () => {
+    const getScreenDataSpy = jest.spyOn(ScreenOverride, 'getScreenData');
+
+    screenOverride = new ScreenOverride(screenContext);
+
+    expect(getScreenDataSpy).toHaveBeenCalledWith(screenContext);
+  });
+
+  it('should create an instance of Screen', () => {
+    expect(screenOverride).toBeInstanceOf(Screen);
   });
 
   it('should handle missing screenContext properties gracefully', () => {
     (getSignupLink as jest.Mock).mockReturnValue(undefined);
     (getResetPasswordLink as jest.Mock).mockReturnValue(undefined);
     (getEditIdentifierLink as jest.Mock).mockReturnValue(undefined);
-    (Screen.getScreenData as jest.Mock).mockReturnValue(undefined);
 
-    const emptyScreenOverride = new ScreenOverride({} as ScreenContext);
+    const emptyScreenOverride = new ScreenOverride({ data: null } as unknown as ScreenContext);
 
     expect(emptyScreenOverride.signupLink).toBeUndefined();
     expect(emptyScreenOverride.resetPasswordLink).toBeUndefined();
     expect(emptyScreenOverride.editIdentifierLink).toBeUndefined();
-    expect(emptyScreenOverride.data).toBeUndefined();
+    expect(emptyScreenOverride.data).toBeNull();
+  });
+
+  describe('getScreenData static method', () => {
+    it('should map show_switch_to_otp_button to showSwitchToOtpButton', () => {
+      const result = ScreenOverride.getScreenData(screenContext);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          username: 'testuser@example.com',
+          showSwitchToOtpButton: true,
+        })
+      );
+    });
+
+    it('should return null when screenContext.data is null', () => {
+      const nullContext = { name: 'login-password', data: null } as unknown as ScreenContext;
+      expect(ScreenOverride.getScreenData(nullContext)).toBeNull();
+    });
+
+    it('should return null when screenContext.data is undefined', () => {
+      const undefinedContext = { name: 'login-password' } as ScreenContext;
+      expect(ScreenOverride.getScreenData(undefinedContext)).toBeNull();
+    });
+
+    it('should handle data without show_switch_to_otp_button', () => {
+      const context = {
+        name: 'login-password',
+        data: { username: 'user@example.com' },
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(context);
+
+      expect(result).toEqual(
+        expect.objectContaining({ username: 'user@example.com' })
+      );
+      expect(result?.showSwitchToOtpButton).toBeUndefined();
+    });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
@@ -145,7 +145,7 @@ describe('PhoneIdentifierChallenge', () => {
 
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'switch-to-password-auth' })
+        expect.objectContaining({ action: FormActions.SWITCH_TO_PASSWORD_AUTH })
       );
       expect(FormHandler).toHaveBeenCalledWith({
         state: phoneIdentifierChallenge.transaction.state,
@@ -158,7 +158,7 @@ describe('PhoneIdentifierChallenge', () => {
       await phoneIdentifierChallenge.switchToPassword(payload);
 
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({ ...payload, action: 'switch-to-password-auth' })
+        expect.objectContaining({ ...payload, action: FormActions.SWITCH_TO_PASSWORD_AUTH })
       );
     });
 

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/index.test.ts
@@ -139,6 +139,36 @@ describe('PhoneIdentifierChallenge', () => {
     });
   });
 
+  describe('switchToPassword method', () => {
+    it('should submit switch-to-password-auth action', async () => {
+      await phoneIdentifierChallenge.switchToPassword();
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'switch-to-password-auth' })
+      );
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: phoneIdentifierChallenge.transaction.state,
+        telemetry: [ScreenIds.PHONE_IDENTIFIER_CHALLENGE, 'switchToPassword'],
+      });
+    });
+
+    it('should merge custom payload with switch-to-password-auth action', async () => {
+      const payload: CustomOptions = { custom: 'value' };
+      await phoneIdentifierChallenge.switchToPassword(payload);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ ...payload, action: 'switch-to-password-auth' })
+      );
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Switch failed'));
+
+      await expect(phoneIdentifierChallenge.switchToPassword()).rejects.toThrow('Switch failed');
+    });
+  });
+
   describe('resendManager method', () => {
     let mockCreateResendControl: jest.Mock;
     let mockResendControl: { startResend: jest.Mock };

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/screen-override.test.ts
@@ -154,7 +154,10 @@ describe('ScreenOverride', () => {
         phone_number: '+9876543210',
         customField: 'customValue',
         phone: '+9876543210',
-        messageType: undefined
+        messageType: undefined,
+        showLinkSms: undefined,
+        showLinkVoice: undefined,
+        showSwitchToPasswordButton: undefined,
       });
     });
 
@@ -168,7 +171,7 @@ describe('ScreenOverride', () => {
 
       expect(result).toEqual({
         phone: undefined,
-        messageType: undefined
+        messageType: undefined,
       });
     });
 
@@ -191,7 +194,10 @@ describe('ScreenOverride', () => {
         custom_field: 'custom_value',
         extra_field: 'extra_value',
         phone: '+5555555555',
-        messageType: 'voice'
+        messageType: 'voice',
+        showLinkSms: undefined,
+        showLinkVoice: undefined,
+        showSwitchToPasswordButton: undefined,
       });
     });
 
@@ -210,7 +216,10 @@ describe('ScreenOverride', () => {
         phone_number: '',
         message_type: 'sms',
         phone: '',
-        messageType: 'sms'
+        messageType: 'sms',
+        showLinkSms: undefined,
+        showLinkVoice: undefined,
+        showSwitchToPasswordButton: undefined,
       });
     });
 
@@ -229,7 +238,10 @@ describe('ScreenOverride', () => {
         phone_number: '+1234567890',
         message_type: '',
         phone: '+1234567890',
-        messageType: ''
+        messageType: '',
+        showLinkSms: undefined,
+        showLinkVoice: undefined,
+        showSwitchToPasswordButton: undefined,
       });
     });
   });

--- a/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/phone-identifier-challenge/screen-override.test.ts
@@ -15,6 +15,9 @@ describe('ScreenOverride', () => {
       data: {
         phone_number: '+1234567890',
         message_type: 'sms',
+        show_link_sms: true,
+        show_link_voice: false,
+        show_switch_to_password_button: true,
       },
     } as ScreenContext;
 
@@ -23,12 +26,15 @@ describe('ScreenOverride', () => {
 
   describe('constructor', () => {
     it('should initialize data correctly with valid screen context', () => {
-      expect(screenOverride.data).toEqual({
-        phone_number: '+1234567890',
-        message_type: 'sms',
-        phone: '+1234567890',
-        messageType: 'sms',
-      });
+      expect(screenOverride.data).toEqual(
+        expect.objectContaining({
+          phone: '+1234567890',
+          messageType: 'sms',
+          showLinkSms: true,
+          showLinkVoice: false,
+          showSwitchToPasswordButton: true,
+        })
+      );
     });
 
     it('should call getScreenData with correct screenContext', () => {
@@ -67,15 +73,52 @@ describe('ScreenOverride', () => {
   });
 
   describe('getScreenData static method', () => {
-    it('should map phone_number to phone and message_type to messageType', () => {
+    it('should map all fields correctly', () => {
       const result = ScreenOverride.getScreenData(screenContext);
 
-      expect(result).toEqual({
-        phone_number: '+1234567890',
-        message_type: 'sms',
-        phone: '+1234567890',
-        messageType: 'sms',
-      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          phone: '+1234567890',
+          messageType: 'sms',
+          showLinkSms: true,
+          showLinkVoice: false,
+          showSwitchToPasswordButton: true,
+        })
+      );
+    });
+
+    it('should return undefined phone when phone_number is absent', () => {
+      const context = {
+        name: 'phone-identifier-challenge',
+        data: { message_type: 'text' },
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(context);
+
+      expect(result?.phone).toBeUndefined();
+    });
+
+    it('should map show_switch_to_password_button to showSwitchToPasswordButton', () => {
+      const context = {
+        name: 'phone-identifier-challenge',
+        data: { show_switch_to_password_button: true },
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(context);
+
+      expect(result?.showSwitchToPasswordButton).toBe(true);
+    });
+
+    it('should map show_link_sms and show_link_voice correctly', () => {
+      const context = {
+        name: 'phone-identifier-challenge',
+        data: { show_link_sms: false, show_link_voice: true },
+      } as ScreenContext;
+
+      const result = ScreenOverride.getScreenData(context);
+
+      expect(result?.showLinkSms).toBe(false);
+      expect(result?.showLinkVoice).toBe(true);
     });
 
     it('should return null when screenContext.data is undefined', () => {

--- a/packages/auth0-acul-react/src/screens/email-identifier-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/email-identifier-challenge.tsx
@@ -37,6 +37,8 @@ export const submitEmailChallenge = (payload: EmailChallengeOptions) =>
 export const resendCode = (payload?: CustomOptions) => withError(instance.resendCode(payload));
 export const returnToPrevious = (payload?: CustomOptions) =>
   withError(instance.returnToPrevious(payload));
+export const switchToPassword = (payload?: CustomOptions) =>
+  withError(instance.switchToPassword(payload));
 
 // Utility Hooks
 export { useResend } from '../hooks/utility/resend-manager';

--- a/packages/auth0-acul-react/src/screens/login-password.tsx
+++ b/packages/auth0-acul-react/src/screens/login-password.tsx
@@ -10,6 +10,7 @@ import type {
   LoginPasswordOptions,
   FederatedLoginOptions,
   SwitchConnectionOptions,
+  CustomOptions,
 } from '@auth0/auth0-acul-js/login-password';
 
 // Register the singleton instance of LoginPassword
@@ -38,7 +39,7 @@ export const federatedLogin = (payload: FederatedLoginOptions) =>
   withError(instance.federatedLogin(payload));
 export const switchConnection = (payload: SwitchConnectionOptions) =>
   withError(instance.switchConnection(payload));
-export const switchToOtp = () => withError(instance.switchToOtp());
+export const switchToOtp = (payload?: CustomOptions) => withError(instance.switchToOtp(payload));
 
 // Common hooks
 export { useCurrentScreen, useErrors, useAuth0Themes, useChangeLanguage } from '../hooks';

--- a/packages/auth0-acul-react/src/screens/login-password.tsx
+++ b/packages/auth0-acul-react/src/screens/login-password.tsx
@@ -38,6 +38,7 @@ export const federatedLogin = (payload: FederatedLoginOptions) =>
   withError(instance.federatedLogin(payload));
 export const switchConnection = (payload: SwitchConnectionOptions) =>
   withError(instance.switchConnection(payload));
+export const switchToOtp = () => withError(instance.switchToOtp());
 
 // Common hooks
 export { useCurrentScreen, useErrors, useAuth0Themes, useChangeLanguage } from '../hooks';

--- a/packages/auth0-acul-react/src/screens/phone-identifier-challenge.tsx
+++ b/packages/auth0-acul-react/src/screens/phone-identifier-challenge.tsx
@@ -40,6 +40,8 @@ export const returnToPrevious = (payload?: CustomOptions) =>
 export const switchToVoice = (payload?: CustomOptions) =>
   withError(instance.switchToVoice(payload));
 export const switchToText = (payload?: CustomOptions) => withError(instance.switchToText(payload));
+export const switchToPassword = (payload?: CustomOptions) =>
+  withError(instance.switchToPassword(payload));
 
 // Utility Hooks
 export { useResend } from '../hooks/utility/resend-manager';


### PR DESCRIPTION
## Summary

- Adds `switchToPassword()` method to `EmailIdentifierChallenge` and `PhoneIdentifierChallenge` screens, allowing users to switch from OTP-based authentication to password-based authentication
- Adds `switchToOtp()` method to `LoginPassword` screen, allowing users to switch from password-based to OTP authentication
- Exposes `showSwitchToPasswordButton` screen data field on `EmailIdentifierChallenge` and `PhoneIdentifierChallenge` — server-driven flag controlling button visibility
- Exposes `showSwitchToOtpButton` screen data field on `LoginPassword` - server-driven flag controlling button visibility

## Changes

### `auth0-acul-js`

**EmailIdentifierChallenge**
- Added `switchToPassword(payload?: CustomOptions): Promise<void>` method - submits `SWITCH_TO_PASSWORD_AUTH` form action
- Added `showSwitchToPasswordButton?: boolean` to `ScreenMembersOnEmailIdentifierChallenge.data`
- Added `switchToPassword` to the `EmailIdentifierChallengeMembers` interface

**PhoneIdentifierChallenge**
- Added `switchToPassword(payload?: CustomOptions): Promise<void>` method - submits `SWITCH_TO_PASSWORD_AUTH` form action
- Added `showSwitchToPasswordButton?: boolean` to `ScreenMembersOnPhoneIdentifierChallenge.data`
- Added `switchToPassword` to the `PhoneIdentifierChallengeMembers` interface

**LoginPassword**
- Added `switchToOtp(payload?: CustomOptions): Promise<void>` method - submits `SWITCH_TO_OTP_AUTH` form action
- Added `showSwitchToOtpButton?: boolean` to `ScreenMembersOnLoginPassword.data`
- Added `switchToOtp` to the `LoginPasswordMembers` interface


### `auth0-acul-react`

- Updated `EmailIdentifierChallenge`, `PhoneIdentifierChallenge`, and `LoginPassword` screen wrappers to re-export the new methods

## Test plan

- [x] `EmailIdentifierChallenge.switchToPassword` unit test - verifies correct action and telemetry
- [x] `PhoneIdentifierChallenge.switchToPassword` unit test - verifies correct action and telemetry
- [x] `LoginPassword.switchToOtp` unit test - verifies correct action and telemetry
