### PR TITLE
Fix: phone-based signup on the signup-password screen

### DIFF
--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -67,6 +67,14 @@ export default class SignupPassword extends BaseContext implements SignupPasswor
       telemetry: [this.constructor.name, 'signup'],
     };
 
+    // The signup-password endpoint expects the phone identifier as `phone_number`,
+    // while the SDK exposes it (and accepts it) as the camelCase `phoneNumber`.
+    // Remap it before submitting so a phone signup is not rejected with "no-phone_number".
+    if (payload.phoneNumber?.trim() ?? '') {
+      const { phoneNumber, ...rest } = payload;
+      payload = { ...rest, phone_number: phoneNumber };
+    }
+
     await new FormHandler(options).submitData<SignupPasswordOptions>(payload);
   }
 

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -70,7 +70,7 @@ export default class SignupPassword extends BaseContext implements SignupPasswor
     // The signup-password endpoint expects the phone identifier as `phone_number`,
     // while the SDK exposes it (and accepts it) as the camelCase `phoneNumber`.
     // Remap it before submitting so a phone signup is not rejected with "no-phone_number".
-    if (payload.phoneNumber?.trim() ?? '') {
+    if (payload.phoneNumber?.trim()) {
       const { phoneNumber, ...rest } = payload;
       payload = { ...rest, phone_number: phoneNumber };
     }

--- a/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
@@ -65,7 +65,7 @@ describe('SignupPassword', () => {
         expect.objectContaining({
           username: 'testUser',
           password: 'testPassword',
-          phoneNumber: '+1234567890',
+          phone_number: '+1234567890',
         })
       );
     });

--- a/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
@@ -68,6 +68,10 @@ describe('SignupPassword', () => {
           phone_number: '+1234567890',
         })
       );
+
+      // The remap should rename `phoneNumber` to `phone_number`, not duplicate it.
+      const submittedPayload = mockFormHandler.submitData.mock.calls[0][0];
+      expect(submittedPayload).not.toHaveProperty('phoneNumber');
     });
 
     it('should throw error when FormHandler rejects', async () => {

--- a/packages/auth0-acul-react/src/export/screens.ts
+++ b/packages/auth0-acul-react/src/export/screens.ts
@@ -77,3 +77,4 @@ export * as 'redeem-ticket' from '../screens/redeem-ticket';
 export * as 'brute-force-protection-unblock' from '../screens/brute-force-protection-unblock';
 export * as 'brute-force-protection-unblock-failure' from '../screens/brute-force-protection-unblock-failure';
 export * as 'brute-force-protection-unblock-success' from '../screens/brute-force-protection-unblock-success';
+export * as 'confirmation' from '../screens/confirmation';


### PR DESCRIPTION

## Summary

Phone-based signups on the signup-password screen were being rejected by the
server with a `no-phone_number` error, even though a valid phone number was
provided. This change ensures the phone identifier is accepted end to end.

## Problem

The signup-password endpoint expects the phone identifier under the field name
`phone_number`. The SDK, however, exposes and accepts it as the camelCase
`phoneNumber`. Because the value was submitted as-is, the server never received
a `phone_number` field and returned a `no-phone_number` error, blocking the
signup.

## Behavior change

- A user signing up with a phone number now completes successfully.
- The phone identifier supplied as `phoneNumber` is delivered to the endpoint
  under the expected `phone_number` field.
- Email- and username-based signups are unaffected.

## Additional fix: React confirmation screen docs

The React confirmation screen documentation page returned a 404. It is now
included in the generated docs, matching the JS SDK.

## Testing

- Verified that submitting a phone number results in the correct payload
  reaching the endpoint.
- Existing signup-password flows (email/username) continue to work as before.
