### PR TITLE
fix(ci): remove npm install pre-scan command so SCA scan succeeds and telemetry is sent

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -10,7 +10,6 @@ jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
     with:
-      pre-scan-commands: "npm install"
       additional-arguments: "--exclude=README.md"
       node-version: 22
     secrets: inherit


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The SCA scan workflow was failing, causing `snyk-cli / send_telemetry` to be skipped so no scan telemetry was reported.

Root cause: this is an npm workspaces monorepo with a single root `package-lock.json` and no lockfiles in the nested `packages/*`. The `pre-scan-commands: "npm install"` only resolved at the root, so Snyk failed when it reached the lockfile-less nested `package.json` files.

Fix: removed `pre-scan-commands: "npm install"`. The reusable workflow already handles `package.json` files without lockfiles, so the manual install was both redundant and the cause of the failure. With the scan succeeding, `send_telemetry` runs instead of being skipped. The scan remains non-blocking (findings surface as annotations).

### References

- Reference working example: [auth0/docs-v2 SCA workflow](https://github.com/auth0/docs-v2)

### Testing

- On this PR/push, confirm `snyk-cli / monitor` succeeds and `snyk-cli / send_telemetry` runs (green) rather than skipped.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
