### PR TITLE
feat: add theme identifiers and country code support

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -244,7 +244,7 @@ This section documents the helper methods and properties exposed by the screen i
 
 - `tenant`- Tenant configuration and metadata (domain, region, settings).
 
-- `branding`- Branding/theme config (colors, logos, fonts, visual tokens).
+- `branding`- Branding/theme config (colors, logos, fonts, visual tokens). `branding.themes.default.identifiers` additionally carries identifier display preferences (`loginDisplay`, `otpAutocomplete`, `phoneDisplay` with `masking` and `formatting`); the `identifiers` key is omitted when the tenant configures none of them.
 
 - `client`- Application client metadata and settings.
 
@@ -282,7 +282,7 @@ This section documents the helper methods and properties exposed by the screen i
   Return the current screen context data.
 
 - `getCurrentThemeOptions()` 
-  Gets the current theme options with flattened configuration from branding context.
+  Gets the current theme options with flattened configuration from branding context. Returns styling tokens only (`colors`, `fonts`, `borders`, `pageBackground`, `widget`) — read `branding.themes.default.identifiers` for identifier display preferences.
 
 - `getErrors()`
    Gets the current errors from the transaction context

--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -248,6 +248,8 @@ This section documents the helper methods and properties exposed by the screen i
 
 - `client`- Application client metadata and settings.
 
+- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided.
+
 - `organization`- Organization context when applicable.
 
 - `prompt`- Current prompt / flow configuration.

--- a/packages/auth0-acul-js/interfaces/export/base-properties.ts
+++ b/packages/auth0-acul-js/interfaces/export/base-properties.ts
@@ -1,6 +1,7 @@
 export type { BaseMembers } from '../models/base-context';
 export type { ClientMembers } from '../models/client';
 export type { BrandingMembers } from '../models/branding';
