### PR TITLE
 feat: expose activeIdentifierType on login and login-id screens

### DIFF
--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -116,3 +116,21 @@ if (config) {
 }
 ```
 
+## activeIdentifierType
+
+When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+
+```typescript
+import LoginId from '@auth0/auth0-acul-js/login-id';
+
+const loginIdManager = new LoginId();
+
+const activeIdentifier = loginIdManager.screen.data?.activeIdentifierType ?? 'email';
+
+if (activeIdentifier === 'phone') {
+  // render the phone number input with the country code picker
+} else {
+  // render the email / username input
+}
+```
+

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -222,3 +222,21 @@ if (config) {
   window.google?.accounts.id.prompt();
 }
 ```
+
+## activeIdentifierType
+
+When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+
+```typescript
+import Login from '@auth0/auth0-acul-js/login';
+
+const loginManager = new Login();
+
+const activeIdentifier = loginManager.screen.data?.activeIdentifierType ?? 'email';
+
+if (activeIdentifier === 'phone') {
+  // render the phone number input with the country code picker
+} else {
+  // render the email / username input
+}
+```

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -27,6 +27,7 @@ export interface ExtendedScreenContext extends ScreenContext {
 
   data?: {
     passkey?: PasskeyRead;
+    active_identifier_type?: IdentifierType;
   };
 }
 
@@ -47,6 +48,22 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   resetPasswordLink: string | null;
   publicKey: PasskeyRead['public_key'] | null;
   googleOneTapConfig: GoogleOneTapConfig | null;
+  /**
+   * Intersected with the inherited `data` record rather than replacing it, so reads of any
+   * other `screen.data` key keep compiling for existing consumers.
+   */
+  data:
+    | (NonNullable<ScreenMembers['data']> & {
+        /**
+         * The identifier input the screen should pre-select, as resolved by the server.
+         *
+         * Absent when the server has not resolved one — do not treat absence as `'email'`;
+         * fall back to your own default instead. Mapped from the server's
+         * `active_identifier_type`, which is not surfaced.
+         */
+        activeIdentifierType?: IdentifierType;
+      })
+    | null;
 }
 
 export interface TransactionMembersOnLoginId extends TransactionMembers {

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -22,6 +22,14 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
   googleOneTapConfig: GoogleOneTapConfig | null;
   data: {
     username?: string;
+    /**
+     * The identifier input the screen should pre-select, as resolved by the server.
+     *
+     * Absent when the server has not resolved one — do not treat absence as `'email'`;
+     * fall back to your own default instead. Mapped from the server's
+     * `active_identifier_type`, which is not surfaced.
+     */
+    activeIdentifierType?: IdentifierType;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -20,17 +20,23 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
   googleOneTapConfig: GoogleOneTapConfig | null;
-  data: {
-    username?: string;
-    /**
-     * The identifier input the screen should pre-select, as resolved by the server.
-     *
-     * Absent when the server has not resolved one — do not treat absence as `'email'`;
-     * fall back to your own default instead. Mapped from the server's
-     * `active_identifier_type`, which is not surfaced.
-     */
-    activeIdentifierType?: IdentifierType;
-  } | null;
+  /**
+   * Intersected with the inherited `data` record rather than replacing it, so reads of any
+   * other `screen.data` key keep compiling for existing consumers.
+   */
+  data:
+    | (NonNullable<ScreenMembers['data']> & {
+        username?: string;
+        /**
+         * The identifier input the screen should pre-select, as resolved by the server.
+         *
+         * Absent when the server has not resolved one — do not treat absence as `'email'`;
+         * fall back to your own default instead. Mapped from the server's
+         * `active_identifier_type`, which is not surfaced.
+         */
+        activeIdentifierType?: IdentifierType;
+      })
+    | null;
 }
 
 /**

--- a/packages/auth0-acul-js/src/screens/login-id/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/screen-override.ts
@@ -9,6 +9,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
   resetPasswordLink: OverrideOptions['resetPasswordLink'];
   publicKey: OverrideOptions['publicKey'];
   googleOneTapConfig: OverrideOptions['googleOneTapConfig'];
+  data: OverrideOptions['data'];
 
   constructor(screenContext: ScreenContext) {
     super(screenContext);
@@ -16,5 +17,23 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     this.resetPasswordLink = getResetPasswordLink(screenContext);
     this.publicKey = getPublicKey(screenContext) as OverrideOptions['publicKey'];
     this.googleOneTapConfig = getGoogleOneTapConfig(screenContext);
+    this.data = ScreenOverride.getScreenData(screenContext);
+  }
+
+  /**
+   * Extracts the screen data, renaming the server's `active_identifier_type` to the camelCase
+   * `activeIdentifierType`. The raw snake_case key is dropped so consumers see a single
+   * camelCase field, matching the declared type.
+   */
+  static getScreenData(screenContext: ScreenContext): OverrideOptions['data'] {
+    const data = screenContext.data;
+    if (!data) return null;
+
+    const { active_identifier_type: activeIdentifierType, ...rest } = data;
+
+    return {
+      ...rest,
+      ...(activeIdentifierType !== undefined && { activeIdentifierType }),
+    } as OverrideOptions['data'];
   }
 }

