### PR TITLE
feat: add Google One Tap support to login, login-id, signup, and signup-id screens

### DIFF
--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -86,8 +86,14 @@ loginIdManager.pickCountryCode();
 
 ## Google One Tap
 
-Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/overview) library and call `googleOneTap` with the returned credential.
 
+First, add the GSI script to your `index.html`:
+```html
+<script src="https://accounts.google.com/gsi/client" async></script>
+```
+
+Then in your screen code:
 ```typescript
 import LoginId from '@auth0/auth0-acul-js/login-id';
 
@@ -95,7 +101,7 @@ const loginIdManager = new LoginId();
 const config = loginIdManager.screen.googleOneTapConfig;
 
 if (config) {
-  google.accounts.id.initialize({
+  window.google?.accounts.id.initialize({
     client_id: config.client_id,
     nonce: config.nonce,
     context: config.context,
@@ -106,8 +112,7 @@ if (config) {
       loginIdManager.googleOneTap({ one_tap_credential: credential });
     },
   });
-
-  google.accounts.id.prompt();
+  window.google?.accounts.id.prompt();
 }
 ```
 

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -84,3 +84,30 @@ const loginIdManager = new LoginId();
 loginIdManager.pickCountryCode();
 ```
 
+## googleOneTap
+
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+
+```typescript
+import LoginId from '@auth0/auth0-acul-js/login-id';
+
+const loginIdManager = new LoginId();
+const config = loginIdManager.screen.googleOneTapConfig;
+
+if (config) {
+  google.accounts.id.initialize({
+    client_id: config.client_id,
+    nonce: config.nonce,
+    context: config.context,
+    itp_support: config.itp_support,
+    auto_select: config.auto_select,
+    cancel_on_tap_outside: config.cancel_on_tap_outside,
+    callback: ({ credential }) => {
+      loginIdManager.googleOneTap({ one_tap_credential: credential });
+    },
+  });
+
+  google.accounts.id.prompt();
+}
+```
+

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -84,7 +84,7 @@ const loginIdManager = new LoginId();
 loginIdManager.pickCountryCode();
 ```
 
-## googleOneTap
+## Google One Tap
 
 Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
 

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -193,8 +193,14 @@ export default LoginScreen;
 
 ## Google One Tap
 
-Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/overview) library and call `googleOneTap` with the returned credential.
 