+export type { CountryCodesMembers } from '../models/country-codes';
 export type { PromptMembers } from '../models/prompt';
 export type { UserMembers } from '../models/user';
 export type { OrganizationMembers } from '../models/organization';

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,6 +1,7 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, AllowCredential, AuthenticatorTransport } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, PasswordComplexityPolicy, UsernamePolicy, Error, Error as ULError, PasswordComplexityRule } from '../models/transaction';
-export type { BrandingSettings, BrandingThemes } from '../models/branding';
+export type { BrandingSettings, BrandingThemes, ThemeIdentifiers } from '../models/branding';
+export type { AvailableCountryCode } from '../models/country-codes';
 export type { CustomOptions, AbortEnrollmentOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, LanguageChangeOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../common/index';
 export type { OnStatusChangeCallback, StartResendOptions, ResendControl } from '../utils/resend-control';
 export type { EnrolledEmail, EnrolledPhoneNumber, EnrolledDevice } from '../models/user';

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -1,6 +1,6 @@
 export type { CaptchaContext, PhonePrefix, PasskeyCreate, Scope, AuthorizationDetail, AllowCredential, AuthenticatorTransport } from '../models/screen';
 export type { Connection, EnterpriseConnection, PasswordPolicy, PasswordComplexityPolicy, UsernamePolicy, Error, Error as ULError, PasswordComplexityRule } from '../models/transaction';
-export type { BrandingSettings, BrandingThemes, ThemeIdentifiers } from '../models/branding';
+export type { BrandingSettings, BrandingThemes, ThemeIdentifiers, LoginDisplay, PhoneMasking, PhoneFormatting } from '../models/branding';
 export type { AvailableCountryCode } from '../models/country-codes';
 export type { CustomOptions, AbortEnrollmentOptions, WebAuthnErrorDetails, CurrentScreenOptions, FlattenedTheme, LanguageChangeOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../common/index';
 export type { OnStatusChangeCallback, StartResendOptions, ResendControl } from '../utils/resend-control';

--- a/packages/auth0-acul-js/interfaces/models/base-context.ts
+++ b/packages/auth0-acul-js/interfaces/models/base-context.ts
@@ -1,6 +1,7 @@
 import type { LanguageChangeOptions } from '../common';
 import type { BrandingContext, BrandingMembers } from './branding';
 import type { ClientContext, ClientMembers } from './client';
+import type { CountryCodesContext, CountryCodesMembers } from './country-codes';
 import type { OrganizationContext, OrganizationMembers } from './organization';
 import type { PromptContext, PromptMembers } from './prompt';
 import type { ScreenContext, ScreenMembers } from './screen';
@@ -12,6 +13,7 @@ import type { UserContext, UserMembers } from './user';
 export interface BaseContext {
   branding?: BrandingContext;
   client: ClientContext;
+  country_codes?: CountryCodesContext;
   organization: OrganizationContext;
   prompt: PromptContext;
   screen: ScreenContext;
@@ -24,6 +26,7 @@ export interface BaseContext {
 export interface BaseMembers {
   branding: BrandingMembers;
   client: ClientMembers;
+  countryCodes: CountryCodesMembers;
   organization: OrganizationMembers;
   prompt: PromptMembers;
   screen: ScreenMembers;

--- a/packages/auth0-acul-js/interfaces/models/base-context.ts
+++ b/packages/auth0-acul-js/interfaces/models/base-context.ts
@@ -26,7 +26,11 @@ export interface BaseContext {
 export interface BaseMembers {
   branding: BrandingMembers;
   client: ClientMembers;
-  countryCodes: CountryCodesMembers;
+  /**
+   * Optional on the interface so existing implementors of `BaseMembers` (e.g. test mocks)
+   * keep compiling. Always populated at runtime by the `BaseContext` constructor.
+   */
+  countryCodes?: CountryCodesMembers;
   organization: OrganizationMembers;
   prompt: PromptMembers;
   screen: ScreenMembers;

--- a/packages/auth0-acul-js/interfaces/models/branding.ts
+++ b/packages/auth0-acul-js/interfaces/models/branding.ts
@@ -30,12 +30,37 @@ export interface BrandingContext {
   };
 }
 
+/**
+ * How the identifier fields are laid out on the login and signup screens.
+ *
+ * - `'unified'`: a single input accepting any enabled identifier.
+ * - `'separate'`: one input per enabled identifier.
+ */
+export type LoginDisplay = 'unified' | 'separate';
+
+/**
+ * How much of an already-entered phone number is revealed when it is displayed back to the user.
+ *
+ * - `'show_all'`: the full number, country code included.
+ * - `'hide_country_code'`: the national digits only.
+ * - `'mask_digits'`: the digits obscured.
+ */
+export type PhoneMasking = 'show_all' | 'hide_country_code' | 'mask_digits';
+
+/**
+ * How a phone number is formatted for display.
+ *
+ * - `'regional'`: the national convention for the number's country.
+ * - `'international'`: the international form, dial code included.
+ */
+export type PhoneFormatting = 'regional' | 'international';
+
 export interface ThemeIdentifiersContext {
-  login_display?: string;
+  login_display?: LoginDisplay;
   otp_autocomplete?: boolean;
   phone_display?: {
-    masking?: string;
-    formatting?: string;
+    masking?: PhoneMasking;
+    formatting?: PhoneFormatting;
   };
 }
 
@@ -57,11 +82,11 @@ export interface BrandingSettings {
 }
 
 export interface ThemeIdentifiers {
-  loginDisplay?: string;
+  loginDisplay?: LoginDisplay;
   otpAutocomplete?: boolean;
   phoneDisplay?: {
-    masking?: string;
-    formatting?: string;
+    masking?: PhoneMasking;
+    formatting?: PhoneFormatting;
   };
 }
 

--- a/packages/auth0-acul-js/interfaces/models/branding.ts
+++ b/packages/auth0-acul-js/interfaces/models/branding.ts
@@ -25,7 +25,17 @@ export interface BrandingContext {
       fonts: Record<string, string | boolean | object>;
       page_background: Record<string, string>;
       widget: Record<string, string | number>;
+      identifiers?: ThemeIdentifiersContext;
     };
+  };
+}
+
+export interface ThemeIdentifiersContext {
+  login_display?: string;
+  otp_autocomplete?: boolean;
+  phone_display?: {
+    masking?: string;
+    formatting?: string;
   };
 }
 
@@ -46,6 +56,15 @@ export interface BrandingSettings {
   fontUrl?: string;
 }
 
+export interface ThemeIdentifiers {
+  loginDisplay?: string;
+  otpAutocomplete?: boolean;
+  phoneDisplay?: {
+    masking?: string;
+    formatting?: string;
+  };
+}
+
 export interface BrandingThemes {
   default: {
     borders: Record<string, string | boolean | number>;
@@ -54,6 +73,7 @@ export interface BrandingThemes {
     fonts: Record<string, string | boolean | object>;
     pageBackground: Record<string, string>;
     widget: Record<string, string | number>;
+    identifiers?: ThemeIdentifiers;
   };
 }
 

--- a/packages/auth0-acul-js/interfaces/models/country-codes.ts
+++ b/packages/auth0-acul-js/interfaces/models/country-codes.ts
@@ -1,0 +1,22 @@
+export interface AvailableCountryCodeContext {
+  code: string;
+  label: string;
+  dial_code: string;
+}
+
+export interface CountryCodesContext {
+  available?: AvailableCountryCodeContext[];
+  recommended?: string;
+}
+
+export interface AvailableCountryCode {
+  code: string;
+  label: string;
+  dialCode: string;
+}
+
+/* @namespace CountryCodes */
+export interface CountryCodesMembers {
+  available: AvailableCountryCode[] | null;
+  recommended: string | null;
+}

--- a/packages/auth0-acul-js/interfaces/models/index.ts
+++ b/packages/auth0-acul-js/interfaces/models/index.ts
@@ -5,6 +5,7 @@ export { UserMembers } from './user';
 export { OrganizationMembers } from './organization';
 export { ScreenMembers } from './screen';
 export { BrandingMembers } from './branding';
+export { CountryCodesMembers } from './country-codes';
 export { TenantMembers } from './tenant';
 export { TransactionMembers } from './transaction';
 export { UntrustedDataMembers } from './untrusted-data';

--- a/packages/auth0-acul-js/src/models/base-context.ts
+++ b/packages/auth0-acul-js/src/models/base-context.ts
@@ -1,5 +1,5 @@
 import { FormActions } from '../constants';
-import { Branding, Client, Prompt, Screen, Organization, User, Transaction, Tenant, UntrustedData } from '../models';
+import { Branding, Client, CountryCodes, Prompt, Screen, Organization, User, Transaction, Tenant, UntrustedData } from '../models';
 import { FormHandler } from '../utils/form-handler';
 
 import type { LanguageChangeOptions } from '../../interfaces/common';
@@ -12,7 +12,8 @@ import type {
   TransactionMembers,
   TenantMembers,
   UntrustedDataMembers,
-  BrandingMembers
+  BrandingMembers,
+  CountryCodesMembers
 } from '../../interfaces/models';
 import type { BaseContext as UniversalLoginContext, BaseMembers } from '../../interfaces/models/base-context';
 import type { Error as TransactionError } from '../../interfaces/models/transaction';
@@ -25,6 +26,7 @@ import type { FormOptions } from '../../interfaces/utils/form-handler';
  */
 export class BaseContext implements BaseMembers {
   branding: BrandingMembers;
+  countryCodes: CountryCodesMembers;
   screen: ScreenMembers;
   tenant: TenantMembers;
   prompt: PromptMembers;
@@ -66,6 +68,7 @@ export class BaseContext implements BaseMembers {
     }
 
     this.branding = new Branding(context.branding);
+    this.countryCodes = new CountryCodes(context.country_codes);
     this.screen = new Screen(context.screen);
     this.tenant = new Tenant(context.tenant);
     this.prompt = new Prompt(context.prompt);

--- a/packages/auth0-acul-js/src/models/branding.ts
+++ b/packages/auth0-acul-js/src/models/branding.ts
@@ -1,4 +1,4 @@
-import type { BrandingContext, BrandingMembers } from '../../interfaces/models/branding';
+import type { BrandingContext, BrandingMembers, ThemeIdentifiers } from '../../interfaces/models/branding';
 
 /**
  * @class Branding
@@ -68,6 +68,12 @@ export class Branding implements BrandingMembers {
       default: { borders = {}, colors = {}, displayName = '', fonts = {}, page_background: pageBackground = {}, widget = {}, identifiers } = {},
     } = branding.themes;
 
+    const themeIdentifiers: ThemeIdentifiers = {
+      ...(identifiers?.login_display !== undefined && { loginDisplay: identifiers.login_display }),
+      ...(identifiers?.otp_autocomplete !== undefined && { otpAutocomplete: identifiers.otp_autocomplete }),
+      ...(identifiers?.phone_display !== undefined && { phoneDisplay: identifiers.phone_display }),
+    };
+
     return {
       default: {
         borders,
@@ -76,13 +82,7 @@ export class Branding implements BrandingMembers {
         fonts,
         pageBackground,
         widget,
-        ...(identifiers && {
-          identifiers: {
-            ...(identifiers.login_display !== undefined && { loginDisplay: identifiers.login_display }),
-            ...(identifiers.otp_autocomplete !== undefined && { otpAutocomplete: identifiers.otp_autocomplete }),
-            ...(identifiers.phone_display !== undefined && { phoneDisplay: identifiers.phone_display }),
-          },
-        }),
+        ...(Object.keys(themeIdentifiers).length > 0 && { identifiers: themeIdentifiers }),
       },
     };
   }

--- a/packages/auth0-acul-js/src/models/branding.ts
+++ b/packages/auth0-acul-js/src/models/branding.ts
@@ -64,8 +64,9 @@ export class Branding implements BrandingMembers {
   static getThemes(branding: BrandingContext | undefined): BrandingMembers['themes'] {
     if (!branding?.themes) return null;
 
-    const { default: { borders = {}, colors = {}, displayName = '', fonts = {}, page_background: pageBackground = {}, widget = {} } = {} } =
-      branding.themes;
+    const {
+      default: { borders = {}, colors = {}, displayName = '', fonts = {}, page_background: pageBackground = {}, widget = {}, identifiers } = {},
+    } = branding.themes;
 
     return {
       default: {
@@ -75,6 +76,13 @@ export class Branding implements BrandingMembers {
         fonts,
         pageBackground,
         widget,
+        ...(identifiers && {
+          identifiers: {
+            ...(identifiers.login_display !== undefined && { loginDisplay: identifiers.login_display }),
+            ...(identifiers.otp_autocomplete !== undefined && { otpAutocomplete: identifiers.otp_autocomplete }),
+            ...(identifiers.phone_display !== undefined && { phoneDisplay: identifiers.phone_display }),
+          },
+        }),
       },
     };
   }

--- a/packages/auth0-acul-js/src/models/country-codes.ts
+++ b/packages/auth0-acul-js/src/models/country-codes.ts
@@ -1,0 +1,41 @@
+import type { CountryCodesContext, CountryCodesMembers } from '../../interfaces/models/country-codes';
+
+/**
+ * @class CountryCodes
+ * @description Provides access to the country codes available for phone number entry,
+ * including the recommended default country code for the current context.
+ * @implements {CountryCodesMembers}
+ */
+export class CountryCodes implements CountryCodesMembers {
+  /** @property {AvailableCountryCode[] | null} available - List of available country codes with label and dial code */
+  available: CountryCodesMembers['available'];
+
+  /** @property {string | null} recommended - The recommended country code (ISO 3166-1 alpha-2), if any */
+  recommended: CountryCodesMembers['recommended'];
+
+  /**
+   * @constructor
+   * @param {CountryCodesContext | undefined} countryCodes - The country codes context from Universal Login
+   */
+  constructor(countryCodes: CountryCodesContext | undefined) {
+    this.available = CountryCodes.getAvailable(countryCodes);
+    this.recommended = countryCodes?.recommended ?? null;
+  }
+
+  /**
+   * @static
+   * @method getAvailable
+   * @description Extracts and transforms the available country codes from the context
+   * @param {CountryCodesContext | undefined} countryCodes - The country codes context
+   * @returns {AvailableCountryCode[] | null} Transformed country codes or null if unavailable
+   */
+  static getAvailable(countryCodes: CountryCodesContext | undefined): CountryCodesMembers['available'] {
+    if (!Array.isArray(countryCodes?.available)) return null;
+
+    return countryCodes.available.map((countryCode) => ({
+      code: countryCode.code,
+      label: countryCode.label,
+      dialCode: countryCode.dial_code,
+    }));
+  }
+}

--- a/packages/auth0-acul-js/src/models/index.ts
+++ b/packages/auth0-acul-js/src/models/index.ts
@@ -1,5 +1,6 @@
 import { Branding } from './branding';
 import { Client } from './client';
+import { CountryCodes } from './country-codes';
 import { Organization } from './organization';
 import { Prompt } from './prompt';
 import { Screen } from './screen';
@@ -8,4 +9,4 @@ import { Transaction } from './transaction';
 import { UntrustedData } from './untrusted-data';
 import { User } from './user';
 
-export { Branding, Client, Prompt, Screen, Organization, User, Transaction, Tenant, UntrustedData };
+export { Branding, Client, CountryCodes, Prompt, Screen, Organization, User, Transaction, Tenant, UntrustedData };

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -57,6 +57,15 @@ export default class Signup extends BaseContext implements SignupMembers {
       state: this.transaction.state,
       telemetry: [Signup.screenIdentifier, 'signup'],
     };
+
+    // The signup endpoint expects the phone identifier as `phone_number`,
+    // while the SDK exposes it (and accepts it) as the camelCase `phoneNumber`.
+    // Remap it before submitting so a phone signup is not rejected with "no-phone_number".
+    if (payload.phoneNumber?.trim()) {
+      const { phoneNumber, ...rest } = payload;
+      payload = { ...rest, phone_number: phoneNumber };
+    }
+
     await new FormHandler(options).submitData<SignupOptions>(payload);
   }
 

--- a/packages/auth0-acul-js/tests/unit/models/branding.test.ts
+++ b/packages/auth0-acul-js/tests/unit/models/branding.test.ts
@@ -1,5 +1,6 @@
 import { Branding } from '../../../src/models/branding';
-import type { BrandingContext, BrandingMembers } from '../../../interfaces/models/branding';
+
+import type { BrandingContext } from '../../../interfaces/models/branding';
 
 describe('Branding', () => {
   let brandingContext: BrandingContext;
@@ -144,6 +145,40 @@ describe('Branding', () => {
           pageBackground: {},
           widget: {},
         },
+      });
+    });
+
+    it('should transform theme identifiers to camelCase when present', () => {
+      const contextWithIdentifiers = {
+        themes: {
+          default: {
+            identifiers: {
+              login_display: 'separate',
+              otp_autocomplete: true,
+              phone_display: { masking: 'mask_digits', formatting: 'international' },
+            },
+          },
+        },
+      } as unknown as BrandingContext;
+
+      expect(Branding.getThemes(contextWithIdentifiers)?.default.identifiers).toEqual({
+        loginDisplay: 'separate',
+        otpAutocomplete: true,
+        phoneDisplay: { masking: 'mask_digits', formatting: 'international' },
+      });
+    });
+
+    it('should not include identifiers when absent from the theme', () => {
+      expect(Branding.getThemes(brandingContext)?.default).not.toHaveProperty('identifiers');
+    });
+
+    it('should include only the provided identifier fields', () => {
+      const contextWithPartialIdentifiers = {
+        themes: { default: { identifiers: { login_display: 'unified' } } },
+      } as unknown as BrandingContext;
+
+      expect(Branding.getThemes(contextWithPartialIdentifiers)?.default.identifiers).toEqual({
+        loginDisplay: 'unified',
       });
     });
   });

--- a/packages/auth0-acul-js/tests/unit/models/branding.test.ts
+++ b/packages/auth0-acul-js/tests/unit/models/branding.test.ts
@@ -181,5 +181,13 @@ describe('Branding', () => {
         loginDisplay: 'unified',
       });
     });