--- a/packages/auth0-acul-js/src/screens/login/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login/screen-override.ts
@@ -18,6 +18,23 @@ export class ScreenOverride extends Screen implements OverrideOptions {
     this.signupLink = getSignupLink(screenContext);
     this.resetPasswordLink = getResetPasswordLink(screenContext);
     this.googleOneTapConfig = getGoogleOneTapConfig(screenContext);
-    this.data = Screen.getScreenData(screenContext) as OverrideOptions['data'];
+    this.data = ScreenOverride.getScreenData(screenContext);
+  }
+
+  /**
+   * Extracts the screen data, renaming the server's `active_identifier_type` to the camelCase
+   * `activeIdentifierType`. The raw snake_case key is dropped so consumers see a single
+   * camelCase field, matching the declared type.
+   */
+  static getScreenData(screenContext: ScreenContext): OverrideOptions['data'] {
+    const data = screenContext.data;
+    if (!data) return null;
+
+    const { active_identifier_type: activeIdentifierType, ...rest } = data;
+
+    return {
+      ...rest,
+      ...(activeIdentifierType !== undefined && { activeIdentifierType }),
+    } as OverrideOptions['data'];
   }
 }

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/screen-override.test.ts
@@ -67,4 +67,25 @@ describe('ScreenOverride', () => {
     const override = new ScreenOverride(screenContext);
     expect(override.googleOneTapConfig).toBeNull();
   });
+
+  describe('activeIdentifierType', () => {
+    const buildData = (data: Record<string, unknown>): ScreenOverride['data'] =>
+      new ScreenOverride({ data } as unknown as ScreenContext).data;
+
+    it.each(['email', 'phone', 'username'])('should expose %s as camelCase activeIdentifierType', (value) => {
+      expect(buildData({ active_identifier_type: value })?.activeIdentifierType).toBe(value);
+    });
+
+    it('should drop the raw snake_case key', () => {
+      expect(buildData({ active_identifier_type: 'phone' })).not.toHaveProperty('active_identifier_type');
+    });
+
+    it('should omit activeIdentifierType when the server does not resolve one', () => {
+      expect(buildData({ passkey: { public_key: {} } })).not.toHaveProperty('activeIdentifierType');
+    });
+
+    it('should return null when the screen has no data', () => {
+      expect(new ScreenOverride({} as ScreenContext).data).toBeNull();
+    });
+  });
 });

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/screen-override.test.ts
@@ -1,10 +1,9 @@
 import { ScreenOverride } from '../../../../src/screens/login-id/screen-override';
 import { getSignupLink, getResetPasswordLink, getPublicKey, getGoogleOneTapConfig } from '../../../../src/shared/screen';
