### PR TITLE
fix(ci): install workspace deps via npm ci before SCA scan

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -10,6 +10,7 @@ jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
     with:
+      pre-scan-commands: "npm ci --workspaces --include-workspace-root"
       additional-arguments: "--exclude=README.md"
       node-version: 22
     secrets: inherit


### PR DESCRIPTION
## Changes
  - Add `pre-scan-commands: "npm ci --workspaces --include-workspace-root"` to the SCA workflow so all workspace packages (including `auth0-acul-react`) have
  `node_modules` installed before Snyk scans them.
  - Uses `npm ci` instead of `npm install` for deterministic, lockfile-based installs consistent with `release.yml`.

  ## Why
  The prior fix (#[PR number]) removed the pre-scan `npm install` step to work around an `npm error E401` during install. That fixed the auth error but left
  `auth0-acul-react` without dependencies in CI, causing Snyk to fail that sub-project scan with `Missing node_modules folder`. Restoring dependency installation — this
  time scoped to workspaces via `npm ci` — fixes the scan without reintroducing the original failure.

  ## Test plan
  - [ ] Confirm the `snyk-cli / monitor` job in CI completes without the `Snyk scan failed with exit code 2` annotation
  - [ ] Confirm `auth0-acul-react` shows up as a monitored project in the Snyk dashboard for this run
  - [ ] Confirm the pre-scan `npm ci` step doesn't reintroduce the earlier `E401` error