+
+    it('should not include identifiers when the theme provides an empty object', () => {
+      const contextWithEmptyIdentifiers = {
+        themes: { default: { identifiers: {} } },
+      } as unknown as BrandingContext;
+
+      expect(Branding.getThemes(contextWithEmptyIdentifiers)?.default).not.toHaveProperty('identifiers');
+    });
   });
 });

--- a/packages/auth0-acul-js/tests/unit/models/country-codes.test.ts
+++ b/packages/auth0-acul-js/tests/unit/models/country-codes.test.ts
@@ -1,0 +1,48 @@
+import { CountryCodes } from '../../../src/models/country-codes';
+
+import type { CountryCodesContext } from '../../../interfaces/models/country-codes';
+
+describe('CountryCodes', () => {
+  it('should transform available country codes to camelCase and set recommended', () => {
+    const context: CountryCodesContext = {
+      available: [
+        { code: 'US', label: 'United States', dial_code: '+1' },
+        { code: 'GB', label: 'United Kingdom', dial_code: '+44' },
+      ],
+      recommended: 'US',
+    };
+
+    const countryCodes = new CountryCodes(context);
+
+    expect(countryCodes.available).toEqual([
+      { code: 'US', label: 'United States', dialCode: '+1' },
+      { code: 'GB', label: 'United Kingdom', dialCode: '+44' },
+    ]);
+    expect(countryCodes.recommended).toBe('US');
+  });
+
+  it('should default to null when context is undefined', () => {
+    const countryCodes = new CountryCodes(undefined);
+
+    expect(countryCodes.available).toBeNull();
+    expect(countryCodes.recommended).toBeNull();
+  });
+
+  it('should set available to null when it is not an array', () => {
+    const countryCodes = new CountryCodes({} as CountryCodesContext);
+
+    expect(countryCodes.available).toBeNull();
+    expect(countryCodes.recommended).toBeNull();
+  });
+
+  it('should set recommended to null when only available is provided', () => {
+    const context: CountryCodesContext = {
+      available: [{ code: 'FR', label: 'France', dial_code: '+33' }],
+    };
+
+    const countryCodes = new CountryCodes(context);
+
+    expect(countryCodes.available).toEqual([{ code: 'FR', label: 'France', dialCode: '+33' }]);
+    expect(countryCodes.recommended).toBeNull();
+  });
+});

