### PR TITLE
chore: add Snyk SCA scan workflow (devsecops-tooling reusable action)

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -1,0 +1,16 @@
+name: SCA
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  snyk-cli:
+    uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
+    with:
+      pre-scan-commands: "npm install"
+      additional-arguments: "--exclude=README.md"
+      node-version: 22
+    secrets: inherit


### PR DESCRIPTION
  By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing
  guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

  ### Description

  Onboards the repository to the Product Security Team's mandated Snyk SCA dependency scanning.

  Adds `.github/workflows/sca_scan.yml`, which calls the reusable action `auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main` and runs on `push` and `pull_request` against the default branch (`master`).
  The existing `snyk.yml` uses the generic `snyk/actions/node` action, which is not the required SCA integration; this adds the correct one.

  `pre-scan-commands: "npm install"` installs dependencies from the monorepo root, and the action's built-in defaults (`--all-projects`) scan both workspace manifests. `node-version` is set to `22` because the repo
   sets `"engineStrict": true` with `"node": "^22.0.0"`. No application code is changed.

  ### References

  - [Dependency Scanning – Snyk Self-Service Wiki](https://oktainc.atlassian.net/wiki/spaces/security/pages/656874051/Dependency+Scanning+Snyk+-+Self-Service+Wiki)

  ### Testing

  CI/CD-only change (a single GitHub Actions workflow), so no unit/integration tests apply. On a PR/merge to `master`, the **SCA** workflow triggers, runs `npm install`, and executes `snyk monitor` across all
  workspace manifests. Reviewers can confirm the **SCA** check appears and passes in this PR's checks.

  - [ ] This change adds test coverage for new/changed/fixed functionality

  ### Checklist

  - [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
  - [x] All active GitHub checks for tests, formatting, and security are passing
  - [x] The correct base branch is being used, if not the default branch