+First, add the GSI script to your `index.html`:
+```html
+<script src="https://accounts.google.com/gsi/client" async></script>
+```
+
+Then in your screen code:
 ```typescript
 import Login from '@auth0/auth0-acul-js/login';
 
@@ -202,7 +208,7 @@ const loginManager = new Login();
 const config = loginManager.screen.googleOneTapConfig;
 
 if (config) {
-  google.accounts.id.initialize({
+  window.google?.accounts.id.initialize({
     client_id: config.client_id,
     nonce: config.nonce,
     context: config.context,
@@ -213,7 +219,6 @@ if (config) {
       loginManager.googleOneTap({ one_tap_credential: credential });
     },
   });
-
-  google.accounts.id.prompt();
+  window.google?.accounts.id.prompt();
 }
 ```

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -190,3 +190,30 @@ const LoginScreen: React.FC = () => {
 
 export default LoginScreen;
 ```
+
+## Google One Tap
+
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+
+```typescript
+import Login from '@auth0/auth0-acul-js/login';
+
+const loginManager = new Login();
+const config = loginManager.screen.googleOneTapConfig;
+
+if (config) {
+  google.accounts.id.initialize({
+    client_id: config.client_id,
+    nonce: config.nonce,
+    context: config.context,
+    itp_support: config.itp_support,
+    auto_select: config.auto_select,
+    cancel_on_tap_outside: config.cancel_on_tap_outside,
+    callback: ({ credential }) => {
+      loginManager.googleOneTap({ one_tap_credential: credential });
+    },
+  });
+
+  google.accounts.id.prompt();
+}
+```

--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -242,5 +242,31 @@ const SignupIdScreen: React.FC = () => {
 };
 
 export default SignupIdScreen;
+```
 
+## googleOneTap
+
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+
+```typescript
+import SignupId from '@auth0/auth0-acul-js/signup-id';
+
+const signupIdManager = new SignupId();
+const config = signupIdManager.screen.googleOneTapConfig;
+
+if (config) {
+  google.accounts.id.initialize({
+    client_id: config.client_id,
+    nonce: config.nonce,
+    context: config.context,
+    itp_support: config.itp_support,
+    auto_select: config.auto_select,
+    cancel_on_tap_outside: config.cancel_on_tap_outside,
+    callback: ({ credential }) => {
+      signupIdManager.googleOneTap({ one_tap_credential: credential });
+    },
+  });
+
+  google.accounts.id.prompt();
+}
 ```

--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -244,7 +244,7 @@ const SignupIdScreen: React.FC = () => {
 export default SignupIdScreen;
 ```
 
-## googleOneTap
+## Google One Tap
 
 Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
 

--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -246,8 +246,14 @@ export default SignupIdScreen;
 
 ## Google One Tap
 
-Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/overview) library and call `googleOneTap` with the returned credential.
 
+First, add the GSI script to your `index.html`:
+```html
+<script src="https://accounts.google.com/gsi/client" async></script>
+```
+
+Then in your screen code:
 ```typescript
 import SignupId from '@auth0/auth0-acul-js/signup-id';
 
@@ -255,7 +261,7 @@ const signupIdManager = new SignupId();
 const config = signupIdManager.screen.googleOneTapConfig;
 
 if (config) {
-  google.accounts.id.initialize({
+  window.google?.accounts.id.initialize({
     client_id: config.client_id,
     nonce: config.nonce,
     context: config.context,
@@ -266,7 +272,6 @@ if (config) {
       signupIdManager.googleOneTap({ one_tap_credential: credential });
     },
   });
-
-  google.accounts.id.prompt();
+  window.google?.accounts.id.prompt();
 }
 ```

--- a/packages/auth0-acul-js/examples/signup.md
+++ b/packages/auth0-acul-js/examples/signup.md
@@ -213,8 +213,14 @@ export default SignupScreen;
 
 ## Google One Tap
 
-Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/overview) library and call `googleOneTap` with the returned credential.
 
+First, add the GSI script to your `index.html`:
+```html
+<script src="https://accounts.google.com/gsi/client" async></script>
+```
+
+Then in your screen code:
 ```typescript
 import Signup from '@auth0/auth0-acul-js/signup';
 
@@ -222,7 +228,7 @@ const signupManager = new Signup();
 const config = signupManager.screen.googleOneTapConfig;
 
 if (config) {
-  google.accounts.id.initialize({
+  window.google?.accounts.id.initialize({
     client_id: config.client_id,
     nonce: config.nonce,
     context: config.context,
@@ -233,7 +239,6 @@ if (config) {
       signupManager.googleOneTap({ one_tap_credential: credential });
     },
   });
-
-  google.accounts.id.prompt();
+  window.google?.accounts.id.prompt();
 }
 ```

--- a/packages/auth0-acul-js/examples/signup.md
+++ b/packages/auth0-acul-js/examples/signup.md
@@ -210,3 +210,30 @@ const SignupScreen: React.FC = () => {
 
 export default SignupScreen;
 ```
+
+## Google One Tap
+
+Use `screen.googleOneTapConfig` to check if the feature is enabled server-side, then initialize the GSI library and call `googleOneTap` with the returned credential.
+
+```typescript
+import Signup from '@auth0/auth0-acul-js/signup';
+
+const signupManager = new Signup();
+const config = signupManager.screen.googleOneTapConfig;
+
+if (config) {
+  google.accounts.id.initialize({
+    client_id: config.client_id,
+    nonce: config.nonce,
+    context: config.context,
+    itp_support: config.itp_support,
+    auto_select: config.auto_select,
+    cancel_on_tap_outside: config.cancel_on_tap_outside,
+    callback: ({ credential }) => {
+      signupManager.googleOneTap({ one_tap_credential: credential });
+    },
+  });
+
+  google.accounts.id.prompt();
+}
+```

--- a/packages/auth0-acul-js/interfaces/common/index.ts
+++ b/packages/auth0-acul-js/interfaces/common/index.ts
@@ -72,11 +72,17 @@ export interface FlattenedTheme {
  * Configuration for Google One Tap / FedCM, provided by the server in screen.data.google_one_tap
  */
 export interface GoogleOneTapConfig {
+  /** The Google OAuth 2.0 client ID for this application. */
   client_id: string;
+  /** A random value used to associate the credential with this session and prevent replay attacks. */
   nonce: string;
+  /** Changes the title and messages shown in the One Tap prompt. Accepted values: "signin" (default), "signup", "use". */
   context: string;
+  /** When true, enables Intelligent Tracking Prevention (ITP) support for Safari/WebKit browsers that restrict third-party cookies. */
   itp_support: boolean;
+  /** When true, the credential is returned automatically without user interaction if a single Google session is available and has previously consented. */
   auto_select: boolean;
+  /** When true, the One Tap prompt closes if the user clicks outside it. Set to false to require an explicit dismissal. */
   cancel_on_tap_outside: boolean;
 }
 

--- a/packages/auth0-acul-js/interfaces/common/index.ts
+++ b/packages/auth0-acul-js/interfaces/common/index.ts
@@ -69,6 +69,25 @@ export interface FlattenedTheme {
 }
 
 /**
+ * Configuration for Google One Tap / FedCM, provided by the server in screen.data.google_one_tap
+ */
+export interface GoogleOneTapConfig {
+  client_id: string;
+  nonce: string;
+  context: string;
+  itp_support: boolean;
+  auto_select: boolean;
+  cancel_on_tap_outside: boolean;
+}
+
+/**
+ * Payload for submitting a Google One Tap credential
+ */
+export interface GoogleOneTapOptions {
+  one_tap_credential: string;
+}
+
+/**
  * Options for changing the language/locale during the authentication flow
  */
 export interface LanguageChangeOptions {

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,7 +1,7 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, AllowCredential, AuthenticatorTransport } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, PasswordComplexityPolicy, UsernamePolicy, Error, Error as ULError, PasswordComplexityRule } from '../models/transaction';
 export type { BrandingSettings, BrandingThemes } from '../models/branding';
-export type { CustomOptions, AbortEnrollmentOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, LanguageChangeOptions } from '../common/index';
+export type { CustomOptions, AbortEnrollmentOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, LanguageChangeOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../common/index';
 export type { OnStatusChangeCallback, StartResendOptions, ResendControl } from '../utils/resend-control';
 export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../models/user';
 export type { IdentifierType } from '../../src/constants';

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -1,5 +1,5 @@
 import type { IdentifierType } from '../../src/constants';
-import type { CustomOptions } from '../common';
+import type { CustomOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../common';
 import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers, PasskeyRead } from '../models/screen';
 import type { TransactionMembers, UsernamePolicy, DBConnection } from '../models/transaction';
@@ -46,6 +46,7 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
   publicKey: PasskeyRead['public_key'] | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
 }
 
 export interface TransactionMembersOnLoginId extends TransactionMembers {
@@ -76,6 +77,7 @@ export interface LoginIdMembers extends BaseMembers {
   federatedLogin(payload: FederatedLoginOptions): Promise<void>;
   passkeyLogin(payload?: CustomOptions): Promise<void>;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
+  googleOneTap(payload: GoogleOneTapOptions): Promise<void>;
   getLoginIdentifiers(): IdentifierType[] | null;
   registerPasskeyAutofill(inputId?: string): Promise<void>;
 }

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -1,5 +1,5 @@
 import type { IdentifierType } from '../../src/constants';
-import type { CustomOptions } from '../common';
+import type { CustomOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../common';
 import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers } from '../models/screen';
 import type { TransactionContext, TransactionMembers, DBConnection, PasswordPolicy } from '../models/transaction';
@@ -19,6 +19,7 @@ export interface ScreenContextOnLogin extends ScreenContext {
 export interface ScreenMembersOnLogin extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
   data: {
     username?: string;
   } | null;
@@ -95,6 +96,11 @@ export interface LoginMembers extends BaseMembers {
    * @param payload Optional custom options
    */
   pickCountryCode(payload?: CustomOptions): Promise<void>;
+  /**
+   * Submits a Google One Tap credential to complete authentication
+   * @param payload The Google ID token returned by the GSI SDK
+   */
+  googleOneTap(payload: GoogleOneTapOptions): Promise<void>;
   /**
    * Gets the active identifier types for the login screen
    * @returns An array of active identifier types or null if none are active

--- a/packages/auth0-acul-js/interfaces/screens/signup-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-id.ts
@@ -1,5 +1,5 @@
 import type { IdentifierType } from '../../src/constants';
-import type { CustomOptions } from '../common';
+import type { CustomOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../common';
 import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers } from '../models/screen';
 import type { TransactionMembers, UsernamePolicy } from '../models/transaction';
@@ -24,6 +24,7 @@ interface ExtendedUntrustedDataContext extends UntrustedDataContext {
 
 export interface ScreenMembersOnSignupId extends ScreenMembers {
   loginLink: string | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
 }
 
 export interface TransactionMembersOnSignupId extends TransactionMembers {
@@ -56,6 +57,7 @@ export interface SignupIdMembers extends BaseMembers {
   transaction: TransactionMembersOnSignupId;
   signup(payload: SignupOptions): Promise<void>;
   federatedSignup(payload: FederatedSignupOptions): Promise<void>;
+  googleOneTap(payload: GoogleOneTapOptions): Promise<void>;
   getSignupIdentifiers(): Identifier[] | null;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
   validateUsername(username: string): UsernameValidationResult;

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -1,7 +1,7 @@
 import type { PasswordValidationResult } from '../../interfaces/utils/validate-password';
 import type { UsernameValidationResult } from '../../interfaces/utils/validate-username';
 import type { IdentifierType } from '../../src/constants';
-import type { CustomOptions } from '../common';
+import type { CustomOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ScreenMembers } from '../models/screen';
 import type { TransactionMembers, UsernamePolicy, PasswordPolicy, PasswordComplexityPolicy } from '../models/transaction';
@@ -22,6 +22,7 @@ export interface FederatedSignupOptions {
 
 export interface ScreenMembersOnSignup extends ScreenMembers {
   loginLink: string | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
 }
 
 export interface TransactionMembersOnSignup extends TransactionMembers {
@@ -38,6 +39,7 @@ export interface SignupMembers extends BaseMembers {
   transaction: TransactionMembersOnSignup;
   signup(payload: SignupOptions): Promise<void>;
   federatedSignup(payload: FederatedSignupOptions): Promise<void>;
+  googleOneTap(payload: GoogleOneTapOptions): Promise<void>;
   pickCountryCode(payload?: CustomOptions): Promise<void>;
   validatePassword(password: string): PasswordValidationResult;
   /**

--- a/packages/auth0-acul-js/src/constants/form-actions.ts
+++ b/packages/auth0-acul-js/src/constants/form-actions.ts
@@ -32,4 +32,5 @@ export const FormActions = {
   CHANGE_LANGUAGE: 'change-language' as const,
   SWITCH_TO_OTP_AUTH: 'switch-to-otp-auth' as const,
   SWITCH_TO_PASSWORD_AUTH: 'switch-to-password-auth' as const,
+  GOOGLE_ONE_TAP: 'google-one-tap' as const,
 } as const;

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -141,11 +141,36 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
   }
 
   /**
-   * @example
-   * import LoginId from "@auth0/auth0-acul-js/login-id";
-   * const loginIdManager = new LoginId();
+   * Submits the Google ID token obtained from the Google Identity Services (GSI) SDK
+   * to complete authentication via Google One Tap.
    *
-   * loginIdManager.googleOneTap({ one_tap_credential: googleIdToken });
+   * Check `screen.googleOneTapConfig` first — it is `null` when the feature is not
+   * enabled server-side, in which case this method should not be called.
+   *
+   * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
+   *
+   * @example
+   * ```typescript
+   * import LoginId from "@auth0/auth0-acul-js/login-id";
+   *
+   * const loginIdManager = new LoginId();
+   * const config = loginIdManager.screen.googleOneTapConfig;
+   *
+   * if (config) {
+   *   google.accounts.id.initialize({
+   *     client_id: config.client_id,
+   *     nonce: config.nonce,
+   *     context: config.context,
+   *     itp_support: config.itp_support,
+   *     auto_select: config.auto_select,
+   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *     callback: ({ credential }) => {
+   *       loginIdManager.googleOneTap({ one_tap_credential: credential });
+   *     },
+   *   });
+   *   google.accounts.id.prompt();
+   * }
+   * ```
    */
   async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
     const options: FormOptions = {

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -10,7 +10,7 @@ import { registerPasskeyAutofill } from '../../utils/passkeys';
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, GoogleOneTapOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -145,6 +145,25 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * import LoginId from "@auth0/auth0-acul-js/login-id";
    * const loginIdManager = new LoginId();
    *
+   * loginIdManager.googleOneTap({ one_tap_credential: googleIdToken });
+   */
+  async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [LoginId.screenIdentifier, 'googleOneTap'],
+    };
+
+    await new FormHandler(options).submitData<CustomOptions>({
+      ...payload,
+      action: FormActions.GOOGLE_ONE_TAP,
+    });
+  }
+
+  /**
+   * @example
+   * import LoginId from "@auth0/auth0-acul-js/login-id";
+   * const loginIdManager = new LoginId();
+   *
    * loginIdManager.pickCountryCode();
    */
   async pickCountryCode(payload?: CustomOptions): Promise<void> {
@@ -269,6 +288,7 @@ export {
   LoginIdMembers,
   LoginOptions,
   FederatedLoginOptions,
+  GoogleOneTapOptions,
   ScreenOptions as ScreenMembersOnLoginId,
   TransactionOptions as TransactionMembersOnLoginId,
 };

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -20,8 +20,8 @@ import type {
   LoginOptions,
   FederatedLoginOptions,
 } from '../../../interfaces/screens/login-id';
+import type { IdentifierType } from '../../../interfaces/utils';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
-import type { IdentifierType } from 'interfaces/utils';
 
 export default class LoginId extends BaseContext implements LoginIdMembers {
   static screenIdentifier: string = ScreenIds.LOGIN_ID;

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -149,6 +149,14 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    *
    * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
    *
+   * @remarks
+   * Requires the Google Identity Services (GSI) script to be loaded before calling this method.
+   * Add it to your HTML: `<script src="https://accounts.google.com/gsi/client" async></script>`
+   * Or inject it dynamically at runtime.
+   *
+   * @see {@link https://developers.google.com/identity/gsi/web/guides/client-library | Google Identity Services: Load the client library}
+   * @see {@link https://auth0.com/docs/authenticate/identity-providers/social-identity-providers/google | Auth0 Google Social Connection}
+   *
    * @example
    * ```typescript
    * import LoginId from "@auth0/auth0-acul-js/login-id";
@@ -157,18 +165,25 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * const config = loginIdManager.screen.googleOneTapConfig;
    *
    * if (config) {
-   *   google.accounts.id.initialize({
-   *     client_id: config.client_id,
-   *     nonce: config.nonce,
-   *     context: config.context,
-   *     itp_support: config.itp_support,
-   *     auto_select: config.auto_select,
-   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
-   *     callback: ({ credential }) => {
-   *       loginIdManager.googleOneTap({ one_tap_credential: credential });
-   *     },
-   *   });
-   *   google.accounts.id.prompt();
+   *   const script = document.createElement('script');
+   *   script.src = 'https://accounts.google.com/gsi/client';
+   *   script.async = true;
+   *   script.defer = true;
+   *   script.onload = () => {
+   *     window.google?.accounts.id.initialize({
+   *       client_id: config.client_id,
+   *       nonce: config.nonce,
+   *       context: config.context,
+   *       itp_support: config.itp_support,
+   *       auto_select: config.auto_select,
+   *       cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *       callback: ({ credential }) => {
+   *         loginIdManager.googleOneTap({ one_tap_credential: credential });
+   *       },
+   *     });
+   *     window.google?.accounts.id.prompt();
+   *   };
+   *   document.head.appendChild(script);
    * }
    * ```
    */

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -20,8 +20,8 @@ import type {
   LoginOptions,
   FederatedLoginOptions,
 } from '../../../interfaces/screens/login-id';
-import type { IdentifierType } from '../../../interfaces/utils';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { IdentifierType } from 'interfaces/utils';
 
 export default class LoginId extends BaseContext implements LoginIdMembers {
   static screenIdentifier: string = ScreenIds.LOGIN_ID;

--- a/packages/auth0-acul-js/src/screens/login-id/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/screen-override.ts
@@ -1,5 +1,5 @@
 import { Screen } from '../../../src/models/screen';
-import { getSignupLink, getResetPasswordLink, getPublicKey } from '../../shared/screen';
+import { getSignupLink, getResetPasswordLink, getPublicKey, getGoogleOneTapConfig } from '../../shared/screen';
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { ScreenMembersOnLoginId as OverrideOptions } from '../../../interfaces/screens/login-id';
@@ -8,11 +8,13 @@ export class ScreenOverride extends Screen implements OverrideOptions {
   signupLink: OverrideOptions['signupLink'];
   resetPasswordLink: OverrideOptions['resetPasswordLink'];
   publicKey: OverrideOptions['publicKey'];
+  googleOneTapConfig: OverrideOptions['googleOneTapConfig'];
 
   constructor(screenContext: ScreenContext) {
     super(screenContext);
     this.signupLink = getSignupLink(screenContext);
     this.resetPasswordLink = getResetPasswordLink(screenContext);
     this.publicKey = getPublicKey(screenContext) as OverrideOptions['publicKey'];
+    this.googleOneTapConfig = getGoogleOneTapConfig(screenContext);
   }
 }

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -99,13 +99,35 @@ export default class Login extends BaseContext implements LoginMembers {
   }
 
   /**
-   * Submits a Google One Tap credential to complete authentication
-   * @param payload The Google ID token returned by the GSI SDK
+   * Submits the Google ID token obtained from the Google Identity Services (GSI) SDK
+   * to complete authentication via Google One Tap.
+   *
+   * Check `screen.googleOneTapConfig` first — it is `null` when the feature is not
+   * enabled server-side, in which case this method should not be called.
+   *
+   * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
+   *
    * @example
    * ```typescript
    * import Login from "@auth0/auth0-acul-js/login";
+   *
    * const loginManager = new Login();
-   * loginManager.googleOneTap({ one_tap_credential: googleIdToken });
+   * const config = loginManager.screen.googleOneTapConfig;
+   *
+   * if (config) {
+   *   google.accounts.id.initialize({
+   *     client_id: config.client_id,
+   *     nonce: config.nonce,
+   *     context: config.context,
+   *     itp_support: config.itp_support,
+   *     auto_select: config.auto_select,
+   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *     callback: ({ credential }) => {
+   *       loginManager.googleOneTap({ one_tap_credential: credential });
+   *     },
+   *   });
+   *   google.accounts.id.prompt();
+   * }
    * ```
    */
   async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -16,8 +16,8 @@ import type {
   TransactionMembersOnLogin as TransactionOptions,
   FederatedLoginOptions,
 } from '../../../interfaces/screens/login';
+import type { IdentifierType } from '../../../interfaces/utils';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
-import type { IdentifierType } from 'interfaces/utils';
 
 /**
  * Login screen implementation class

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -16,8 +16,8 @@ import type {
   TransactionMembersOnLogin as TransactionOptions,
   FederatedLoginOptions,
 } from '../../../interfaces/screens/login';
-import type { IdentifierType } from '../../../interfaces/utils';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { IdentifierType } from 'interfaces/utils';
 
 /**
  * Login screen implementation class

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -131,7 +131,10 @@ export default class Login extends BaseContext implements LoginMembers {
    * ```
    */
   async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
-    const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'googleOneTap'] };
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [Login.screenIdentifier, 'googleOneTap'],
+    };
     await new FormHandler(options).submitData<CustomOptions>({
       ...payload,
       action: FormActions.GOOGLE_ONE_TAP,

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -6,7 +6,7 @@ import { getLoginIdentifiers as _getLoginIdentifiers } from '../../utils/login-i
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
-import type { CustomOptions } from '../../../interfaces/common';
+import type { CustomOptions, GoogleOneTapOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -99,6 +99,24 @@ export default class Login extends BaseContext implements LoginMembers {
   }
 
   /**
+   * Submits a Google One Tap credential to complete authentication
+   * @param payload The Google ID token returned by the GSI SDK
+   * @example
+   * ```typescript
+   * import Login from "@auth0/auth0-acul-js/login";
+   * const loginManager = new Login();
+   * loginManager.googleOneTap({ one_tap_credential: googleIdToken });
+   * ```
+   */
+  async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
+    const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'googleOneTap'] };
+    await new FormHandler(options).submitData<CustomOptions>({
+      ...payload,
+      action: FormActions.GOOGLE_ONE_TAP,
+    });
+  }
+
+  /**
    * Gets the active identifier types for the login screen
    * @returns An array of active identifier types or null if none are active
    * @example
@@ -114,6 +132,13 @@ export default class Login extends BaseContext implements LoginMembers {
   }
 }
 
-export { LoginMembers, LoginOptions, FederatedLoginOptions, ScreenOptions as ScreenMembersOnLogin, TransactionOptions as TransactionMembersOnLogin };
+export {
+  LoginMembers,
+  LoginOptions,
+  FederatedLoginOptions,
+  GoogleOneTapOptions,
+  ScreenOptions as ScreenMembersOnLogin,
+  TransactionOptions as TransactionMembersOnLogin,
+};
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -107,6 +107,14 @@ export default class Login extends BaseContext implements LoginMembers {
    *
    * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
    *
+   * @remarks
+   * Requires the Google Identity Services (GSI) script to be loaded before calling this method.
+   * Add it to your HTML: `<script src="https://accounts.google.com/gsi/client" async></script>`
+   * Or inject it dynamically at runtime.
+   *
+   * @see {@link https://developers.google.com/identity/gsi/web/guides/client-library | Google Identity Services: Load the client library}
+   * @see {@link https://auth0.com/docs/authenticate/identity-providers/social-identity-providers/google | Auth0 Google Social Connection}
+   *
    * @example
    * ```typescript
    * import Login from "@auth0/auth0-acul-js/login";
@@ -115,18 +123,25 @@ export default class Login extends BaseContext implements LoginMembers {
    * const config = loginManager.screen.googleOneTapConfig;
    *
    * if (config) {
-   *   google.accounts.id.initialize({
-   *     client_id: config.client_id,
-   *     nonce: config.nonce,
-   *     context: config.context,
-   *     itp_support: config.itp_support,
-   *     auto_select: config.auto_select,
-   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
-   *     callback: ({ credential }) => {
-   *       loginManager.googleOneTap({ one_tap_credential: credential });
-   *     },
-   *   });
-   *   google.accounts.id.prompt();
+   *   const script = document.createElement('script');
+   *   script.src = 'https://accounts.google.com/gsi/client';
+   *   script.async = true;
+   *   script.defer = true;
+   *   script.onload = () => {
+   *     window.google?.accounts.id.initialize({
+   *       client_id: config.client_id,
+   *       nonce: config.nonce,
+   *       context: config.context,
+   *       itp_support: config.itp_support,
+   *       auto_select: config.auto_select,
+   *       cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *       callback: ({ credential }) => {
+   *         loginManager.googleOneTap({ one_tap_credential: credential });
+   *       },
+   *     });
+   *     window.google?.accounts.id.prompt();
+   *   };
+   *   document.head.appendChild(script);
    * }
    * ```
    */

--- a/packages/auth0-acul-js/src/screens/login/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login/screen-override.ts
@@ -1,5 +1,5 @@
 import { Screen } from '../../models/screen';
-import { getSignupLink, getResetPasswordLink } from '../../shared/screen';
+import { getSignupLink, getResetPasswordLink, getGoogleOneTapConfig } from '../../shared/screen';
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { ScreenMembersOnLogin as OverrideOptions } from '../../../interfaces/screens/login';
@@ -10,12 +10,14 @@ import type { ScreenMembersOnLogin as OverrideOptions } from '../../../interface
 export class ScreenOverride extends Screen implements OverrideOptions {
   signupLink: OverrideOptions['signupLink'];
   resetPasswordLink: OverrideOptions['resetPasswordLink'];
+  googleOneTapConfig: OverrideOptions['googleOneTapConfig'];
   data: OverrideOptions['data'];
 
   constructor(screenContext: ScreenContext) {
     super(screenContext);
     this.signupLink = getSignupLink(screenContext);
     this.resetPasswordLink = getResetPasswordLink(screenContext);
+    this.googleOneTapConfig = getGoogleOneTapConfig(screenContext);
     this.data = Screen.getScreenData(screenContext) as OverrideOptions['data'];
   }
 }

--- a/packages/auth0-acul-js/src/screens/mfa-detect-browser-capabilities/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-detect-browser-capabilities/index.ts
@@ -3,9 +3,9 @@ import { ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
+import type { CustomOptions } from '../../../interfaces/common';
 import type { MfaDetectBrowserCapabilitiesMembers } from '../../../interfaces/screens/mfa-detect-browser-capabilities';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
-import type { CustomOptions } from 'interfaces/common';
 
 /**
  * Class implementing the mfa-detect-browser-capabilities screen functionality

--- a/packages/auth0-acul-js/src/screens/mfa-detect-browser-capabilities/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-detect-browser-capabilities/index.ts
@@ -3,9 +3,9 @@ import { ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
-import type { CustomOptions } from '../../../interfaces/common';
 import type { MfaDetectBrowserCapabilitiesMembers } from '../../../interfaces/screens/mfa-detect-browser-capabilities';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { CustomOptions } from 'interfaces/common';
 
 /**
  * Class implementing the mfa-detect-browser-capabilities screen functionality

--- a/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
@@ -15,8 +15,8 @@ import type {
   ScreenMembersOnResetPasswordRequest as ScreenOptions,
   TransactionMembersOnResetPasswordRequest as TransactionOptions,
 } from '../../../interfaces/screens/reset-password-request';
-import type { IdentifierType } from '../../../interfaces/utils';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { IdentifierType } from 'interfaces/utils';
 
 export default class ResetPasswordRequest extends BaseContext implements ResetPasswordRequestMembers {
   static screenIdentifier: string = ScreenIds.RESET_PASSWORD_REQUEST;

--- a/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
+++ b/packages/auth0-acul-js/src/screens/reset-password-request/index.ts
@@ -15,8 +15,8 @@ import type {
   ScreenMembersOnResetPasswordRequest as ScreenOptions,
   TransactionMembersOnResetPasswordRequest as TransactionOptions,
 } from '../../../interfaces/screens/reset-password-request';
+import type { IdentifierType } from '../../../interfaces/utils';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
-import type { IdentifierType } from 'interfaces/utils';
 
 export default class ResetPasswordRequest extends BaseContext implements ResetPasswordRequestMembers {
   static screenIdentifier: string = ScreenIds.RESET_PASSWORD_REQUEST;

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -8,6 +8,7 @@ import { validateUsername as _validateUsername} from '../../utils/validate-usern
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
+import type { CustomOptions, GoogleOneTapOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -111,6 +112,24 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
   }
 
   /**
+   * @example
+   * import SignupId from "@auth0/auth0-acul-js/signup-id";
+   * const signupIdManager = new SignupId();
+   *
+   * signupIdManager.googleOneTap({ one_tap_credential: googleIdToken });
+   */
+  async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [SignupId.screenIdentifier, 'googleOneTap'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({
+      ...payload,
+      action: FormActions.GOOGLE_ONE_TAP,
+    });
+  }
+
+  /**
    * Returns the list of enabled identifiers for the signup-id form,
    * marking each as required or optional based on transaction config.
    *
@@ -172,6 +191,7 @@ export {
   UsernameValidationResult,
   SignupOptions,
   FederatedSignupOptions,
+  GoogleOneTapOptions,
   ScreenOptions as ScreenMembersOnSignupId,
   TransactionOptions as TransactionMembersOnSignupId,
 };

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -112,11 +112,36 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
   }
 
   /**
-   * @example
-   * import SignupId from "@auth0/auth0-acul-js/signup-id";
-   * const signupIdManager = new SignupId();
+   * Submits the Google ID token obtained from the Google Identity Services (GSI) SDK
+   * to complete sign-up via Google One Tap.
    *
-   * signupIdManager.googleOneTap({ one_tap_credential: googleIdToken });
+   * Check `screen.googleOneTapConfig` first — it is `null` when the feature is not
+   * enabled server-side, in which case this method should not be called.
+   *
+   * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
+   *
+   * @example
+   * ```typescript
+   * import SignupId from "@auth0/auth0-acul-js/signup-id";
+   *
+   * const signupIdManager = new SignupId();
+   * const config = signupIdManager.screen.googleOneTapConfig;
+   *
+   * if (config) {
+   *   google.accounts.id.initialize({
+   *     client_id: config.client_id,
+   *     nonce: config.nonce,
+   *     context: config.context,
+   *     itp_support: config.itp_support,
+   *     auto_select: config.auto_select,
+   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *     callback: ({ credential }) => {
+   *       signupIdManager.googleOneTap({ one_tap_credential: credential });
+   *     },
+   *   });
+   *   google.accounts.id.prompt();
+   * }
+   * ```
    */
   async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
     const options: FormOptions = {

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -120,6 +120,14 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
    *
    * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
    *
+   * @remarks
+   * Requires the Google Identity Services (GSI) script to be loaded before calling this method.
+   * Add it to your HTML: `<script src="https://accounts.google.com/gsi/client" async></script>`
+   * Or inject it dynamically at runtime.
+   *
+   * @see {@link https://developers.google.com/identity/gsi/web/guides/client-library | Google Identity Services: Load the client library}
+   * @see {@link https://auth0.com/docs/authenticate/identity-providers/social-identity-providers/google | Auth0 Google Social Connection}
+   *
    * @example
    * ```typescript
    * import SignupId from "@auth0/auth0-acul-js/signup-id";
@@ -128,18 +136,25 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
    * const config = signupIdManager.screen.googleOneTapConfig;
    *
    * if (config) {
-   *   google.accounts.id.initialize({
-   *     client_id: config.client_id,
-   *     nonce: config.nonce,
-   *     context: config.context,
-   *     itp_support: config.itp_support,
-   *     auto_select: config.auto_select,
-   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
-   *     callback: ({ credential }) => {
-   *       signupIdManager.googleOneTap({ one_tap_credential: credential });
-   *     },
-   *   });
-   *   google.accounts.id.prompt();
+   *   const script = document.createElement('script');
+   *   script.src = 'https://accounts.google.com/gsi/client';
+   *   script.async = true;
+   *   script.defer = true;
+   *   script.onload = () => {
+   *     window.google?.accounts.id.initialize({
+   *       client_id: config.client_id,
+   *       nonce: config.nonce,
+   *       context: config.context,
+   *       itp_support: config.itp_support,
+   *       auto_select: config.auto_select,
+   *       cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *       callback: ({ credential }) => {
+   *         signupIdManager.googleOneTap({ one_tap_credential: credential });
+   *       },
+   *     });
+   *     window.google?.accounts.id.prompt();
+   *   };
+   *   document.head.appendChild(script);
    * }
    * ```
    */

--- a/packages/auth0-acul-js/src/screens/signup-id/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/screen-override.ts
@@ -1,4 +1,4 @@
-import { getLoginLink } from '../../../src/shared/screen';
+import { getLoginLink, getGoogleOneTapConfig } from '../../../src/shared/screen';
 import { Screen } from '../../models/screen';
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
@@ -6,9 +6,11 @@ import type { ScreenMembersOnSignupId as OverrideOptions } from '../../../interf
 
 export class ScreenOverride extends Screen implements OverrideOptions {
   loginLink: OverrideOptions['loginLink'];
+  googleOneTapConfig: OverrideOptions['googleOneTapConfig'];
 
   constructor(screenContext: ScreenContext) {
     super(screenContext);
     this.loginLink = getLoginLink(screenContext);
+    this.googleOneTapConfig = getGoogleOneTapConfig(screenContext);
   }
 }

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -89,11 +89,36 @@ export default class Signup extends BaseContext implements SignupMembers {
   }
 
   /**
-   * @example
-   * import Signup from "@auth0/auth0-acul-js/signup";
-   * const signupManager = new Signup();
+   * Submits the Google ID token obtained from the Google Identity Services (GSI) SDK
+   * to complete sign-up via Google One Tap.
    *
-   * signupManager.googleOneTap({ one_tap_credential: googleIdToken });
+   * Check `screen.googleOneTapConfig` first — it is `null` when the feature is not
+   * enabled server-side, in which case this method should not be called.
+   *
+   * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
+   *
+   * @example
+   * ```typescript
+   * import Signup from "@auth0/auth0-acul-js/signup";
+   *
+   * const signupManager = new Signup();
+   * const config = signupManager.screen.googleOneTapConfig;
+   *
+   * if (config) {
+   *   google.accounts.id.initialize({
+   *     client_id: config.client_id,
+   *     nonce: config.nonce,
+   *     context: config.context,
+   *     itp_support: config.itp_support,
+   *     auto_select: config.auto_select,
+   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *     callback: ({ credential }) => {
+   *       signupManager.googleOneTap({ one_tap_credential: credential });
+   *     },
+   *   });
+   *   google.accounts.id.prompt();
+   * }
+   * ```
    */
   async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
     const options: FormOptions = {

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -97,6 +97,14 @@ export default class Signup extends BaseContext implements SignupMembers {
    *
    * @param payload - `one_tap_credential`: the ID token returned by the GSI `callback`.
    *
+   * @remarks
+   * Requires the Google Identity Services (GSI) script to be loaded before calling this method.
+   * Add it to your HTML: `<script src="https://accounts.google.com/gsi/client" async></script>`
+   * Or inject it dynamically at runtime.
+   *
+   * @see {@link https://developers.google.com/identity/gsi/web/guides/client-library | Google Identity Services: Load the client library}
+   * @see {@link https://auth0.com/docs/authenticate/identity-providers/social-identity-providers/google | Auth0 Google Social Connection}
+   *
    * @example
    * ```typescript
    * import Signup from "@auth0/auth0-acul-js/signup";
@@ -105,18 +113,25 @@ export default class Signup extends BaseContext implements SignupMembers {
    * const config = signupManager.screen.googleOneTapConfig;
    *
    * if (config) {
-   *   google.accounts.id.initialize({
-   *     client_id: config.client_id,
-   *     nonce: config.nonce,
-   *     context: config.context,
-   *     itp_support: config.itp_support,
-   *     auto_select: config.auto_select,
-   *     cancel_on_tap_outside: config.cancel_on_tap_outside,
-   *     callback: ({ credential }) => {
-   *       signupManager.googleOneTap({ one_tap_credential: credential });
-   *     },
-   *   });
-   *   google.accounts.id.prompt();
+   *   const script = document.createElement('script');
+   *   script.src = 'https://accounts.google.com/gsi/client';
+   *   script.async = true;
+   *   script.defer = true;
+   *   script.onload = () => {
+   *     window.google?.accounts.id.initialize({
+   *       client_id: config.client_id,
+   *       nonce: config.nonce,
+   *       context: config.context,
+   *       itp_support: config.itp_support,
+   *       auto_select: config.auto_select,
+   *       cancel_on_tap_outside: config.cancel_on_tap_outside,
+   *       callback: ({ credential }) => {
+   *         signupManager.googleOneTap({ one_tap_credential: credential });
+   *       },
+   *     });
+   *     window.google?.accounts.id.prompt();
+   *   };
+   *   document.head.appendChild(script);
    * }
    * ```
    */

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -9,6 +9,7 @@ import { validateUsername as _validateUsername} from '../../utils/validate-usern
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
 
+import type { CustomOptions, GoogleOneTapOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
 import type {
@@ -92,6 +93,24 @@ export default class Signup extends BaseContext implements SignupMembers {
    * import Signup from "@auth0/auth0-acul-js/signup";
    * const signupManager = new Signup();
    *
+   * signupManager.googleOneTap({ one_tap_credential: googleIdToken });
+   */
+  async googleOneTap(payload: GoogleOneTapOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [Signup.screenIdentifier, 'googleOneTap'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({
+      ...payload,
+      action: FormActions.GOOGLE_ONE_TAP,
+    });
+  }
+
+  /**
+   * @example
+   * import Signup from "@auth0/auth0-acul-js/signup";
+   * const signupManager = new Signup();
+   *
    * signupManager.pickCountryCode();
    */
   async pickCountryCode(): Promise<void> {
@@ -154,6 +173,6 @@ export default class Signup extends BaseContext implements SignupMembers {
   }
 }
 
-export { PasswordValidationResult, UsernameValidationResult, Identifier, SignupMembers, SignupOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup, FederatedSignupOptions };
+export { PasswordValidationResult, UsernameValidationResult, Identifier, SignupMembers, SignupOptions, FederatedSignupOptions, GoogleOneTapOptions, ScreenOptions as ScreenMembersOnSignup, TransactionOptions as TransactionMembersOnSignup };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/signup/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/signup/screen-override.ts
@@ -1,14 +1,16 @@
 import { Screen } from '../../models/screen';
-import { getLoginLink } from '../../shared/screen';
+import { getLoginLink, getGoogleOneTapConfig } from '../../shared/screen';
 
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { ScreenMembersOnSignup as OverrideOptions } from '../../../interfaces/screens/signup';
 
 export class ScreenOverride extends Screen implements OverrideOptions {
   loginLink: OverrideOptions['loginLink'];
+  googleOneTapConfig: OverrideOptions['googleOneTapConfig'];
 
   constructor(screenContext: ScreenContext) {
     super(screenContext);
     this.loginLink = getLoginLink(screenContext);
+    this.googleOneTapConfig = getGoogleOneTapConfig(screenContext);
   }
 }

--- a/packages/auth0-acul-js/src/shared/screen.ts
+++ b/packages/auth0-acul-js/src/shared/screen.ts
@@ -1,3 +1,4 @@
+import type { GoogleOneTapConfig } from '../../interfaces/common';
 import type { PasskeyCreate, PasskeyRead, Scope, ScreenContext } from '../../interfaces/models/screen';
 
 /**
@@ -96,6 +97,16 @@ export function getShowRememberDevice(screen: ScreenContext): boolean {
  */
 export function getWebAuthnType(screen: ScreenContext): string | null {
   return screen.data?.webauthnType as string ?? null;
+}
+
+/**
+ * Retrieves the Google One Tap configuration from the screen context.
+ *
+ * @param {ScreenContext} screen - The screen context object from Universal Login.
+ * @returns {GoogleOneTapConfig | null} - The Google One Tap config or null if not available.
+ */
+export function getGoogleOneTapConfig(screen: ScreenContext): GoogleOneTapConfig | null {
+  return (screen.data?.google_one_tap as GoogleOneTapConfig | undefined) ?? null;
 }
 
 /**

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
@@ -11,6 +11,7 @@ import { getPasskeyCredentials, registerPasskeyAutofill } from '../../../../src/
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../../interfaces/models/transaction';
 import type { LoginOptions, FederatedLoginOptions } from '../../../../interfaces/screens/login-id';
+import type { GoogleOneTapOptions } from '../../../../interfaces/common';
 
 jest.mock('../../../../src/screens/login-id/screen-override');
 jest.mock('../../../../src/screens/login-id/transaction-override');
@@ -115,6 +116,27 @@ describe('LoginId', () => {
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
         passkey: JSON.stringify({ id: 'mockPasskey' }),
       });
+    });
+  });
+
+  describe('googleOneTap', () => {
+    it('submits google-one-tap action with credential and correct telemetry', async () => {
+      const payload: GoogleOneTapOptions = { one_tap_credential: 'mock-google-id-token' };
+      await loginId.googleOneTap(payload);
+
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: 'mockState',
+        telemetry: [ScreenIds.LOGIN_ID, 'googleOneTap'],
+      });
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
+        one_tap_credential: 'mock-google-id-token',
+        action: FormActions.GOOGLE_ONE_TAP,
+      });
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      (FormHandler.prototype.submitData as jest.Mock).mockRejectedValueOnce(new Error('Mocked reject'));
+      await expect(loginId.googleOneTap({ one_tap_credential: 'token' })).rejects.toThrow('Mocked reject');
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/screen-override.test.ts
@@ -1,5 +1,5 @@
 import { ScreenOverride } from '../../../../src/screens/login-id/screen-override';
-import { getSignupLink, getResetPasswordLink, getPublicKey } from '../../../../src/shared/screen';
+import { getSignupLink, getResetPasswordLink, getPublicKey, getGoogleOneTapConfig } from '../../../../src/shared/screen';
 import { Screen } from '../../../../src/models/screen';
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
@@ -18,6 +18,7 @@ describe('ScreenOverride', () => {
     (getSignupLink as jest.Mock).mockReturnValue('mockSignupLink');
     (getResetPasswordLink as jest.Mock).mockReturnValue('mockResetPasswordLink');
     (getPublicKey as jest.Mock).mockReturnValue('mockPublicKey');
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
 
     screenOverride = new ScreenOverride(screenContext);
   });
@@ -50,5 +51,20 @@ describe('ScreenOverride', () => {
     expect(emptyScreenOverride.signupLink).toBeUndefined();
     expect(emptyScreenOverride.resetPasswordLink).toBeUndefined();
     expect(emptyScreenOverride.publicKey).toBeUndefined();
+  });
+
+  it('should return googleOneTapConfig when getGoogleOneTapConfig returns config', () => {
+    const config = { client_id: 'id', nonce: 'n', context: 'signin',
+      itp_support: true, auto_select: false, cancel_on_tap_outside: false };
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(config);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toEqual(config);
+    expect(getGoogleOneTapConfig).toHaveBeenCalledWith(screenContext);
+  });
+
+  it('should return null for googleOneTapConfig when getGoogleOneTapConfig returns null', () => {
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toBeNull();
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -118,7 +118,10 @@ describe('Login', () => {
     it('should submit google-one-tap action with credential and correct telemetry', async () => {
       const payload: GoogleOneTapOptions = { one_tap_credential: 'mock-google-id-token' };
       await login.googleOneTap(payload);
-      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(FormHandler).toHaveBeenLastCalledWith({
+        state: 'randomStateString1234567890',
+        telemetry: [ScreenIds.LOGIN, 'googleOneTap'],
+      });
       expect(mockFormHandler.submitData).toHaveBeenCalledWith({
         one_tap_credential: 'mock-google-id-token',
         action: FormActions.GOOGLE_ONE_TAP,

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -4,6 +4,7 @@ import { FormHandler } from '../../../../src/utils/form-handler';
 import { baseContextData } from '../../../data/test-data';
 
 import type { LoginOptions, FederatedLoginOptions } from '../../../../interfaces/screens/login';
+import type { GoogleOneTapOptions } from '../../../../interfaces/common';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -110,6 +111,23 @@ describe('Login', () => {
       expect(login.getLoginIdentifiers()).toBeNull();
       login.transaction.allowedIdentifiers = [];
       expect(login.getLoginIdentifiers()).toEqual([]);
+    });
+  });
+
+  describe('googleOneTap', () => {
+    it('should submit google-one-tap action with credential and correct telemetry', async () => {
+      const payload: GoogleOneTapOptions = { one_tap_credential: 'mock-google-id-token' };
+      await login.googleOneTap(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        one_tap_credential: 'mock-google-id-token',
+        action: FormActions.GOOGLE_ONE_TAP,
+      });
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
+      await expect(login.googleOneTap({ one_tap_credential: 'token' })).rejects.toThrow('Mocked reject');
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/login/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/screen-override.test.ts
@@ -1,5 +1,5 @@
 import { ScreenOverride } from '../../../../src/screens/login/screen-override';
-import { getSignupLink, getResetPasswordLink } from '../../../../src/shared/screen';
+import { getSignupLink, getResetPasswordLink, getGoogleOneTapConfig } from '../../../../src/shared/screen';
 import { Screen } from '../../../../src/models/screen';
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
@@ -17,6 +17,7 @@ describe('ScreenOverride', () => {
 
     (getSignupLink as jest.Mock).mockReturnValue('mockSignupLink');
     (getResetPasswordLink as jest.Mock).mockReturnValue('mockResetPasswordLink');
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
     (Screen.getScreenData as jest.Mock).mockReturnValue({ mockData: 'mockData' });
 
     screenOverride = new ScreenOverride(screenContext);
@@ -32,5 +33,20 @@ describe('ScreenOverride', () => {
 
   it('should initialize data correctly', () => {
     expect(screenOverride.data).toEqual({ mockData: 'mockData' });
+  });
+
+  it('should return googleOneTapConfig when getGoogleOneTapConfig returns config', () => {
+    const config = { client_id: 'test-client-id', nonce: 'test-nonce', context: 'signin',
+      itp_support: true, auto_select: false, cancel_on_tap_outside: false };
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(config);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toEqual(config);
+    expect(getGoogleOneTapConfig).toHaveBeenCalledWith(screenContext);
+  });
+
+  it('should return null for googleOneTapConfig when getGoogleOneTapConfig returns null', () => {
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toBeNull();
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
@@ -4,6 +4,7 @@ import { getBrowserCapabilities } from '../../../../src/utils/browser-capabiliti
 import { FormHandler } from '../../../../src/utils/form-handler';
 import { baseContextData } from '../../../data/test-data';
 
+import type { GoogleOneTapOptions } from '../../../../interfaces/common';
 import type {
   SignupOptions,
   FederatedSignupOptions,
@@ -137,6 +138,23 @@ describe('SignupId', () => {
     });
   });
 
+  describe('googleOneTap', () => {
+    it('should submit google-one-tap action with credential and correct telemetry', async () => {
+      const payload: GoogleOneTapOptions = { one_tap_credential: 'mock-google-id-token' };
+      await signupId.googleOneTap(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        one_tap_credential: 'mock-google-id-token',
+        action: FormActions.GOOGLE_ONE_TAP,
+      });
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValueOnce(new Error('Mocked reject'));
+      await expect(signupId.googleOneTap({ one_tap_credential: 'token' })).rejects.toThrow('Mocked reject');
+    });
+  });
+
   describe('pickCountryCode', () => {
     it('should submit pick-country-code action', async () => {
       await signupId.pickCountryCode();
@@ -153,4 +171,5 @@ describe('SignupId', () => {
       await expect(signupId.pickCountryCode()).rejects.toThrow(expectedError);
     });
   });
+
 });

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
@@ -142,7 +142,10 @@ describe('SignupId', () => {
     it('should submit google-one-tap action with credential and correct telemetry', async () => {
       const payload: GoogleOneTapOptions = { one_tap_credential: 'mock-google-id-token' };
       await signupId.googleOneTap(payload);
-      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: 'randomStateString1234567890',
+        telemetry: [ScreenIds.SIGNUP_ID, 'googleOneTap'],
+      });
       expect(mockFormHandler.submitData).toHaveBeenCalledWith({
         one_tap_credential: 'mock-google-id-token',
         action: FormActions.GOOGLE_ONE_TAP,

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/screen-override.test.ts
@@ -1,5 +1,5 @@
 import { ScreenOverride } from '../../../../src/screens/signup-id/screen-override';
-import { getLoginLink } from '../../../../src/shared/screen';
+import { getLoginLink, getGoogleOneTapConfig } from '../../../../src/shared/screen';
 import { Screen } from '../../../../src/models/screen';
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
@@ -16,6 +16,7 @@ describe('ScreenOverride', () => {
     } as ScreenContext;
 
     (getLoginLink as jest.Mock).mockReturnValue('mockLoginLink');
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
 
     screenOverride = new ScreenOverride(screenContext);
   });
@@ -30,5 +31,20 @@ describe('ScreenOverride', () => {
 
   it('should extend Screen class', () => {
     expect(screenOverride).toBeInstanceOf(Screen);
+  });
+
+  it('should return googleOneTapConfig when getGoogleOneTapConfig returns config', () => {
+    const config = { client_id: 'id', nonce: 'n', context: 'signup',
+      itp_support: true, auto_select: false, cancel_on_tap_outside: false };
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(config);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toEqual(config);
+    expect(getGoogleOneTapConfig).toHaveBeenCalledWith(screenContext);
+  });
+
+  it('should return null for googleOneTapConfig when getGoogleOneTapConfig returns null', () => {
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toBeNull();
   });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
@@ -85,7 +85,10 @@ describe('Signup', () => {
     it('should submit google-one-tap action with credential and correct telemetry', async () => {
       const payload: GoogleOneTapOptions = { one_tap_credential: 'mock-google-id-token' };
       await signup.googleOneTap(payload);
-      expect(FormHandler).toHaveBeenCalledWith(expect.objectContaining({ state: 'mockState' }));
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: 'mockState',
+        telemetry: [ScreenIds.SIGNUP, 'googleOneTap'],
+      });
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
         one_tap_credential: 'mock-google-id-token',
         action: FormActions.GOOGLE_ONE_TAP,

--- a/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
@@ -10,6 +10,7 @@ import { validatePassword as _validatePassword } from '../../../../src/utils/val
 
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 import type { PasswordPolicy, TransactionContext } from '../../../../interfaces/models/transaction';
+import type { GoogleOneTapOptions } from '../../../../interfaces/common';
 import type { SignupOptions, FederatedSignupOptions } from '../../../../interfaces/screens/signup';
 
 
@@ -77,6 +78,23 @@ describe('Signup', () => {
       await signup.federatedSignup(payload);
       expect(FormHandler).toHaveBeenCalledWith(expect.objectContaining({ state: 'mockState' }));
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  describe('googleOneTap', () => {
+    it('should submit google-one-tap action with credential and correct telemetry', async () => {
+      const payload: GoogleOneTapOptions = { one_tap_credential: 'mock-google-id-token' };
+      await signup.googleOneTap(payload);
+      expect(FormHandler).toHaveBeenCalledWith(expect.objectContaining({ state: 'mockState' }));
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
+        one_tap_credential: 'mock-google-id-token',
+        action: FormActions.GOOGLE_ONE_TAP,
+      });
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      (FormHandler.prototype.submitData as jest.Mock).mockRejectedValueOnce(new Error('Mocked reject'));
+      await expect(signup.googleOneTap({ one_tap_credential: 'token' })).rejects.toThrow('Mocked reject');
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/signup/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup/screen-override.test.ts
@@ -1,5 +1,5 @@
 import { ScreenOverride } from '../../../../src/screens/signup/screen-override';
-import { getLoginLink } from '../../../../src/shared/screen';
+import { getLoginLink, getGoogleOneTapConfig } from '../../../../src/shared/screen';
 import { Screen } from '../../../../src/models/screen';
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
@@ -13,6 +13,7 @@ describe('ScreenOverride', () => {
     screenContext = { name: 'signup' } as ScreenContext;
 
     (getLoginLink as jest.Mock).mockReturnValue('mockLoginLink');
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
 
     screenOverride = new ScreenOverride(screenContext);
   });
@@ -27,5 +28,20 @@ describe('ScreenOverride', () => {
 
   it('should extend Screen class', () => {
     expect(screenOverride).toBeInstanceOf(Screen);
+  });
+
+  it('should return googleOneTapConfig when getGoogleOneTapConfig returns config', () => {
+    const config = { client_id: 'id', nonce: 'n', context: 'signup',
+      itp_support: true, auto_select: false, cancel_on_tap_outside: false };
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(config);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toEqual(config);
+    expect(getGoogleOneTapConfig).toHaveBeenCalledWith(screenContext);
+  });
+
+  it('should return null for googleOneTapConfig when getGoogleOneTapConfig returns null', () => {
+    (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
+    const override = new ScreenOverride(screenContext);
+    expect(override.googleOneTapConfig).toBeNull();
   });
 });

--- a/packages/auth0-acul-js/tests/unit/shared/screen.test.ts
+++ b/packages/auth0-acul-js/tests/unit/shared/screen.test.ts
@@ -5,7 +5,8 @@ import {
   getResetPasswordLink,
   getForgotPasswordLink,
   getEditIdentifierLink,
-  getPublicKey
+  getPublicKey,
+  getGoogleOneTapConfig
 } from '../../../src/shared/screen';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type { TransactionContext } from '../../../interfaces/models/transaction';
@@ -109,5 +110,30 @@ describe(':: overrides | when missing links or passkey', () => {
 
   it('should return null if passkey public key is missing', () => {
     expect(getPublicKey(screenWithNoPasskey)).toBeNull();
+  });
+});
+
+describe('getGoogleOneTapConfig', () => {
+  it('returns the google_one_tap config when present', () => {
+    const config = {
+      client_id: 'test-client',
+      nonce: 'test-nonce',
+      context: 'signin',
+      itp_support: true,
+      auto_select: false,
+      cancel_on_tap_outside: true,
+    };
+    const screen = { name: 'login', data: { google_one_tap: config } } as unknown as ScreenContext;
+    expect(getGoogleOneTapConfig(screen)).toEqual(config);
+  });
+
+  it('returns null when google_one_tap is absent', () => {
+    const screen = { name: 'login', data: {} } as ScreenContext;
+    expect(getGoogleOneTapConfig(screen)).toBeNull();
+  });
+
+  it('returns null when data is undefined', () => {
+    const screen = { name: 'login' } as ScreenContext;
+    expect(getGoogleOneTapConfig(screen)).toBeNull();
   });
 });

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -426,3 +426,48 @@ const LoginIdScreen: React.FC = () => {
 export default LoginIdScreen;
 
 ```
+
+### Example using Google One Tap
+
+```tsx
+import React, { useEffect } from 'react';
+import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/login-id';
+
+declare global {
+  interface Window {
+    google?: any;
+  }
+}
+
+const LoginIdScreenWithGoogleOneTap: React.FC = () => {
+  const screen = useScreen();
+  const config = screen.googleOneTapConfig;
+
+  useEffect(() => {
+    if (!config || !window.google) return;
+
+    window.google.accounts.id.initialize({
+      client_id: config.client_id,
+      nonce: config.nonce,
+      context: config.context,
+      itp_support: config.itp_support,
+      auto_select: config.auto_select,
+      cancel_on_tap_outside: config.cancel_on_tap_outside,
+      callback: ({ credential }: { credential: string }) => {
+        googleOneTap({ one_tap_credential: credential });
+      },
+    });
+
+    window.google.accounts.id.prompt();
+  }, [config]);
+
+  return (
+    <div>
+      {/* Google One Tap renders its own overlay — no extra markup needed */}
+      <p>{screen.texts?.title || 'Welcome'}</p>
+    </div>
+  );
+};
+
+export default LoginIdScreenWithGoogleOneTap;
+```

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -429,6 +429,8 @@ export default LoginIdScreen;
 
 ### Example using Google One Tap
 
+The [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/client-library) script is loaded dynamically inside `useEffect` so it only runs when `googleOneTapConfig` is available server-side.
+
 ```tsx
 import React, { useEffect } from 'react';
 import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/login-id';
@@ -444,26 +446,32 @@ const LoginIdScreenWithGoogleOneTap: React.FC = () => {
   const config = screen.googleOneTapConfig;
 
   useEffect(() => {
-    if (!config || !window.google) return;
+    if (!config) return;
 
-    window.google.accounts.id.initialize({
-      client_id: config.client_id,
-      nonce: config.nonce,
-      context: config.context,
-      itp_support: config.itp_support,
-      auto_select: config.auto_select,
-      cancel_on_tap_outside: config.cancel_on_tap_outside,
-      callback: ({ credential }: { credential: string }) => {
-        googleOneTap({ one_tap_credential: credential });
-      },
-    });
-
-    window.google.accounts.id.prompt();
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      window.google?.accounts.id.initialize({
+        client_id: config.client_id,
+        nonce: config.nonce,
+        context: config.context,
+        itp_support: config.itp_support,
+        auto_select: config.auto_select,
+        cancel_on_tap_outside: config.cancel_on_tap_outside,
+        callback: ({ credential }: { credential: string }) => {
+          googleOneTap({ one_tap_credential: credential });
+        },
+      });
+      window.google?.accounts.id.prompt();
+    };
+    document.head.appendChild(script);
 
     return () => {
-      window.google?.accounts.id.cancel();
+      document.head.removeChild(script);
     };
-  }, [config]);
+  }, []);
 
   return (
     <div>

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -459,6 +459,10 @@ const LoginIdScreenWithGoogleOneTap: React.FC = () => {
     });
 
     window.google.accounts.id.prompt();
+
+    return () => {
+      window.google?.accounts.id.cancel();
+    };
   }, [config]);
 
   return (

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -291,3 +291,48 @@ const LoginScreen: React.FC = () => {
 export default LoginScreen;
 
 ```
+
+### Example using Google One Tap
+
+```tsx
+import React, { useEffect } from 'react';
+import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/login';
+
+declare global {
+  interface Window {
+    google?: any;
+  }
+}
+
+const LoginScreenWithGoogleOneTap: React.FC = () => {
+  const screen = useScreen();
+  const config = screen.googleOneTapConfig;
+
+  useEffect(() => {
+    if (!config || !window.google) return;
+
+    window.google.accounts.id.initialize({
+      client_id: config.client_id,
+      nonce: config.nonce,
+      context: config.context,
+      itp_support: config.itp_support,
+      auto_select: config.auto_select,
+      cancel_on_tap_outside: config.cancel_on_tap_outside,
+      callback: ({ credential }: { credential: string }) => {
+        googleOneTap({ one_tap_credential: credential });
+      },
+    });
+
+    window.google.accounts.id.prompt();
+  }, [config]);
+
+  return (
+    <div>
+      {/* Google One Tap renders its own overlay — no extra markup needed */}
+      <p>{screen.texts?.title || 'Welcome'}</p>
+    </div>
+  );
+};
+
+export default LoginScreenWithGoogleOneTap;
+```

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -294,6 +294,8 @@ export default LoginScreen;
 
 ### Example using Google One Tap
 
+The [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/client-library) script is loaded dynamically inside `useEffect` so it only runs when `googleOneTapConfig` is available server-side.
+
 ```tsx
 import React, { useEffect } from 'react';
 import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/login';
@@ -309,26 +311,32 @@ const LoginScreenWithGoogleOneTap: React.FC = () => {
   const config = screen.googleOneTapConfig;
 
   useEffect(() => {
-    if (!config || !window.google) return;
+    if (!config) return;
 
-    window.google.accounts.id.initialize({
-      client_id: config.client_id,
-      nonce: config.nonce,
-      context: config.context,
-      itp_support: config.itp_support,
-      auto_select: config.auto_select,
-      cancel_on_tap_outside: config.cancel_on_tap_outside,
-      callback: ({ credential }: { credential: string }) => {
-        googleOneTap({ one_tap_credential: credential });
-      },
-    });
-
-    window.google.accounts.id.prompt();
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      window.google?.accounts.id.initialize({
+        client_id: config.client_id,
+        nonce: config.nonce,
+        context: config.context,
+        itp_support: config.itp_support,
+        auto_select: config.auto_select,
+        cancel_on_tap_outside: config.cancel_on_tap_outside,
+        callback: ({ credential }: { credential: string }) => {
+          googleOneTap({ one_tap_credential: credential });
+        },
+      });
+      window.google?.accounts.id.prompt();
+    };
+    document.head.appendChild(script);
 
     return () => {
-      window.google?.accounts.id.cancel();
+      document.head.removeChild(script);
     };
-  }, [config]);
+  }, []);
 
   return (
     <div>

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -324,6 +324,10 @@ const LoginScreenWithGoogleOneTap: React.FC = () => {
     });
 
     window.google.accounts.id.prompt();
+
+    return () => {
+      window.google?.accounts.id.cancel();
+    };
   }, [config]);
 
   return (

--- a/packages/auth0-acul-react/examples/signup-id.md
+++ b/packages/auth0-acul-react/examples/signup-id.md
@@ -523,6 +523,49 @@ const SignupIdScreen: React.FC = () => {
 };
 
 export default SignupIdScreen;
+```
 
+### Example using Google One Tap
 
+```tsx
+import React, { useEffect } from 'react';
+import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/signup-id';
+
+declare global {
+  interface Window {
+    google?: any;
+  }
+}
+
+const SignupIdScreenWithGoogleOneTap: React.FC = () => {
+  const screen = useScreen();
+  const config = screen.googleOneTapConfig;
+
+  useEffect(() => {
+    if (!config || !window.google) return;
+
+    window.google.accounts.id.initialize({
+      client_id: config.client_id,
+      nonce: config.nonce,
+      context: config.context,
+      itp_support: config.itp_support,
+      auto_select: config.auto_select,
+      cancel_on_tap_outside: config.cancel_on_tap_outside,
+      callback: ({ credential }: { credential: string }) => {
+        googleOneTap({ one_tap_credential: credential });
+      },
+    });
+
+    window.google.accounts.id.prompt();
+  }, [config]);
+
+  return (
+    <div>
+      {/* Google One Tap renders its own overlay — no extra markup needed */}
+      <p>{screen.texts?.title || 'Sign up'}</p>
+    </div>
+  );
+};
+
+export default SignupIdScreenWithGoogleOneTap;
 ```

--- a/packages/auth0-acul-react/examples/signup-id.md
+++ b/packages/auth0-acul-react/examples/signup-id.md
@@ -527,6 +527,8 @@ export default SignupIdScreen;
 
 ### Example using Google One Tap
 
+The [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/client-library) script is loaded dynamically inside `useEffect` so it only runs when `googleOneTapConfig` is available server-side.
+
 ```tsx
 import React, { useEffect } from 'react';
 import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/signup-id';
@@ -542,26 +544,32 @@ const SignupIdScreenWithGoogleOneTap: React.FC = () => {
   const config = screen.googleOneTapConfig;
 
   useEffect(() => {
-    if (!config || !window.google) return;
+    if (!config) return;
 
-    window.google.accounts.id.initialize({
-      client_id: config.client_id,
-      nonce: config.nonce,
-      context: config.context,
-      itp_support: config.itp_support,
-      auto_select: config.auto_select,
-      cancel_on_tap_outside: config.cancel_on_tap_outside,
-      callback: ({ credential }: { credential: string }) => {
-        googleOneTap({ one_tap_credential: credential });
-      },
-    });
-
-    window.google.accounts.id.prompt();
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      window.google?.accounts.id.initialize({
+        client_id: config.client_id,
+        nonce: config.nonce,
+        context: config.context,
+        itp_support: config.itp_support,
+        auto_select: config.auto_select,
+        cancel_on_tap_outside: config.cancel_on_tap_outside,
+        callback: ({ credential }: { credential: string }) => {
+          googleOneTap({ one_tap_credential: credential });
+        },
+      });
+      window.google?.accounts.id.prompt();
+    };
+    document.head.appendChild(script);
 
     return () => {
-      window.google?.accounts.id.cancel();
+      document.head.removeChild(script);
     };
-  }, [config]);
+  }, []);
 
   return (
     <div>

--- a/packages/auth0-acul-react/examples/signup-id.md
+++ b/packages/auth0-acul-react/examples/signup-id.md
@@ -557,6 +557,10 @@ const SignupIdScreenWithGoogleOneTap: React.FC = () => {
     });
 
     window.google.accounts.id.prompt();
+
+    return () => {
+      window.google?.accounts.id.cancel();
+    };
   }, [config]);
 
   return (

--- a/packages/auth0-acul-react/examples/signup.md
+++ b/packages/auth0-acul-react/examples/signup.md
@@ -377,6 +377,10 @@ const SignupScreenWithGoogleOneTap: React.FC = () => {
     });
 
     window.google.accounts.id.prompt();
+
+    return () => {
+      window.google?.accounts.id.cancel();
+    };
   }, [config]);
 
   return (

--- a/packages/auth0-acul-react/examples/signup.md
+++ b/packages/auth0-acul-react/examples/signup.md
@@ -347,6 +347,8 @@ export default SignupScreen;
 
 ### Example using Google One Tap
 
+The [Google Identity Services (GSI)](https://developers.google.com/identity/gsi/web/guides/client-library) script is loaded dynamically inside `useEffect` so it only runs when `googleOneTapConfig` is available server-side.
+
 ```tsx
 import React, { useEffect } from 'react';
 import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/signup';
@@ -362,26 +364,32 @@ const SignupScreenWithGoogleOneTap: React.FC = () => {
   const config = screen.googleOneTapConfig;
 
   useEffect(() => {
-    if (!config || !window.google) return;
+    if (!config) return;
 
-    window.google.accounts.id.initialize({
-      client_id: config.client_id,
-      nonce: config.nonce,
-      context: config.context,
-      itp_support: config.itp_support,
-      auto_select: config.auto_select,
-      cancel_on_tap_outside: config.cancel_on_tap_outside,
-      callback: ({ credential }: { credential: string }) => {
-        googleOneTap({ one_tap_credential: credential });
-      },
-    });
-
-    window.google.accounts.id.prompt();
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      window.google?.accounts.id.initialize({
+        client_id: config.client_id,
+        nonce: config.nonce,
+        context: config.context,
+        itp_support: config.itp_support,
+        auto_select: config.auto_select,
+        cancel_on_tap_outside: config.cancel_on_tap_outside,
+        callback: ({ credential }: { credential: string }) => {
+          googleOneTap({ one_tap_credential: credential });
+        },
+      });
+      window.google?.accounts.id.prompt();
+    };
+    document.head.appendChild(script);
 
     return () => {
-      window.google?.accounts.id.cancel();
+      document.head.removeChild(script);
     };
-  }, [config]);
+  }, []);
 
   return (
     <div>

--- a/packages/auth0-acul-react/examples/signup.md
+++ b/packages/auth0-acul-react/examples/signup.md
@@ -345,6 +345,51 @@ const SignupScreen: React.FC = () => {
 export default SignupScreen;
 ```
 
+### Example using Google One Tap
+
+```tsx
+import React, { useEffect } from 'react';
+import { useScreen, googleOneTap } from '@auth0/auth0-acul-react/signup';
+
+declare global {
+  interface Window {
+    google?: any;
+  }
+}
+
+const SignupScreenWithGoogleOneTap: React.FC = () => {
+  const screen = useScreen();
+  const config = screen.googleOneTapConfig;
+
+  useEffect(() => {
+    if (!config || !window.google) return;
+
+    window.google.accounts.id.initialize({
+      client_id: config.client_id,
+      nonce: config.nonce,
+      context: config.context,
+      itp_support: config.itp_support,
+      auto_select: config.auto_select,
+      cancel_on_tap_outside: config.cancel_on_tap_outside,
+      callback: ({ credential }: { credential: string }) => {
+        googleOneTap({ one_tap_credential: credential });
+      },
+    });
+
+    window.google.accounts.id.prompt();
+  }, [config]);
+
+  return (
+    <div>
+      {/* Google One Tap renders its own overlay — no extra markup needed */}
+      <p>{screen.texts?.title || 'Sign up'}</p>
+    </div>
+  );
+};
+
+export default SignupScreenWithGoogleOneTap;
+```
+
 ### 2. How It Works
 
 1.  **Imports**: We import `useSignup` and various context hooks from the dedicated `@auth0/auth0-acul-react/signup` entry point.

--- a/packages/auth0-acul-react/src/screens/login-id.tsx
+++ b/packages/auth0-acul-react/src/screens/login-id.tsx
@@ -10,6 +10,7 @@ import type {
   LoginOptions,
   FederatedLoginOptions,
   CustomOptions,
+  GoogleOneTapOptions,
 } from '@auth0/auth0-acul-js/login-id';
 
 // Register the singleton instance of LoginId
@@ -39,6 +40,8 @@ export const federatedLogin = (payload: FederatedLoginOptions) =>
 export const passkeyLogin = (payload?: CustomOptions) => withError(instance.passkeyLogin(payload));
 export const pickCountryCode = (payload?: CustomOptions) =>
   withError(instance.pickCountryCode(payload));
+export const googleOneTap = (payload: GoogleOneTapOptions) =>
+  withError(instance.googleOneTap(payload));
 
 // Utility Hooks
 export { useLoginIdentifiers } from '../hooks/utility/login-identifiers';

--- a/packages/auth0-acul-react/src/screens/login.tsx
+++ b/packages/auth0-acul-react/src/screens/login.tsx
@@ -10,6 +10,7 @@ import type {
   LoginOptions,
   FederatedLoginOptions,
   CustomOptions,
+  GoogleOneTapOptions,
 } from '@auth0/auth0-acul-js/login';
 
 // Register the singleton instance of Login
@@ -38,6 +39,8 @@ export const federatedLogin = (payload: FederatedLoginOptions) =>
   withError(instance.federatedLogin(payload));
 export const pickCountryCode = (payload?: CustomOptions) =>
   withError(instance.pickCountryCode(payload));
+export const googleOneTap = (payload: GoogleOneTapOptions) =>
+  withError(instance.googleOneTap(payload));
 
 // Utility Hooks
 export { useLoginIdentifiers } from '../hooks/utility/login-identifiers';

--- a/packages/auth0-acul-react/src/screens/signup-id.tsx
+++ b/packages/auth0-acul-react/src/screens/signup-id.tsx
@@ -9,6 +9,7 @@ import type {
   SignupIdMembers,
   SignupOptions,
   FederatedSignupOptions,
+  GoogleOneTapOptions,
   CustomOptions,
 } from '@auth0/auth0-acul-js/signup-id';
 
@@ -36,6 +37,8 @@ export const {
 export const signup = (payload: SignupOptions) => withError(instance.signup(payload));
 export const federatedSignup = (payload: FederatedSignupOptions) =>
   withError(instance.federatedSignup(payload));
+export const googleOneTap = (payload: GoogleOneTapOptions) =>
+  withError(instance.googleOneTap(payload));
 export const pickCountryCode = (payload?: CustomOptions) =>
   withError(instance.pickCountryCode(payload));
 

--- a/packages/auth0-acul-react/src/screens/signup.tsx
+++ b/packages/auth0-acul-react/src/screens/signup.tsx
@@ -9,6 +9,7 @@ import type {
   SignupMembers,
   SignupOptions,
   FederatedSignupOptions,
+  GoogleOneTapOptions,
   CustomOptions,
 } from '@auth0/auth0-acul-js/signup';
 
@@ -36,6 +37,8 @@ export const {
 export const signup = (payload: SignupOptions) => withError(instance.signup(payload));
 export const federatedSignup = (payload: FederatedSignupOptions) =>
   withError(instance.federatedSignup(payload));
+export const googleOneTap = (payload: GoogleOneTapOptions) =>
+  withError(instance.googleOneTap(payload));
 export const pickCountryCode = (payload?: CustomOptions) =>
   withError(instance.pickCountryCode(payload));
 

--- a/packages/auth0-acul-react/tests/screens/login-id.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/login-id.test.tsx
@@ -30,6 +30,7 @@ jest.mock('@auth0/auth0-acul-js/login-id', () => {
   return jest.fn().mockImplementation(function MockLoginId(this: any) {
     this.continue = jest.fn(() => Promise.resolve());
     this.submit = jest.fn(() => Promise.resolve());
+    this.googleOneTap = jest.fn(() => Promise.resolve());
   });
 }, { virtual: true });
 
@@ -170,6 +171,18 @@ describe('LoginId Screen', () => {
           // Function may require specific parameters
         }
       });
+    });
+  });
+
+  describe('googleOneTap', () => {
+    it('should export googleOneTap as a function', () => {
+      expect(typeof LoginIdScreen.googleOneTap).toBe('function');
+    });
+
+    it('should call instance.googleOneTap with the provided payload', () => {
+      const payload = { one_tap_credential: 'test-credential' };
+      const result = LoginIdScreen.googleOneTap(payload);
+      expect(result).toBeDefined();
     });
   });
 });

--- a/packages/auth0-acul-react/tests/screens/login.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/login.test.tsx
@@ -13,7 +13,9 @@ jest.mock('@auth0/auth0-acul-js', () => ({
 
 // Mock the core SDK class
 jest.mock('@auth0/auth0-acul-js/login', () => {
-  return jest.fn().mockImplementation(() => {});
+  return jest.fn().mockImplementation(function MockLogin(this: any) {
+    this.googleOneTap = jest.fn(() => Promise.resolve());
+  });
 }, { virtual: true });
 
 // Mock the instance store
@@ -146,6 +148,18 @@ describe('Login Screen', () => {
           // Function may require specific parameters
         }
       });
+    });
+  });
+
+  describe('googleOneTap', () => {
+    it('should export googleOneTap as a function', () => {
+      expect(typeof LoginScreen.googleOneTap).toBe('function');
+    });
+
+    it('should call instance.googleOneTap with the provided payload', () => {
+      const payload = { one_tap_credential: 'test-credential' };
+      const result = LoginScreen.googleOneTap(payload);
+      expect(result).toBeDefined();
     });
   });
 });

--- a/packages/auth0-acul-react/tests/screens/signup-id.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/signup-id.test.tsx
@@ -31,6 +31,7 @@ jest.mock('@auth0/auth0-acul-js/signup-id', () => {
     // Add any instance methods/hooks that the screen might use
     this.continue = jest.fn(() => Promise.resolve());
     this.submit = jest.fn(() => Promise.resolve());
+    this.googleOneTap = jest.fn(() => Promise.resolve());
   });
 }, { virtual: true });
 
