### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci --workspaces --include-workspace-root
+        run: npm ci --ignore-scripts --workspaces --include-workspace-root
 
       - name: Build
         run: npm run build:local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: node --version
 
       - name: Install deps
-        run: npm ci --workspaces --include-workspace-root
+        run: npm ci --ignore-scripts --workspaces --include-workspace-root
 
       # Parse package name and version from branch
       - name: Parse version and package


### PR DESCRIPTION
## Description

Adds `--ignore-scripts` to `npm ci` in the CI and release workflows so dependency lifecycle scripts don't execute on CI runners.

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

Supersedes #333. That PR carries the same change but its commits are unsigned (`verified: false`, reason `unsigned`), and `master` has a `required_signatures` rule so it can't be merged. 