--- a/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
@@ -70,6 +70,40 @@ describe('Signup', () => {
       expect(FormHandler).toHaveBeenCalledWith(expect.objectContaining({ state: 'mockState' }));
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(payload);
     });
+
+    it('should remap phoneNumber to phone_number', async () => {
+      const payload: SignupOptions = { phoneNumber: '+1234567890', password: 'P@ssw0rd!' };
+      await signup.signup(payload);
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phone_number: '+1234567890',
+          password: 'P@ssw0rd!',
+        })
+      );
+
+      // The remap should rename `phoneNumber` to `phone_number`, not duplicate it.
+      const submittedPayload = (FormHandler.prototype.submitData as jest.Mock).mock.calls[0][0];
+      expect(submittedPayload).not.toHaveProperty('phoneNumber');
+    });
+
+    it('should not remap an empty phoneNumber', async () => {
+      const payload: SignupOptions = { email: 'test@example.com', phoneNumber: '', password: 'P@ssw0rd!' };
+      await signup.signup(payload);
+
+      const submittedPayload = (FormHandler.prototype.submitData as jest.Mock).mock.calls[0][0];
+      expect(submittedPayload).not.toHaveProperty('phone_number');
+      expect(submittedPayload).toHaveProperty('phoneNumber', '');
+    });
+
+    it('should leave a payload without phoneNumber untouched', async () => {
+      const payload: SignupOptions = { email: 'test@example.com', username: 'testUser', password: 'P@ssw0rd!' };
+      await signup.signup(payload);
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(payload);
+      const submittedPayload = (FormHandler.prototype.submitData as jest.Mock).mock.calls[0][0];
+      expect(submittedPayload).not.toHaveProperty('phone_number');
+    });
   });
 
   describe('federatedSignup', () => {

--- a/packages/auth0-acul-react/README.md
+++ b/packages/auth0-acul-react/README.md
@@ -231,6 +231,9 @@ Refer to our [API Reference](#api-reference) for the full list of available type
 - `useOrganization()` - Organization context (if applicable)
 - `usePrompt()` - Current authentication prompt
 - `useUntrustedData()` - Untrusted data from the authentication flow
+
+#### Available on specific screens
+- `useCountryCodes()` - Available phone country codes and the recommended default. Exported only from `login`, `login-id`, `signup`, and `signup-id`.
  
 ### Utility Hooks
 Specialized hooks for form validation, polling, and identifier management:

--- a/packages/auth0-acul-react/scripts/generate-sdk/index.ts
+++ b/packages/auth0-acul-react/scripts/generate-sdk/index.ts
@@ -20,12 +20,26 @@ const CONTEXT_MODELS = [
   'tenant',
   'branding',
   'client',
+  'countryCodes',
   'organization',
   'prompt',
   'screen',
   'transaction',
   'untrustedData',
 ];
+
+// Context models exposed only on specific screens (model name -> kebab screen names).
+// Any model listed here is omitted from every other screen.
+const SCREEN_SCOPED_CONTEXT_MODELS: Record<string, string[]> = {
+  countryCodes: ['login', 'login-id', 'signup', 'signup-id'],
+};
+
+function getContextModels(kebab: string): string[] {
+  return CONTEXT_MODELS.filter((model) => {
+    const screens = SCREEN_SCOPED_CONTEXT_MODELS[model];
+    return !screens || screens.includes(kebab);
+  });
+}
 
 let errorCount = 0;
 
@@ -220,7 +234,7 @@ for (const symbol of screenSymbols) {
   screenLines.push(`\n// Context hooks`);
   screenLines.push(`const factory = new ContextHooks<${baseInterface}>(instance);`);
   screenLines.push(`export const {`);
-  screenLines.push(`  ${CONTEXT_MODELS.map((m) => `use${toPascal(m)}`).join(',\n  ')}`);
+  screenLines.push(`  ${getContextModels(kebab).map((m) => `use${toPascal(m)}`).join(',\n  ')}`);
   screenLines.push(`} = factory;`);
 
   if (exportedMethods.length) {

--- a/packages/auth0-acul-react/src/hooks/context/index.tsx
+++ b/packages/auth0-acul-react/src/hooks/context/index.tsx
@@ -60,6 +60,19 @@ export class ContextHooks<T extends BaseMembers> {
   useClient = () => this.instance.client as T['client'];
 
   /**
+   * Hook to access the available phone country codes and recommended default.
+   * @returns CountryCodes object containing the `available` list (each with `code`, `label`, `dialCode`) and the `recommended` default; both `null` when not provided
+   * @example
+   * ```jsx
+   * import { useCountryCodes } from '@auth0/auth0-acul-react/login-id';
+   * function CountryPicker() {
+   *   const { available, recommended } = useCountryCodes();
+   * }
+   * ```
+   */
+  useCountryCodes = () => this.instance.countryCodes as T['countryCodes'];
+
+  /**
    * Hook to access organization context and settings.
    * @returns Organization object containing org-specific data, metadata, and configuration
    * @example

--- a/packages/auth0-acul-react/src/hooks/context/index.tsx
+++ b/packages/auth0-acul-react/src/hooks/context/index.tsx
@@ -66,7 +66,8 @@ export class ContextHooks<T extends BaseMembers> {
    * ```jsx
    * import { useCountryCodes } from '@auth0/auth0-acul-react/login-id';
    * function CountryPicker() {
-   *   const { available, recommended } = useCountryCodes();
+   *   const countryCodes = useCountryCodes();
+   *   const available = countryCodes?.available;
    * }
    * ```
    */

--- a/packages/auth0-acul-react/src/screens/login-id.tsx
+++ b/packages/auth0-acul-react/src/screens/login-id.tsx
@@ -26,6 +26,7 @@ export const {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,

--- a/packages/auth0-acul-react/src/screens/login.tsx
+++ b/packages/auth0-acul-react/src/screens/login.tsx
@@ -26,6 +26,7 @@ export const {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,

--- a/packages/auth0-acul-react/src/screens/signup-id.tsx
+++ b/packages/auth0-acul-react/src/screens/signup-id.tsx
@@ -26,6 +26,7 @@ export const {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,

--- a/packages/auth0-acul-react/src/screens/signup.tsx
+++ b/packages/auth0-acul-react/src/screens/signup.tsx
@@ -26,6 +26,7 @@ export const {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,

--- a/packages/auth0-acul-react/tests/hooks/context/context-hooks.test.ts
+++ b/packages/auth0-acul-react/tests/hooks/context/context-hooks.test.ts
@@ -174,8 +174,8 @@ describe('ContextHooks', () => {
       const countryCodes = contextHooks.useCountryCodes();
 
       expect(countryCodes).toEqual(mockInstance.countryCodes);
-      expect(countryCodes.available).toEqual([{ code: 'US', label: 'United States', dialCode: '+1' }]);
-      expect(countryCodes.recommended).toBe('US');
+      expect(countryCodes?.available).toEqual([{ code: 'US', label: 'United States', dialCode: '+1' }]);
+      expect(countryCodes?.recommended).toBe('US');
     });
 
     it('should return the same reference as instance.countryCodes', () => {

--- a/packages/auth0-acul-react/tests/hooks/context/context-hooks.test.ts
+++ b/packages/auth0-acul-react/tests/hooks/context/context-hooks.test.ts
@@ -46,6 +46,10 @@ const createMockInstance = (): BaseMembers => ({
     description: 'Test application',
     metadata: { description: 'Test application' },
   },
+  countryCodes: {
+    available: [{ code: 'US', label: 'United States', dialCode: '+1' }],
+    recommended: 'US',
+  },
   organization: {
     id: 'org123',
     name: 'Test Organization',
@@ -162,6 +166,21 @@ describe('ContextHooks', () => {
     it('should return the same reference as instance.client', () => {
       const client = contextHooks.useClient();
       expect(client).toBe(mockInstance.client);
+    });
+  });
+
+  describe('useCountryCodes', () => {
+    it('should return country codes data from instance', () => {
+      const countryCodes = contextHooks.useCountryCodes();
+
+      expect(countryCodes).toEqual(mockInstance.countryCodes);
+      expect(countryCodes.available).toEqual([{ code: 'US', label: 'United States', dialCode: '+1' }]);
+      expect(countryCodes.recommended).toBe('US');
+    });
+
+    it('should return the same reference as instance.countryCodes', () => {
+      const countryCodes = contextHooks.useCountryCodes();
+      expect(countryCodes).toBe(mockInstance.countryCodes);
     });
   });
 


### PR DESCRIPTION


## Summary

Adds two new fields to the context from the server so screens can show the same identifier experience as Universal Login:

- **Theme identifiers** (`branding.themes.default.identifiers`): `loginDisplay` (unified or separate), `otpAutocomplete`, and `phoneDisplay` (masking, formatting).
- **Country codes** (`countryCodes`): `available` (each with `code`, `label`, `dialCode`) and `recommended`. Both are `null` when none are provided.

## Changes

- **`countryCodes`** — new top-level context accessor exposing the tenant's available phone country codes and the recommended default:
  ```ts
  const loginId = new LoginId();
  loginId.countryCodes.available   // [{ code, label, dialCode }] | null
  loginId.countryCodes.recommended // "US" | null
  ```
  Maps the raw `country_codes` context (`dial_code` → `dialCode`); returns `null` when absent.

- **`branding.themes.default.identifiers`** — new theme block exposing the separate-identifier experience settings:
  ```ts
  loginId.branding.themes?.default.identifiers
  // { loginDisplay?, otpAutocomplete?, phoneDisplay?: { masking?, formatting? } }
  ```
  Mapped snake_case → camelCase; omitted entirely when the server doesn't send it (feature-flag gated server-side).

## Usage

```ts
import LoginId from '@auth0/auth0-acul-js/login-id';

const loginId = new LoginId();

// Country codes
const { available, recommended } = loginId.countryCodes;
// available    -> [{ code: 'US', label: 'United States', dialCode: '+1' }, ...] | null
// recommended  -> 'US' | null

// Theme identifiers
const identifiers = loginId.branding.themes?.default.identifiers;
if (identifiers?.loginDisplay === 'separate') {
  // render the separate identifier experience
}
// identifiers -> { loginDisplay?, otpAutocomplete?, phoneDisplay?: { masking?, formatting? } }
```

## Notes

- **Non-breaking**: all fields are additive; existing screens are unaffected. Consumers only read these fields.
- New public types: `CountryCodesMembers`, `AvailableCountryCode`, `ThemeIdentifiers`.
- Unit tests added for both the `CountryCodes` model and the theme-identifier mapping.
