### PR TITLE
fix(auth0-acul-js): support excludeCredentials in passkey create flow [EMBL-1061]

### DIFF
--- a/packages/auth0-acul-js/interfaces/models/screen.ts
+++ b/packages/auth0-acul-js/interfaces/models/screen.ts
@@ -45,6 +45,11 @@ export interface PasskeyCreate {
       userVerification: string;
       authenticatorAttachment?: string;
     };
+    excludeCredentials?: {
+      id: string;
+      type: string;
+      transports?: AuthenticatorTransport[] | undefined;
+    }[];
   };
 }
 

--- a/packages/auth0-acul-js/src/utils/passkeys.ts
+++ b/packages/auth0-acul-js/src/utils/passkeys.ts
@@ -13,7 +13,7 @@ function safeBase64Url(buffer: ArrayBuffer | null): string | null {
 function decodePublicKey(
   publicKey: PasskeyCreate["public_key"]
 ): PublicKeyCredentialCreationOptions {
-  const { challenge, user, authenticatorSelection, pubKeyCredParams, rp } =
+  const { challenge, user, authenticatorSelection, pubKeyCredParams, rp, excludeCredentials } =
     publicKey;
   const decodedUser: PublicKeyCredentialUserEntity = {
     id: base64UrlToUint8Array(user.id),
@@ -44,7 +44,16 @@ function decodePublicKey(
         | "platform"
         | "cross-platform"
         | undefined,
-    } : undefined
+    } : undefined,
+    ...(excludeCredentials && excludeCredentials.length > 0
+      ? {
+          excludeCredentials: excludeCredentials.map((cred) => ({
+            id: base64UrlToUint8Array(cred.id),
+            type: 'public-key',
+            ...cred.transports && { transports: cred.transports },
+          })),
+        }
+      : {}),
   };
 }
 

--- a/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/passkeys.test.ts
@@ -466,3 +466,79 @@ describe('registerPasskeyAutofill', () => {
     expect(onReject).not.toHaveBeenCalled();
   });
 });
+
+describe('createPasskeyCredentials / decodePublicKey', () => {
+  let createMock: jest.Mock;
+  const originalNavigator = Object.getOwnPropertyDescriptor(global, 'navigator');
+
+  const basePublicKey: PasskeyCreate['public_key'] = {
+    user: { id: 'dXNlcklk', name: 'user@example.com', displayName: 'User' },
+    rp: { id: 'example.com', name: 'Example' },
+    challenge: 'Y2hhbGxlbmdl',
+    pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+    authenticatorSelection: { residentKey: 'required', userVerification: 'preferred' },
+  };
+
+  const credentialResult = {
+    id: 'credId',
+    rawId: new Uint8Array([1, 2, 3]).buffer,
+    type: 'public-key',
+    authenticatorAttachment: 'platform',
+    response: {
+      clientDataJSON: new Uint8Array([4, 5]).buffer,
+      attestationObject: new Uint8Array([6, 7]).buffer,
+      getTransports: () => ['internal'],
+    },
+  };
+
+  beforeEach(() => {
+    createMock = jest.fn().mockResolvedValue(credentialResult);
+    Object.defineProperty(global, 'navigator', {
+      value: { credentials: { create: createMock } },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalNavigator) {
+      Object.defineProperty(global, 'navigator', originalNavigator);
+    } else {
+      delete (global as { navigator?: unknown }).navigator;
+    }
+  });
+
+  it('decodes excludeCredentials ids and preserves type/transports', async () => {
+    const publicKey: PasskeyCreate['public_key'] = {
+      ...basePublicKey,
+      excludeCredentials: [
+        { id: 'ZXhjbHVkZWRJZA', type: 'public-key', transports: ['internal', 'hybrid'] },
+        { id: 'c2Vjb25kSWQ', type: 'public-key' },
+      ],
+    };
+
+    await createPasskeyCredentials(publicKey);
+
+    const passedOptions = createMock.mock.calls[0][0].publicKey as PublicKeyCredentialCreationOptions;
+    expect(passedOptions.excludeCredentials).toHaveLength(2);
+    expect(passedOptions.excludeCredentials![0].id).toEqual(base64UrlToUint8Array('ZXhjbHVkZWRJZA'));
+    expect(passedOptions.excludeCredentials![0].type).toBe('public-key');
+    expect(passedOptions.excludeCredentials![0].transports).toEqual(['internal', 'hybrid']);
+    expect(passedOptions.excludeCredentials![1].id).toEqual(base64UrlToUint8Array('c2Vjb25kSWQ'));
+    expect(passedOptions.excludeCredentials![1].transports).toBeUndefined();
+  });
+
+  it('omits excludeCredentials when absent', async () => {
+    await createPasskeyCredentials(basePublicKey);
+
+    const passedOptions = createMock.mock.calls[0][0].publicKey as PublicKeyCredentialCreationOptions;
+    expect(passedOptions.excludeCredentials).toBeUndefined();
+  });
+
+  it('omits excludeCredentials when empty', async () => {
+    await createPasskeyCredentials({ ...basePublicKey, excludeCredentials: [] });
+
+    const passedOptions = createMock.mock.calls[0][0].publicKey as PublicKeyCredentialCreationOptions;
+    expect(passedOptions.excludeCredentials).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description
Adds support for the WebAuthn `excludeCredentials` option in the passkey create (registration) flow. This lets the server signal already-registered credentials so the authenticator can prevent re-registering an existing passkey.

### Changes
- Add optional `excludeCredentials` to the `PasskeyCreate.public_key` interface.
- Map `excludeCredentials` in `decodePublicKey`: base64url-decode each `id`, default `type` to `public-key`, and forward `transports` when present. Omitted when absent or empty.
- Add unit tests for the decode, absent, and empty cases.

### Testing
- `npm test` (unit tests in `tests/unit/utils/passkeys.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)