-import { Screen } from '../../../../src/models/screen';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 jest.mock('../../../../src/shared/screen');
-jest.mock('../../../../src/models/screen');
 
 describe('ScreenOverride', () => {
   let screenContext: ScreenContext;

--- a/packages/auth0-acul-js/tests/unit/screens/login/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/screen-override.test.ts
@@ -1,9 +1,9 @@
 import { ScreenOverride } from '../../../../src/screens/login/screen-override';
 import { getSignupLink, getResetPasswordLink, getGoogleOneTapConfig } from '../../../../src/shared/screen';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 jest.mock('../../../../src/shared/screen');
-jest.mock('../../../../src/models/screen');
 
 describe('ScreenOverride', () => {
   let screenContext: ScreenContext;

--- a/packages/auth0-acul-js/tests/unit/screens/login/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/screen-override.test.ts
@@ -1,6 +1,5 @@
 import { ScreenOverride } from '../../../../src/screens/login/screen-override';
 import { getSignupLink, getResetPasswordLink, getGoogleOneTapConfig } from '../../../../src/shared/screen';
-import { Screen } from '../../../../src/models/screen';
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 jest.mock('../../../../src/shared/screen');
@@ -12,13 +11,12 @@ describe('ScreenOverride', () => {
 
   beforeEach(() => {
     screenContext = {
-      // mock the screenContext properties as needed
-    } as ScreenContext;
+      data: { mockData: 'mockData' },
+    } as unknown as ScreenContext;
 
     (getSignupLink as jest.Mock).mockReturnValue('mockSignupLink');
     (getResetPasswordLink as jest.Mock).mockReturnValue('mockResetPasswordLink');
     (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
-    (Screen.getScreenData as jest.Mock).mockReturnValue({ mockData: 'mockData' });
 
     screenOverride = new ScreenOverride(screenContext);
   });
@@ -48,5 +46,30 @@ describe('ScreenOverride', () => {
     (getGoogleOneTapConfig as jest.Mock).mockReturnValue(null);
     const override = new ScreenOverride(screenContext);
     expect(override.googleOneTapConfig).toBeNull();
+  });
+
+  describe('activeIdentifierType', () => {
+    const buildData = (data: Record<string, unknown>): ScreenOverride['data'] =>
+      new ScreenOverride({ data } as unknown as ScreenContext).data;
+
+    it.each(['email', 'phone', 'username'])('should expose %s as camelCase activeIdentifierType', (value) => {
+      expect(buildData({ active_identifier_type: value })?.activeIdentifierType).toBe(value);
+    });
+
+    it('should drop the raw snake_case key', () => {
+      expect(buildData({ active_identifier_type: 'phone' })).not.toHaveProperty('active_identifier_type');
+    });
+
+    it('should omit activeIdentifierType when the server does not resolve one', () => {
+      expect(buildData({ username: 'someone' })).not.toHaveProperty('activeIdentifierType');
+    });
+
+    it('should preserve sibling screen data keys', () => {
+      expect(buildData({ username: 'someone', active_identifier_type: 'email' })?.username).toBe('someone');
+    });
+
+    it('should return null when the screen has no data', () => {
+      expect(new ScreenOverride({} as ScreenContext).data).toBeNull();
+    });
   });
 });

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -483,3 +483,37 @@ const LoginIdScreenWithGoogleOneTap: React.FC = () => {
 
 export default LoginIdScreenWithGoogleOneTap;
 ```
+### Example using activeIdentifierType
+
+When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+
+```tsx
+import React, { useRef } from 'react';
+import { useScreen, login } from '@auth0/auth0-acul-react/login-id';
+
+const LoginIdScreenWithActiveIdentifier: React.FC = () => {
+  const screen = useScreen();
+  const identifierRef = useRef<HTMLInputElement>(null);
+
+  const activeIdentifier = screen.data?.activeIdentifierType ?? 'email';
+
+  return (
+    <div>
+      <label htmlFor="identifier">
+        {activeIdentifier === 'phone' ? 'Phone number' : 'Email address'}
+      </label>
+      <input
+        id="identifier"
+        ref={identifierRef}
+        type={activeIdentifier === 'phone' ? 'tel' : 'email'}
+        autoComplete={activeIdentifier === 'phone' ? 'tel' : 'email'}
+      />
+      <button onClick={() => login({ username: identifierRef.current?.value ?? '' })}>
+        Continue
+      </button>
+    </div>
+  );
+};
+
+export default LoginIdScreenWithActiveIdentifier;
+```

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -348,3 +348,46 @@ const LoginScreenWithGoogleOneTap: React.FC = () => {
 
 export default LoginScreenWithGoogleOneTap;
 ```
+### Example using activeIdentifierType
+
+When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+
+```tsx
+import React, { useRef } from 'react';
+import { useScreen, login } from '@auth0/auth0-acul-react/login';
+
+const LoginScreenWithActiveIdentifier: React.FC = () => {
+  const screen = useScreen();
+  const identifierRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+
+  const activeIdentifier = screen.data?.activeIdentifierType ?? 'email';
+
+  return (
+    <div>
+      <label htmlFor="identifier">
+        {activeIdentifier === 'phone' ? 'Phone number' : 'Email address'}
+      </label>
+      <input
+        id="identifier"
+        ref={identifierRef}
+        type={activeIdentifier === 'phone' ? 'tel' : 'email'}
+        autoComplete={activeIdentifier === 'phone' ? 'tel' : 'email'}
+      />
+      <input id="password" ref={passwordRef} type="password" autoComplete="current-password" />
+      <button
+        onClick={() =>
+          login({
+            username: identifierRef.current?.value ?? '',
+            password: passwordRef.current?.value ?? '',
+          })
+        }
+      >
+        Continue
+      </button>
+    </div>
+  );
+};
+
+export default LoginScreenWithActiveIdentifier;
+```


### PR DESCRIPTION
## Description

Exposes the server-resolved active identifier type on the `login` and `login-id` screens as `screen.data.activeIdentifierType`.

When a tenant allows multiple identifiers (email, phone, username), this lets custom screens render the correct input on first paint instead of guessing or defaulting.

The value is `'email' | 'phone' | 'username'`, and is `undefined` when the server has not resolved one. In that case fall back to your own default rather than assuming `'email'`.

## Example

```ts
import LoginId from '@auth0/auth0-acul-js/login-id';

const loginId = new LoginId();

const activeIdentifier = loginId.screen.data?.activeIdentifierType ?? 'email';

if (activeIdentifier === 'phone') {
  // render phone number input with country code picker
} else {
  // render email / username input
}
```


## Testing

Unit tests cover each identifier value, the absent case, and sibling `screen.data` keys. `tsc`, the full test suite  and the build all pass.