@@ -171,6 +172,18 @@ describe('SignupId Screen', () => {
           // Function may require specific parameters
         }
       });
+    });
+  });
+
+  describe('googleOneTap', () => {
+    it('should export googleOneTap as a function', () => {
+      expect(typeof SignupIdScreen.googleOneTap).toBe('function');
+    });
+
+    it('should call instance.googleOneTap with the provided payload', () => {
+      const payload = { one_tap_credential: 'test-credential' };
+      const result = SignupIdScreen.googleOneTap(payload);
+      expect(result).toBeDefined();
     });
   });
 });

--- a/packages/auth0-acul-react/tests/screens/signup.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/signup.test.tsx
@@ -13,7 +13,9 @@ jest.mock('@auth0/auth0-acul-js', () => ({
 
 // Mock the core SDK class
 jest.mock('@auth0/auth0-acul-js/signup', () => {
-  return jest.fn().mockImplementation(() => {});
+  return jest.fn().mockImplementation(function MockSignup(this: any) {
+    this.googleOneTap = jest.fn(() => Promise.resolve());
+  });
 }, { virtual: true });
 
 // Mock the instance store
@@ -156,6 +158,18 @@ describe('Signup Screen', () => {
           // Function may require specific parameters
         }
       });
+    });
+  });
+
+  describe('googleOneTap', () => {
+    it('should export googleOneTap as a function', () => {
+      expect(typeof SignupScreen.googleOneTap).toBe('function');
+    });
+
+    it('should call instance.googleOneTap with the provided payload', () => {
+      const payload = { one_tap_credential: 'test-credential' };
+      const result = SignupScreen.googleOneTap(payload);
+      expect(result).toBeDefined();
     });
   });
 });


### PR DESCRIPTION


## Summary

This PR adds Google One Tap (FedCM) support to the `login`, `login-id`, `signup`, and `signup-id` screens.

When the server provides a `google_one_tap` config in `screen.data`, the SDK now:

- Exposes the server-provided config via `screen.googleOneTapConfig` (`client_id`, `nonce`, `context`, `itp_support`, `auto_select`, `cancel_on_tap_outside`)
- Provides a `googleOneTap({ one_tap_credential })` method to submit the Google ID token returned by the GSI SDK to Auth0

## Test plan

**Manual: One Tap prompt**
- [ ] `login-id`: One Tap overlay appears automatically on page load
- [ ] `login`: One Tap overlay appears automatically on page load
- [ ] `signup-id`: One Tap overlay appears automatically on page load
- [ ] `signup`: One Tap overlay appears automatically on page load

https://github.com/user-attachments/assets/692e5635-e03f-4c70-b929-f739a03ed352

