### PR TITLE
feat: add support for confirmation screen

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -232,6 +232,7 @@ Get up and running quickly with our boilerplate starter template: [Link](https:/
 | 74     |consent                   | consent | [Link](https://auth0.github.io/universal-login/auth0-acul-js/classes/Screens.consent.html)   |
 | 75     |customized-consent        | customized-consent | [Link](https://auth0.github.io/universal-login/auth0-acul-js/classes/Screens.CustomizedConsent.html)   |
 | 76     |email-otp-challenge                   | email-otp-challenge | [Link](https://auth0.github.io/universal-login/auth0-acul-js/classes/Screens.EmailOTPChallenge.html)   |
+| 77     |confirmation                   | confirmation | [Link](https://auth0.github.io/universal-login/auth0-acul-js/classes/Screens.Confirmation.html)   |
 </details>
 
 

--- a/packages/auth0-acul-js/examples/confirmation.md
+++ b/packages/auth0-acul-js/examples/confirmation.md
@@ -1,0 +1,93 @@
+import Confirmation from '@auth0/auth0-acul-js/confirmation';
+
+# Confirmation Screen
+
+This screen is displayed to let users confirm or decline account creation (auto-signup) after OTP verification.
+
+## React Component Example with TailwindCSS
+
+```tsx
+import React from 'react';
+import Confirmation from '@auth0/auth0-acul-js/confirmation';
+
+const ConfirmationScreen: React.FC = () => {
+  const confirmationManager = new Confirmation();
+  const { screen, transaction: { errors } } = confirmationManager;
+  const texts = screen?.texts || {};
+
+  const handleProceedToSignup = async () => {
+    await confirmationManager.proceedToSignup();
+  };
+
+  const handleGoBack = async () => {
+    await confirmationManager.goBack();
+  };
+
+  return (
+    <div className="flex flex-col items-center min-h-screen bg-gray-100 px-4">
+      <div className="bg-white shadow-md rounded-xl p-6 w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-bold text-center">
+          {texts.title ?? 'Confirm Account Creation'}
+        </h1>
+
+        {texts.description && (
+          <p className="text-sm text-gray-600 text-center">
+            {texts.description}
+          </p>
+        )}
+
+        {errors?.length && (
+          <div className="mt-2 space-y-1 text-left">
+            {errors.map((error, idx) => (
+              <p key={idx} className="text-red-600 text-sm">
+                {error.message}
+              </p>
+            ))}
+          </div>
+        )}
+
+        <div className="flex justify-between mt-6">
+          <button
+            className="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-2 px-4 rounded-lg w-[45%]"
+            onClick={handleGoBack}
+          >
+            {texts.backButtonText ?? 'Back'}
+          </button>
+          <button
+            className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg w-[45%]"
+            onClick={handleProceedToSignup}
+          >
+            {texts.confirmButtonText ?? 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmationScreen;
+```
+
+## Usage Examples
+
+### Proceed to Signup
+
+```typescript
+import Confirmation from '@auth0/auth0-acul-js/confirmation';
+
+const confirmation = new Confirmation();
+
+// Proceed with account creation after OTP verification
+await confirmation.proceedToSignup();
+```
+
+### Go Back
+
+```typescript
+import Confirmation from '@auth0/auth0-acul-js/confirmation';
+
+const confirmation = new Confirmation();
+
+// Navigate back to the previous screen
+await confirmation.goBack();
+```

--- a/packages/auth0-acul-js/examples/confirmation.md
+++ b/packages/auth0-acul-js/examples/confirmation.md
@@ -1,5 +1,3 @@
-import Confirmation from '@auth0/auth0-acul-js/confirmation';
-
 # Confirmation Screen
 
 This screen is displayed to let users confirm or decline account creation (auto-signup) after OTP verification.

--- a/packages/auth0-acul-js/examples/confirmation.md
+++ b/packages/auth0-acul-js/examples/confirmation.md
@@ -86,6 +86,6 @@ import Confirmation from '@auth0/auth0-acul-js/confirmation';
 
 const confirmation = new Confirmation();
 
-// Navigate back to the previous screen
+// Decline auto-signup and return to the login screen without creating an account
 await confirmation.goBack();
 ```

--- a/packages/auth0-acul-js/interfaces/export/screen-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/screen-properties.ts
@@ -77,3 +77,4 @@ export type { ResetPasswordMfaWebAuthnRoamingChallengeMembers } from '../screens
 export type { BruteForceProtectionUnblockMembers } from '../screens/brute-force-protection-unblock';
 export type { BruteForceProtectionUnblockFailureMembers, ScreenMembersOnBruteForceProtectionUnblockFailure } from '../screens/brute-force-protection-unblock-failure';
 export type { BruteForceProtectionUnblockSuccessMembers, ScreenMembersOnBruteForceProtectionUnblockSuccess } from '../screens/brute-force-protection-unblock-success';
+export type { ConfirmationMembers } from '../screens/confirmation';

--- a/packages/auth0-acul-js/interfaces/screens/confirmation.ts
+++ b/packages/auth0-acul-js/interfaces/screens/confirmation.ts
@@ -1,0 +1,19 @@
+import type { CustomOptions } from '../common';
+import type { BaseMembers } from '../models/base-context';
+
+/**
+ * Interface describing the members of the Confirmation screen.
+ */
+export interface ConfirmationMembers extends BaseMembers {
+  /**
+   * Proceeds with account creation after OTP verification.
+   * @param payload Optional custom options to include with the request.
+   */
+  proceedToSignup(payload?: CustomOptions): Promise<void>;
+
+  /**
+   * Navigates back to the previous screen.
+   * @param payload Optional custom options to include with the request.
+   */
+  goBack(payload?: CustomOptions): Promise<void>;
+}

--- a/packages/auth0-acul-js/interfaces/screens/confirmation.ts
+++ b/packages/auth0-acul-js/interfaces/screens/confirmation.ts
@@ -12,7 +12,7 @@ export interface ConfirmationMembers extends BaseMembers {
   proceedToSignup(payload?: CustomOptions): Promise<void>;
 
   /**
-   * Navigates back to the previous screen.
+   * Declines auto-signup and returns the user to the login screen without creating an account.
    * @param payload Optional custom options to include with the request.
    */
   goBack(payload?: CustomOptions): Promise<void>;

--- a/packages/auth0-acul-js/interfaces/screens/index.ts
+++ b/packages/auth0-acul-js/interfaces/screens/index.ts
@@ -63,3 +63,4 @@ export * as ResetPasswordMfaWebAuthnRoamingChallenge from './reset-password-mfa-
 export * as BruteForceProtectionUnblock from './brute-force-protection-unblock';
 export * as BruteForceProtectionUnblockFailure from './brute-force-protection-unblock-failure';
 export * as BruteForceProtectionUnblockSuccess from './brute-force-protection-unblock-success';
+export * as Confirmation from './confirmation';

--- a/packages/auth0-acul-js/src/constants/enums.ts
+++ b/packages/auth0-acul-js/src/constants/enums.ts
@@ -74,5 +74,6 @@ export const ScreenIds = {
   MFA_WEBAUTHN_CHANGE_KEY_NICKNAME: 'mfa-webauthn-change-key-nickname',
   CONSENT: 'consent',
   RESET_PASSWORD_MFA_WEBAUTHN_PLATFORM_CHALLENGE: 'reset-password-mfa-webauthn-platform-challenge',
-  RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE: 'reset-password-mfa-webauthn-roaming-challenge', 
+  RESET_PASSWORD_MFA_WEBAUTHN_ROAMING_CHALLENGE: 'reset-password-mfa-webauthn-roaming-challenge',
+  CONFIRMATION: 'confirmation',
 };

--- a/packages/auth0-acul-js/src/constants/form-actions.ts
+++ b/packages/auth0-acul-js/src/constants/form-actions.ts
@@ -33,4 +33,5 @@ export const FormActions = {
   SWITCH_TO_OTP_AUTH: 'switch-to-otp-auth' as const,
   SWITCH_TO_PASSWORD_AUTH: 'switch-to-password-auth' as const,
   GOOGLE_ONE_TAP: 'google-one-tap' as const,
+  PROCEED_TO_SIGNUP: 'proceed-to-signup' as const,
 } as const;

--- a/packages/auth0-acul-js/src/screens/confirmation/index.ts
+++ b/packages/auth0-acul-js/src/screens/confirmation/index.ts
@@ -1,0 +1,64 @@
+import { ScreenIds, FormActions } from '../../constants';
+import { BaseContext } from '../../models/base-context';
+import { FormHandler } from '../../utils/form-handler';
+
+import type { CustomOptions } from '../../../interfaces/common';
+import type { ConfirmationMembers } from '../../../interfaces/screens/confirmation';
+import type { FormOptions } from '../../../interfaces/utils/form-handler';
+
+/**
+ * Class implementing the Confirmation screen functionality.
+ * This screen allows users to confirm or decline auto-signup after OTP verification.
+ */
+export default class Confirmation extends BaseContext implements ConfirmationMembers {
+  static screenIdentifier: string = ScreenIds.CONFIRMATION;
+
+  /**
+   * Creates an instance of the Confirmation screen.
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * Proceeds with account creation after OTP verification.
+   * @param payload Optional custom options to include with the request.
+   * @example
+   * ```typescript
+   * import Confirmation from '@auth0/auth0-acul-js/confirmation';
+   *
+   * const confirmation = new Confirmation();
+   * await confirmation.proceedToSignup();
+   * ```
+   */
+  async proceedToSignup(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [Confirmation.screenIdentifier, 'proceedToSignup'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.PROCEED_TO_SIGNUP });
+  }
+
+  /**
+   * Navigates back to the previous screen.
+   * @param payload Optional custom options to include with the request.
+   * @example
+   * ```typescript
+   * import Confirmation from '@auth0/auth0-acul-js/confirmation';
+   *
+   * const confirmation = new Confirmation();
+   * await confirmation.goBack();
+   * ```
+   */
+  async goBack(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [Confirmation.screenIdentifier, 'goBack'],
+    };
+    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
+  }
+}
+
+export { ConfirmationMembers };
+export * from '../../../interfaces/export/common';
+export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/src/screens/confirmation/index.ts
+++ b/packages/auth0-acul-js/src/screens/confirmation/index.ts
@@ -42,7 +42,10 @@ export default class Confirmation extends BaseContext implements ConfirmationMem
       state: this.transaction.state,
       telemetry: [Confirmation.screenIdentifier, 'proceedToSignup'],
     };
-    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.PROCEED_TO_SIGNUP });
+
+    const submitPayload = { ...payload, action: FormActions.PROCEED_TO_SIGNUP };
+
+    await new FormHandler(options).submitData<typeof submitPayload>(submitPayload);
   }
 
   /**
@@ -65,7 +68,10 @@ export default class Confirmation extends BaseContext implements ConfirmationMem
       state: this.transaction.state,
       telemetry: [Confirmation.screenIdentifier, 'goBack'],
     };
-    await new FormHandler(options).submitData<CustomOptions>({ ...payload, action: FormActions.BACK });
+
+    const submitPayload = { ...payload, action: FormActions.BACK };
+
+    await new FormHandler(options).submitData<typeof submitPayload>(submitPayload);
   }
 }
 

--- a/packages/auth0-acul-js/src/screens/confirmation/index.ts
+++ b/packages/auth0-acul-js/src/screens/confirmation/index.ts
@@ -49,7 +49,7 @@ export default class Confirmation extends BaseContext implements ConfirmationMem
   }
 
   /**
-   * Navigates back to the previous screen.
+   * Declines auto-signup and returns the user to the login screen without creating an account.
    * @param payload Optional custom options to include with the request.
    * @throws {Error} Throws an error if `FormHandler` encounters an unrecoverable issue
    *                 during submission (e.g., network error). Server-side validation errors

--- a/packages/auth0-acul-js/src/screens/confirmation/index.ts
+++ b/packages/auth0-acul-js/src/screens/confirmation/index.ts
@@ -15,6 +15,8 @@ export default class Confirmation extends BaseContext implements ConfirmationMem
 
   /**
    * Creates an instance of the Confirmation screen.
+   * @throws {Error} If the Universal Login Context is not available or if the
+   * current screen name in the context does not match `Confirmation.screenIdentifier`.
    */
   constructor() {
     super();
@@ -23,6 +25,10 @@ export default class Confirmation extends BaseContext implements ConfirmationMem
   /**
    * Proceeds with account creation after OTP verification.
    * @param payload Optional custom options to include with the request.
+   * @throws {Error} Throws an error if `FormHandler` encounters an unrecoverable issue
+   *                 during submission (e.g., network error). Server-side validation errors
+   *                 from Auth0 are not thrown as JavaScript errors but are made available
+   *                 in `this.transaction.errors` after the operation.
    * @example
    * ```typescript
    * import Confirmation from '@auth0/auth0-acul-js/confirmation';
@@ -42,6 +48,10 @@ export default class Confirmation extends BaseContext implements ConfirmationMem
   /**
    * Navigates back to the previous screen.
    * @param payload Optional custom options to include with the request.
+   * @throws {Error} Throws an error if `FormHandler` encounters an unrecoverable issue
+   *                 during submission (e.g., network error). Server-side validation errors
+   *                 from Auth0 are not thrown as JavaScript errors but are made available
+   *                 in `this.transaction.errors` after the operation.
    * @example
    * ```typescript
    * import Confirmation from '@auth0/auth0-acul-js/confirmation';

--- a/packages/auth0-acul-js/src/screens/index.ts
+++ b/packages/auth0-acul-js/src/screens/index.ts
@@ -77,3 +77,4 @@ export { default as ResetPasswordMfaWebAuthnRoamingChallenge } from './reset-pas
 export { default as BruteForceProtectionUnblock } from './brute-force-protection-unblock';
 export { default as BruteForceProtectionUnblockFailure } from './brute-force-protection-unblock-failure';
 export { default as BruteForceProtectionUnblockSuccess } from './brute-force-protection-unblock-success';
+export { default as Confirmation } from './confirmation';

--- a/packages/auth0-acul-js/tests/unit/screens/confirmation/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/confirmation/index.test.ts
@@ -39,6 +39,22 @@ describe('Confirmation', () => {
       });
     });
 
+    it('should construct FormHandler with state and telemetry', async () => {
+      await confirmation.proceedToSignup();
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: baseContextData.transaction.state,
+        telemetry: [ScreenIds.CONFIRMATION, 'proceedToSignup'],
+      });
+    });
+
+    it('should merge custom payload with the action', async () => {
+      await confirmation.proceedToSignup({ foo: 'bar' });
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        foo: 'bar',
+        action: 'proceed-to-signup',
+      });
+    });
+
     it('should throw if FormHandler.submitData rejects', async () => {
       mockFormHandler.submitData.mockRejectedValue(new Error('Submit failed'));
       await expect(confirmation.proceedToSignup()).rejects.toThrow('Submit failed');
@@ -49,6 +65,22 @@ describe('Confirmation', () => {
     it('should call FormHandler.submitData with action "back-action"', async () => {
       await confirmation.goBack();
       expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        action: 'back-action',
+      });
+    });
+
+    it('should construct FormHandler with state and telemetry', async () => {
+      await confirmation.goBack();
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: baseContextData.transaction.state,
+        telemetry: [ScreenIds.CONFIRMATION, 'goBack'],
+      });
+    });
+
+    it('should merge custom payload with the action', async () => {
+      await confirmation.goBack({ foo: 'bar' });
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        foo: 'bar',
         action: 'back-action',
       });
     });

--- a/packages/auth0-acul-js/tests/unit/screens/confirmation/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/confirmation/index.test.ts
@@ -1,0 +1,61 @@
+import Confirmation from '../../../../src/screens/confirmation';
+import { baseContextData } from '../../../data/test-data';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { ScreenIds } from '../../../../src/constants';
+
+jest.mock('../../../../src/utils/form-handler');
+
+describe('Confirmation', () => {
+  let confirmation: Confirmation;
+  let mockFormHandler: { submitData: jest.Mock };
+
+  beforeEach(() => {
+    global.window = Object.create(window);
+    baseContextData.screen.name = ScreenIds.CONFIRMATION;
+    window.universal_login_context = baseContextData;
+
+    mockFormHandler = {
+      submitData: jest.fn(),
+    };
+    (FormHandler as jest.Mock).mockImplementation(() => mockFormHandler);
+
+    confirmation = new Confirmation();
+  });
+
+  it('should have a static screenIdentifier property', () => {
+    expect(Confirmation.screenIdentifier).toBeDefined();
+    expect(Confirmation.screenIdentifier).toBe(ScreenIds.CONFIRMATION);
+  });
+
+  it('should create an instance of Confirmation', () => {
+    expect(confirmation).toBeInstanceOf(Confirmation);
+  });
+
+  describe('proceedToSignup', () => {
+    it('should call FormHandler.submitData with action "proceed-to-signup"', async () => {
+      await confirmation.proceedToSignup();
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        action: 'proceed-to-signup',
+      });
+    });
+
+    it('should throw if FormHandler.submitData rejects', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Submit failed'));
+      await expect(confirmation.proceedToSignup()).rejects.toThrow('Submit failed');
+    });
+  });
+
+  describe('goBack', () => {
+    it('should call FormHandler.submitData with action "back-action"', async () => {
+      await confirmation.goBack();
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        action: 'back-action',
+      });
+    });
+
+    it('should throw if FormHandler.submitData rejects', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Go back failed'));
+      await expect(confirmation.goBack()).rejects.toThrow('Go back failed');
+    });
+  });
+});

--- a/packages/auth0-acul-react/README.md
+++ b/packages/auth0-acul-react/README.md
@@ -215,6 +215,7 @@ Refer to our [API Reference](#api-reference) for the full list of available type
 | 74     |consent                   | consent | [Link](https://auth0.github.io/universal-login/auth0-acul-react/modules/Screens.consent.html)   |
 | 75     |customized-consent        | customized-consent | [Link](https://auth0.github.io/universal-login/auth0-acul-react/modules/Screens.customized-consent.html)   |
 | 76     |email-otp-challenge                   | email-otp-challenge | [Link](https://auth0.github.io/universal-login/auth0-acul-react/modules/Screens.email-otp-challenge.html)   |
+| 77     |confirmation                   | confirmation | [Link](https://auth0.github.io/universal-login/auth0-acul-react/modules/Screens.confirmation.html)   |
 </details>
 
 ---

--- a/packages/auth0-acul-react/examples/confirmation.md
+++ b/packages/auth0-acul-react/examples/confirmation.md
@@ -1,0 +1,100 @@
+# `confirmation`
+
+The `confirmation` screen is used to let users confirm or decline account creation (auto-signup) after OTP verification.
+
+## ⚛️ React Example
+
+This example demonstrates how to build a React component for the `confirmation` screen.
+
+### 1. Create the Component
+
+Create a component file (e.g., `Confirmation.tsx`) and add the following code:
+
+```tsx
+import React, { useState } from 'react';
+import {
+  useConfirmation,
+  proceedToSignup,
+  goBack,
+  useUser,
+  useTenant,
+  useBranding,
+  useClient,
+  useOrganization,
+  usePrompt,
+  useUntrustedData
+} from '@auth0/auth0-acul-react/confirmation';
+
+export const Confirmation: React.FC = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Main hook for screen logic
+  const screen = useConfirmation();
+
+  // Context hooks
+  const userData = useUser();
+  const tenantData = useTenant();
+  const brandingData = useBranding();
+  const clientData = useClient();
+  const organizationData = useOrganization();
+  const promptData = usePrompt();
+  const untrusteddataData = useUntrustedData();
+
+  const handleProceedToSignup = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await proceedToSignup();
+      // On success, the core SDK handles redirection.
+    } catch (err: any) {
+      setError(err.message || 'An unexpected error occurred.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleGoBack = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await goBack();
+    } catch (err: any) {
+      setError(err.message || 'An unexpected error occurred.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Confirmation</h1>
+
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+
+      <button onClick={handleGoBack} disabled={isLoading}>
+        Back
+      </button>
+      <button onClick={handleProceedToSignup} disabled={isLoading}>
+        {isLoading ? 'Processing...' : 'Confirm'}
+      </button>
+    </div>
+  );
+};
+```
+
+### 2. How It Works
+
+1.  **Imports**: We import `useConfirmation` and the `proceedToSignup`/`goBack` action functions, plus various context hooks from the dedicated `@auth0/auth0-acul-react/confirmation` entry point.
+2.  **Hooks**:
+    *   `useConfirmation()`: Provides the core screen instance for reading screen/transaction data.
+    *   `proceedToSignup()` / `goBack()`: Error-managed action functions that submit the corresponding action to the server.
+    *   Context hooks like `useUser()` and `useTenant()` provide read-only data about the current state.
+3.  **State Management**: `useState` is used to manage loading indicators and error messages.
+4.  **Actions**:
+    *   `handleProceedToSignup` calls `proceedToSignup()` to confirm account creation.
+    *   `handleGoBack` calls `goBack()` to return to the previous screen.
+    *   The core SDK will handle the API request and subsequent redirection on success.
+    *   Errors are caught and can be displayed to the user.

--- a/packages/auth0-acul-react/examples/confirmation.md
+++ b/packages/auth0-acul-react/examples/confirmation.md
@@ -95,6 +95,6 @@ export const Confirmation: React.FC = () => {
 3.  **State Management**: `useState` is used to manage loading indicators and error messages.
 4.  **Actions**:
     *   `handleProceedToSignup` calls `proceedToSignup()` to confirm account creation.
-    *   `handleGoBack` calls `goBack()` to return to the previous screen.
+    *   `handleGoBack` calls `goBack()` to decline auto-signup and return to the login screen without creating an account.
     *   The core SDK will handle the API request and subsequent redirection on success.
     *   Errors are caught and can be displayed to the user.

--- a/packages/auth0-acul-react/examples/confirmation.md
+++ b/packages/auth0-acul-react/examples/confirmation.md
@@ -39,7 +39,7 @@ export const Confirmation: React.FC = () => {
   const clientData = useClient();
   const organizationData = useOrganization();
   const promptData = usePrompt();
-  const untrusteddataData = useUntrustedData();
+  const untrustedData = useUntrustedData();
 
   const handleProceedToSignup = async () => {
     setIsLoading(true);

--- a/packages/auth0-acul-react/src/index.ts
+++ b/packages/auth0-acul-react/src/index.ts
@@ -80,6 +80,7 @@ export { useResetPasswordMfaWebAuthnRoamingChallenge } from './screens/reset-pas
 export { useBruteForceProtectionUnblock } from './screens/brute-force-protection-unblock';
 export { useBruteForceProtectionUnblockFailure } from './screens/brute-force-protection-unblock-failure';
 export { useBruteForceProtectionUnblockSuccess } from './screens/brute-force-protection-unblock-success';
+export { useConfirmation } from './screens/confirmation';
 export { useCurrentScreen, useErrors, useAuth0Themes, useChangeLanguage } from './hooks';
 
 // Common types from core SDK

--- a/packages/auth0-acul-react/src/screens/confirmation.tsx
+++ b/packages/auth0-acul-react/src/screens/confirmation.tsx
@@ -28,7 +28,8 @@ export const {
 } = factory;
 
 // Submit functions
-export const proceedToSignup = (payload?: CustomOptions) => withError(instance.proceedToSignup(payload));
+export const proceedToSignup = (payload?: CustomOptions) =>
+  withError(instance.proceedToSignup(payload));
 export const goBack = (payload?: CustomOptions) => withError(instance.goBack(payload));
 
 // Common hooks

--- a/packages/auth0-acul-react/src/screens/confirmation.tsx
+++ b/packages/auth0-acul-react/src/screens/confirmation.tsx
@@ -2,12 +2,16 @@ import Confirmation from '@auth0/auth0-acul-js/confirmation';
 import { useMemo } from 'react';
 
 import { ContextHooks } from '../hooks';
+import { errorManager } from '../hooks';
 import { registerScreen } from '../state/instance-store';
 
-import type { ConfirmationMembers } from '@auth0/auth0-acul-js/confirmation';
+import type { ConfirmationMembers, CustomOptions } from '@auth0/auth0-acul-js/confirmation';
 
 // Register the singleton instance of Confirmation
 const instance = registerScreen<ConfirmationMembers>(Confirmation)!;
+
+// Error wrapper
+const { withError } = errorManager;
 
 // Context hooks
 const factory = new ContextHooks<ConfirmationMembers>(instance);
@@ -22,6 +26,10 @@ export const {
   useTransaction,
   useUntrustedData,
 } = factory;
+
+// Submit functions
+export const proceedToSignup = (payload?: CustomOptions) => withError(instance.proceedToSignup(payload));
+export const goBack = (payload?: CustomOptions) => withError(instance.goBack(payload));
 
 // Common hooks
 export { useCurrentScreen, useErrors, useAuth0Themes, useChangeLanguage } from '../hooks';

--- a/packages/auth0-acul-react/src/screens/confirmation.tsx
+++ b/packages/auth0-acul-react/src/screens/confirmation.tsx
@@ -1,0 +1,30 @@
+import Confirmation from '@auth0/auth0-acul-js/confirmation';
+import { useMemo } from 'react';
+
+import { ContextHooks } from '../hooks';
+import { registerScreen } from '../state/instance-store';
+
+import type { ConfirmationMembers } from '@auth0/auth0-acul-js/confirmation';
+
+// Register the singleton instance of Confirmation
+const instance = registerScreen<ConfirmationMembers>(Confirmation)!;
+
+// Context hooks
+const factory = new ContextHooks<ConfirmationMembers>(instance);
+export const {
+  useUser,
+  useTenant,
+  useBranding,
+  useClient,
+  useOrganization,
+  usePrompt,
+  useScreen,
+  useTransaction,
+  useUntrustedData,
+} = factory;
+
+// Common hooks
+export { useCurrentScreen, useErrors, useAuth0Themes, useChangeLanguage } from '../hooks';
+
+// Main instance hook. Returns singleton instance of Confirmation
+export const useConfirmation = (): ConfirmationMembers => useMemo(() => instance, []);

--- a/packages/auth0-acul-react/tests/screens/confirmation.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/confirmation.test.tsx
@@ -1,0 +1,150 @@
+import { renderHook } from '@testing-library/react';
+import * as ConfirmationScreen from '../../src/screens/confirmation';
+import { categorizeScreenExports } from './test-helpers';
+
+// Mock the base @auth0/auth0-acul-js module
+jest.mock('@auth0/auth0-acul-js', () => ({
+  ConfigurationError: class ConfigurationError extends Error {},
+  ValidationError: class ValidationError extends Error {},
+  Auth0Error: class Auth0Error extends Error {},
+  NetworkError: class NetworkError extends Error {},
+  __esModule: true,
+}), { virtual: true });
+
+// Mock the core SDK class
+jest.mock('@auth0/auth0-acul-js/confirmation', () => {
+  return jest.fn().mockImplementation(() => {});
+}, { virtual: true });
+
+// Mock the instance store
+jest.mock('../../src/state/instance-store', () => ({
+  registerScreen: jest.fn((Screen) => new Screen()),
+}));
+
+// Mock error manager and hooks
+jest.mock('../../src/hooks', () => ({
+  errorManager: {
+    withError: jest.fn((promise) => promise),
+  },
+  ContextHooks: jest.fn().mockImplementation(() => ({
+    useUser: jest.fn(),
+    useTenant: jest.fn(),
+    useBranding: jest.fn(),
+    useClient: jest.fn(),
+    useOrganization: jest.fn(),
+    usePrompt: jest.fn(),
+    useScreen: jest.fn(),
+    useTransaction: jest.fn(),
+    useUntrustedData: jest.fn(),
+  })),
+  useCurrentScreen: jest.fn(),
+  useErrors: jest.fn(),
+  useAuth0Themes: jest.fn(),
+}));
+
+describe('Confirmation Screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Categorize exports once for all tests
+  const exports = categorizeScreenExports(ConfirmationScreen);
+
+  describe('exports', () => {
+    it('should export all context hooks', () => {
+      expect(ConfirmationScreen.useUser).toBeDefined();
+      expect(ConfirmationScreen.useTenant).toBeDefined();
+      expect(ConfirmationScreen.useBranding).toBeDefined();
+      expect(ConfirmationScreen.useClient).toBeDefined();
+      expect(ConfirmationScreen.useOrganization).toBeDefined();
+      expect(ConfirmationScreen.usePrompt).toBeDefined();
+      expect(ConfirmationScreen.useScreen).toBeDefined();
+      expect(ConfirmationScreen.useTransaction).toBeDefined();
+      expect(ConfirmationScreen.useUntrustedData).toBeDefined();
+    });
+
+    it('should export common hooks', () => {
+      expect(ConfirmationScreen.useCurrentScreen).toBeDefined();
+      expect(ConfirmationScreen.useErrors).toBeDefined();
+      expect(ConfirmationScreen.useAuth0Themes).toBeDefined();
+    });
+  });
+
+  describe('instance hook', () => {
+    it('should provide instance hook that returns screen instance', () => {
+      exports.instanceHooks.forEach(hookName => {
+        try {
+          const { result } = renderHook(() => (ConfirmationScreen as any)[hookName]());
+          if (result.current && typeof result.current === 'object') {
+            expect(result.current).toBeDefined();
+          }
+        } catch (e) {
+          // Skip if it requires parameters
+        }
+      });
+    });
+
+    it('should return stable reference across renders for instance hooks', () => {
+      exports.instanceHooks.forEach(hookName => {
+        try {
+          const { result, rerender } = renderHook(() => (ConfirmationScreen as any)[hookName]());
+          if (result.current && typeof result.current === 'object') {
+            const firstResult = result.current;
+            rerender();
+            expect(result.current).toBe(firstResult);
+          }
+        } catch (e) {
+          // Skip if it requires parameters
+        }
+      });
+    });
+  });
+
+  describe('submit functions', () => {
+    it('should export proceedToSignup and goBack', () => {
+      expect(typeof ConfirmationScreen.proceedToSignup).toBe('function');
+      expect(typeof ConfirmationScreen.goBack).toBe('function');
+    });
+
+    it('should export submit functions if available', () => {
+      exports.submitFunctions.forEach(funcName => {
+        expect(typeof (ConfirmationScreen as any)[funcName]).toBe('function');
+      });
+    });
+  });
+
+  describe('utility hooks', () => {
+    it('should export utility hooks if available', () => {
+      exports.utilityHooks.forEach(hookName => {
+        expect(typeof (ConfirmationScreen as any)[hookName]).toBe('function');
+      });
+    });
+
+    it('should call utility hooks successfully', () => {
+      exports.utilityHooks.forEach(hookName => {
+        try {
+          const { result } = renderHook(() => (ConfirmationScreen as any)[hookName]());
+          expect(result.current).toBeDefined();
+        } catch (e) {
+          // Some utility hooks may require parameters
+        }
+      });
+    });
+  });
+
+  describe('submit functions coverage', () => {
+    it('should call submit functions', () => {
+      exports.submitFunctions.forEach(funcName => {
+        try {
+          const func = (ConfirmationScreen as any)[funcName];
+          const result = func({});
+          if (result && typeof result.then === 'function') {
+            expect(result).toBeDefined();
+          }
+        } catch (e) {
+          // Function may require specific parameters
+        }
+      });
+    });
+  });
+});

--- a/packages/auth0-acul-react/tests/screens/confirmation.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/confirmation.test.tsx
@@ -16,9 +16,13 @@ jest.mock('@auth0/auth0-acul-js/confirmation', () => {
   return jest.fn().mockImplementation(() => {});
 }, { virtual: true });
 
-// Mock the instance store
+// Mock the instance store with stub action methods so submit functions can be
+// invoked without throwing (the mocked Confirmation class has no real methods)
 jest.mock('../../src/state/instance-store', () => ({
-  registerScreen: jest.fn((Screen) => new Screen()),
+  registerScreen: jest.fn(() => ({
+    proceedToSignup: jest.fn(() => Promise.resolve()),
+    goBack: jest.fn(() => Promise.resolve()),
+  })),
 }));
 
 // Mock error manager and hooks
@@ -72,30 +76,19 @@ describe('Confirmation Screen', () => {
 
   describe('instance hook', () => {
     it('should provide instance hook that returns screen instance', () => {
+      // useConfirmation() takes no parameters, so it should never throw here.
       exports.instanceHooks.forEach(hookName => {
-        try {
-          const { result } = renderHook(() => (ConfirmationScreen as any)[hookName]());
-          if (result.current && typeof result.current === 'object') {
-            expect(result.current).toBeDefined();
-          }
-        } catch (e) {
-          // Skip if it requires parameters
-        }
+        const { result } = renderHook(() => (ConfirmationScreen as any)[hookName]());
+        expect(result.current).toBeDefined();
       });
     });
 
     it('should return stable reference across renders for instance hooks', () => {
       exports.instanceHooks.forEach(hookName => {
-        try {
-          const { result, rerender } = renderHook(() => (ConfirmationScreen as any)[hookName]());
-          if (result.current && typeof result.current === 'object') {
-            const firstResult = result.current;
-            rerender();
-            expect(result.current).toBe(firstResult);
-          }
-        } catch (e) {
-          // Skip if it requires parameters
-        }
+        const { result, rerender } = renderHook(() => (ConfirmationScreen as any)[hookName]());
+        const firstResult = result.current;
+        rerender();
+        expect(result.current).toBe(firstResult);
       });
     });
   });
@@ -133,17 +126,13 @@ describe('Confirmation Screen', () => {
   });
 
   describe('submit functions coverage', () => {
-    it('should call submit functions', () => {
+    it('should call submit functions and return a promise', async () => {
+      // proceedToSignup/goBack both accept an optional payload, so calling
+      // them with {} should never throw.
       exports.submitFunctions.forEach(funcName => {
-        try {
-          const func = (ConfirmationScreen as any)[funcName];
-          const result = func({});
-          if (result && typeof result.then === 'function') {
-            expect(result).toBeDefined();
-          }
-        } catch (e) {
-          // Function may require specific parameters
-        }
+        const func = (ConfirmationScreen as any)[funcName];
+        const result = func({});
+        expect(result).toBeInstanceOf(Promise);
       });
     });
   });


### PR DESCRIPTION
### Description

Adds support for the `confirmation` screen in both `@auth0/auth0-acul-js` and `@auth0/auth0-acul-react`.

This screen is shown when a user logs in with an identifier that has `no existing account` and the tenant is set up to auto-signup after OTP verification. Once the OTP is verified, the user lands on this `confirmation` screen to confirm or decline creating the account.

### Changes

The only new behavior is the two actions on the screen instance:

```ts
import Confirmation from '@auth0/auth0-acul-js/confirmation';

const confirmation = new Confirmation();

// confirm and create the account
await confirmation.proceedToSignup();

// or decline and go back to login
await confirmation.goBack();
```

Same thing on the React side via the dedicated entry point:

```tsx
import { proceedToSignup, goBack } from '@auth0/auth0-acul-react/confirmation';

await proceedToSignup(); // confirm
await goBack();          // cancel
```

### Testing

Verified end-to-end using the sample app against a tenant with auto-signup enabled:

1. Logged in with an identifier that has no existing account.
2. Verified the OTP sent to that identifier.
3. Landed on the confirmation screen, which rendered the submitted identifier (read-only) along with `Confirm` and `Cancel` actions.
4. `Confirm` proceeds with account creation.
5. `Cancel` returns to the login screen without creating an account.

https://github.com/user-attachments/assets/90afc468-4cab-45d6-883c-fe39b01275a5


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
