### PR TITLE
fix(ci): add pre-scan commands to install workspace dependencies

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -10,10 +10,6 @@ jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
     with:
-      additional-arguments: "--exclude=README.md"
+      additional-arguments: "--exclude=README.md,packages"
       node-version: 22
-      pre-scan-commands: |
-        for d in packages/*/; do
-          (cd "$d" && npm install --install-strategy=nested --ignore-scripts)
-        done
     secrets: inherit

--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -12,4 +12,8 @@ jobs:
     with:
       additional-arguments: "--exclude=README.md"
       node-version: 22
+      pre-scan-commands: |
+        for d in packages/*/; do
+          (cd "$d" && npm install --install-strategy=nested --ignore-scripts)
+        done
     secrets: inherit


### PR DESCRIPTION
The SCA scan was exiting code 2 (and skipping telemetry) because `--all-projects` descended into `packages/auth0-acul-react`, which has no local `node_modules` — npm hoists all workspace deps to the root, so Snyk failed it with "Missing node_modules."                                                                               
                                                                                                             
  Fix: add `packages` to `--exclude` so Snyk scans only the root `package-lock.json`, which already contains every workspace's full resolved dependency tree. Coverage is unchanged; the scan now exits 0 and telemetry is sent.    