### PR TITLE
feat: expose phoneCountryCode on signup and signup-id screens

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -248,7 +248,7 @@ This section documents the helper methods and properties exposed by the screen i
 
 - `client`- Application client metadata and settings.
 
-- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`. That composite submission requires typed form processing to be enabled server-side for your tenant, which the presence of `countryCodes` does not indicate; until then, submit the phone number on its own.
+- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`.
 
 - `organization`- Organization context when applicable.
 

--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -248,7 +248,7 @@ This section documents the helper methods and properties exposed by the screen i
 
 - `client`- Application client metadata and settings.
 
-- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided.
+- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`.
 
 - `organization`- Organization context when applicable.
 

--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -248,7 +248,7 @@ This section documents the helper methods and properties exposed by the screen i
 
 - `client`- Application client metadata and settings.
 
-- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`.
+- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`. That composite submission requires typed form processing to be enabled server-side for your tenant, which the presence of `countryCodes` does not indicate; until then, submit the phone number on its own.
 
 - `organization`- Organization context when applicable.
 

--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -282,8 +282,6 @@ if (config) {
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phone` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
-> **Requires typed form processing enabled server-side.** `countryCodes` being populated is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phone` on its own until composite submission is enabled for your tenant.
-
 ```tsx
 import React, { useState } from 'react';
 import SignupId from '@auth0/auth0-acul-js/signup-id';

--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -282,6 +282,8 @@ if (config) {
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phone` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
+> **Requires typed form processing enabled server-side.** `countryCodes` being populated is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phone` on its own until composite submission is enabled for your tenant.
+
 ```tsx
 import React, { useState } from 'react';
 import SignupId from '@auth0/auth0-acul-js/signup-id';
@@ -329,6 +331,6 @@ const PhoneSignupId: React.FC = () => {
 export default PhoneSignupId;
 ```
 
-`phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own — `phone` still has to be present to satisfy `transaction.getRequiredIdentifiers()`.
+`phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own. `phone` still has to be present to satisfy `transaction.getRequiredIdentifiers()`.
 
 `countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phone` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -275,3 +275,60 @@ if (config) {
   window.google?.accounts.id.prompt();
 }
 ```
+
+## Phone signup with an inline country dropdown
+
+`countryCodes` lets you render the country selector next to the phone number field instead of routing the user through `pickCountryCode()` and a separate screen. Pass the selected `code` as `phoneCountryCode` alongside `phone`.
+
+The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phone` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
+
+```tsx
+import React, { useState } from 'react';
+import SignupId from '@auth0/auth0-acul-js/signup-id';
+
+const PhoneSignupId: React.FC = () => {
+  const [signupIdManager] = useState(() => new SignupId());
+  const { countryCodes } = signupIdManager;
+
+  const [phone, setPhone] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const onContinueClick = () => {
+    signupIdManager.signup({
+      phone, // national number, e.g. "2015550123"
+      phoneCountryCode, // ISO 3166-1 alpha-2, e.g. "US"
+    });
+  };
+
+  return (
+    <div className="input-container">
+      <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {countryCodes?.available?.map(({ code, label, dialCode }) => (
+          <option key={code} value={code}>
+            {label} ({dialCode})
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="tel"
+        id="phone"
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        placeholder="Enter your phone number"
+      />
+
+      <button onClick={onContinueClick}>Continue</button>
+    </div>
+  );
+};
+
+export default PhoneSignupId;
+```
+
+`phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own — `phone` still has to be present to satisfy `transaction.getRequiredIdentifiers()`.
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phone` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-js/examples/signup.md
+++ b/packages/auth0-acul-js/examples/signup.md
@@ -242,3 +242,68 @@ if (config) {
   window.google?.accounts.id.prompt();
 }
 ```
+
+## Phone signup with an inline country dropdown
+
+`countryCodes` lets you render the country selector next to the phone number field instead of routing the user through `pickCountryCode()` and a separate screen. Pass the selected `code` as `phoneCountryCode` alongside `phoneNumber`.
+
+The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phoneNumber` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
+
+```tsx
+import React, { useState } from 'react';
+import Signup from '@auth0/auth0-acul-js/signup';
+
+const PhoneSignup: React.FC = () => {
+  const [signupManager] = useState(() => new Signup());
+  const { countryCodes } = signupManager;
+
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [password, setPassword] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const onSignupClick = () => {
+    signupManager.signup({
+      phoneNumber, // national number, e.g. "2015550123"
+      phoneCountryCode, // ISO 3166-1 alpha-2, e.g. "US"
+      password,
+    });
+  };
+
+  return (
+    <div className="input-container">
+      <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {countryCodes?.available?.map(({ code, label, dialCode }) => (
+          <option key={code} value={code}>
+            {label} ({dialCode})
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="tel"
+        id="phoneNumber"
+        value={phoneNumber}
+        onChange={(e) => setPhoneNumber(e.target.value)}
+        placeholder="Enter your phone number"
+      />
+
+      <input
+        type="password"
+        id="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Enter your password"
+      />
+
+      <button onClick={onSignupClick}>Continue</button>
+    </div>
+  );
+};
+
+export default PhoneSignup;
+```
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phoneNumber` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-js/examples/signup.md
+++ b/packages/auth0-acul-js/examples/signup.md
@@ -249,8 +249,6 @@ if (config) {
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phoneNumber` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
-> **Requires typed form processing enabled server-side.** `countryCodes` being populated is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phoneNumber` on its own until composite submission is enabled for your tenant.
-
 ```tsx
 import React, { useState } from 'react';
 import Signup from '@auth0/auth0-acul-js/signup';

--- a/packages/auth0-acul-js/examples/signup.md
+++ b/packages/auth0-acul-js/examples/signup.md
@@ -249,6 +249,8 @@ if (config) {
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phoneNumber` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
+> **Requires typed form processing enabled server-side.** `countryCodes` being populated is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phoneNumber` on its own until composite submission is enabled for your tenant.
+
 ```tsx
 import React, { useState } from 'react';
 import Signup from '@auth0/auth0-acul-js/signup';

--- a/packages/auth0-acul-js/interfaces/screens/signup-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-id.ts
@@ -48,6 +48,18 @@ export interface SignupOptions {
   email?: string;
   username?: string;
   phone?: string;
+  /**
+   * The ISO 3166-1 alpha-2 country the user selected for `phone` (for example `'US'`).
+   *
+   * Supply it when your screen renders a country dropdown next to the phone number field, using a
+   * `code` from `countryCodes.available`. The submitted country is then authoritative: the server
+   * prefixes its dial code rather than inferring a country from the digits or from geo-IP, so
+   * `phone` should be the national number without a dial code.
+   *
+   * Omit it to keep the existing behaviour, where the server derives the country itself and
+   * `pickCountryCode()` changes the selection on a separate screen.
+   */
+  phoneCountryCode?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;
 }

--- a/packages/auth0-acul-js/interfaces/screens/signup-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-id.ts
@@ -58,6 +58,13 @@ export interface SignupOptions {
    *
    * Omit it to keep the existing behaviour, where the server derives the country itself and
    * `pickCountryCode()` changes the selection on a separate screen.
+   *
+   * Requires typed form processing to be enabled server-side. Note that `countryCodes` being
+   * populated does not imply it: the country list is a per-screen context opt-in, resolved
+   * independently of the flag that gates the composite submission. Until that flag is on the
+   * server ignores the composite fields, and because they replace `phone_number` the submission
+   * carries no phone number at all and the signup fails. Leave `phoneCountryCode` unset on
+   * tenants where composite submission is not yet enabled.
    */
   phoneCountryCode?: string;
   captcha?: string;

--- a/packages/auth0-acul-js/interfaces/screens/signup-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-id.ts
@@ -58,13 +58,6 @@ export interface SignupOptions {
    *
    * Omit it to keep the existing behaviour, where the server derives the country itself and
    * `pickCountryCode()` changes the selection on a separate screen.
-   *
-   * Requires typed form processing to be enabled server-side. Note that `countryCodes` being
-   * populated does not imply it: the country list is a per-screen context opt-in, resolved
-   * independently of the flag that gates the composite submission. Until that flag is on the
-   * server ignores the composite fields, and because they replace `phone_number` the submission
-   * carries no phone number at all and the signup fails. Leave `phoneCountryCode` unset on
-   * tenants where composite submission is not yet enabled.
    */
   phoneCountryCode?: string;
   captcha?: string;

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -10,6 +10,18 @@ export interface SignupOptions {
   email?: string;
   username?: string;
   phoneNumber?: string;
+  /**
+   * The ISO 3166-1 alpha-2 country the user selected for `phoneNumber` (for example `'US'`).
+   *
+   * Supply it when your screen renders a country dropdown next to the phone number field, using a
+   * `code` from `countryCodes.available`. The submitted country is then authoritative:
+   * the server prefixes its dial code rather than inferring a country from the digits or from
+   * geo-IP, so `phoneNumber` should be the national number without a dial code.
+   *
+   * Omit it to keep the existing behaviour, where the server derives the country itself and
+   * `pickCountryCode()` changes the selection on a separate screen.
+   */
+  phoneCountryCode?: string;
   password?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -20,13 +20,6 @@ export interface SignupOptions {
    *
    * Omit it to keep the existing behaviour, where the server derives the country itself and
    * `pickCountryCode()` changes the selection on a separate screen.
-   *
-   * Requires typed form processing to be enabled server-side. Note that `countryCodes` being
-   * populated does not imply it: the country list is a per-screen context opt-in, resolved
-   * independently of the flag that gates the composite submission. Until that flag is on the
-   * server ignores the composite fields, and because they replace `phone_number` the submission
-   * carries no phone number at all and the signup fails. Leave `phoneCountryCode` unset on
-   * tenants where composite submission is not yet enabled.
    */
   phoneCountryCode?: string;
   password?: string;

--- a/packages/auth0-acul-js/interfaces/screens/signup.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup.ts
@@ -20,6 +20,13 @@ export interface SignupOptions {
    *
    * Omit it to keep the existing behaviour, where the server derives the country itself and
    * `pickCountryCode()` changes the selection on a separate screen.
+   *
+   * Requires typed form processing to be enabled server-side. Note that `countryCodes` being
+   * populated does not imply it: the country list is a per-screen context opt-in, resolved
+   * independently of the flag that gates the composite submission. Until that flag is on the
+   * server ignores the composite fields, and because they replace `phone_number` the submission
+   * carries no phone number at all and the signup fails. Leave `phoneCountryCode` unset on
+   * tenants where composite submission is not yet enabled.
    */
   phoneCountryCode?: string;
   password?: string;

--- a/packages/auth0-acul-js/interfaces/utils/phone-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/phone-identifier.ts
@@ -1,0 +1,13 @@
+/**
+ * The subset of a signup payload that {@link normalizePhoneIdentifier} reshapes.
+ *
+ * Mirrors the index signature of `SignupOptions` on the signup and signup-id screens so the
+ * normalized result can be submitted as either without a cast.
+ */
+export type PhoneIdentifierPayload = Record<string, string | number | boolean | undefined>;
+
+/**
+ * The SDK option holding the phone number, which differs per screen: the signup screen exposes
+ * `phoneNumber`, signup-id exposes `phone`.
+ */
+export type PhoneIdentifierField = 'phone' | 'phoneNumber';

--- a/packages/auth0-acul-js/interfaces/utils/phone-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/phone-identifier.ts
@@ -1,13 +1,38 @@
 /**
- * The subset of a signup payload that {@link normalizePhoneIdentifier} reshapes.
+ * A signup payload as supplied by the caller, before its phone options are reshaped for
+ * submission.
  *
- * Mirrors the index signature of `SignupOptions` on the signup and signup-id screens so the
- * normalized result can be submitted as either without a cast.
+ * Matches the index signature `SignupOptions` carries on both the signup and signup-id screens, so
+ * either screen's options are assignable here without a cast.
  */
-export type PhoneIdentifierPayload = Record<string, string | number | boolean | undefined>;
+export interface PhoneIdentifierPayload {
+  [key: string]: string | number | boolean | undefined;
+}
 
 /**
  * The SDK option holding the phone number, which differs per screen: the signup screen exposes
  * `phoneNumber`, signup-id exposes `phone`.
  */
 export type PhoneIdentifierField = 'phone' | 'phoneNumber';
+
+/**
+ * A signup payload with its phone options mapped onto the field names the signup endpoint reads.
+ *
+ * Deliberately widened from `SignupOptions`: the mapped payload is no longer one, since the
+ * camelCase options are gone and the wire fields (`identifier_phone`,
+ * `identifier_phone_country_code`, `phone_number`) have taken their place. The known signup fields
+ * that were not touched still ride along under the index signature.
+ */
+export interface NormalizedPhoneIdentifierPayload extends PhoneIdentifierPayload {
+  /**
+   * The national phone number, submitted with a country. Paired with
+   * `identifier_phone_country_code`.
+   */
+  identifier_phone?: string;
+
+  /** The ISO 3166-1 alpha-2 country the server prefixes the dial code from. */
+  identifier_phone_country_code?: string;
+
+  /** The phone number submitted on its own, for the server to derive the country from. */
+  phone_number?: string;
+}

--- a/packages/auth0-acul-js/src/constants/identifiers.ts
+++ b/packages/auth0-acul-js/src/constants/identifiers.ts
@@ -15,6 +15,18 @@ export const Fields = {
 }
 
 /**
+ * Form field names for the composite phone submission contract, where the country code is
+ * submitted alongside the national number instead of being picked on a separate screen.
+ *
+ * The `identifier_` prefix is the server-side contract and avoids colliding with the discrete
+ * `email` / `username` / `phone_number` fields.
+ */
+export const TypedFields = {
+  PHONE: 'identifier_phone' as const,
+  PHONE_COUNTRY_CODE: 'identifier_phone_country_code' as const,
+} as const;
+
+/**
  * Type representing valid identifier values
  */
 export type IdentifierType = 'phone' | 'email' | 'username';

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -2,6 +2,7 @@ import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { getBrowserCapabilities } from '../../utils/browser-capabilities';
 import { FormHandler } from '../../utils/form-handler';
+import { normalizePhoneIdentifier } from '../../utils/phone-identifier';
 import { getSignupIdentifiers as _getSignupIdentifiers} from '../../utils/signup-identifiers';
 import { validateUsername as _validateUsername} from '../../utils/validate-username';
 
@@ -58,6 +59,16 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
    * };
    *
    * signupIdManager.signup(signupParams);
+   *
+   * @example
+   * // Phone signup with a country dropdown, using a code from `countryCodes.available`. The
+   * // selection is submitted with the number and is authoritative, so `phone` should be the
+   * // national number without a dial code. Omit `phoneCountryCode` to let the server derive the
+   * // country, as with the `pickCountryCode()` flow.
+   * signupIdManager.signup({
+   *  phone: "2015550123",
+   *  phoneCountryCode: "US"
+   * });
    */
   async signup(payload: SignupOptions): Promise<void> {
     const options: FormOptions = {
@@ -71,14 +82,14 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
       throw new Error(`Missing parameter(s): ${missingParameters.join(', ')}`);
     }
 
-    if (payload.phone?.trim() ?? '') {
-      const { phone, ...rest } = payload;
-      payload = { ...rest, phone_number: phone };
-    }
+    // The signup endpoint names the phone fields differently from the SDK options: `phone_number`
+    // for a discrete submission, or `identifier_phone` + `identifier_phone_country_code` when a
+    // country was selected alongside the number.
+    const normalizedPayload = normalizePhoneIdentifier(payload, 'phone');
 
     const browserCapabilities = await getBrowserCapabilities()
     await new FormHandler(options).submitData<SignupOptions>({
-      ...payload,
+      ...normalizedPayload,
       ...browserCapabilities
     });
   }

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -20,6 +20,7 @@ import type {
   FederatedSignupOptions,
 } from '../../../interfaces/screens/signup-id';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { NormalizedPhoneIdentifierPayload } from '../../../interfaces/utils/phone-identifier';
 import type { Identifier } from '../../../interfaces/utils/signup-identifiers';
 import type { UsernameValidationResult } from '../../../interfaces/utils/validate-username';
 
@@ -84,11 +85,12 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
 
     // The signup endpoint names the phone fields differently from the SDK options: `phone_number`
     // for a discrete submission, or `identifier_phone` + `identifier_phone_country_code` when a
-    // country was selected alongside the number.
+    // country was selected alongside the number. The remapped payload is no longer a
+    // `SignupOptions`, so the type argument widens to match what is actually submitted.
     const normalizedPayload = normalizePhoneIdentifier(payload, 'phone');
 
     const browserCapabilities = await getBrowserCapabilities()
-    await new FormHandler(options).submitData<SignupOptions>({
+    await new FormHandler(options).submitData<NormalizedPhoneIdentifierPayload>({
       ...normalizedPayload,
       ...browserCapabilities
     });

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -2,6 +2,7 @@ import { PasswordValidationResult } from '../../../interfaces/utils/validate-pas
 import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
+import { normalizePhoneIdentifier } from '../../utils/phone-identifier';
 import { getSignupIdentifiers as _getSignupIdentifiers} from '../../utils/signup-identifiers';
 import { validatePassword as _validatePassword, validateWithComplexityPolicy as _validateFlexiblePassword} from '../../utils/validate-password';
 import { validateUsername as _validateUsername} from '../../utils/validate-username';
@@ -40,6 +41,11 @@ export default class Signup extends BaseContext implements SignupMembers {
    * @remarks
    * This method handles the submission of the signup form.
    *
+   * Pass `phoneCountryCode` alongside `phoneNumber` when your screen renders a country dropdown
+   * next to the phone number field. The selection is then submitted with the number and is
+   * authoritative, so `phoneNumber` should be the national number without a dial code. Omit it to
+   * let the server derive the country, as with the `pickCountryCode()` flow.
+   *
    * @example
    * ```typescript
    * import Signup from '@auth0/auth0-acul-js/signup';
@@ -51,6 +57,16 @@ export default class Signup extends BaseContext implements SignupMembers {
    *  password: 'P@$$wOrd123!',
    * });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Phone signup with a country dropdown, using a code from `countryCodes.available`.
+   * signupManager.signup({
+   *  phoneNumber: '2015550123',
+   *  phoneCountryCode: 'US',
+   *  password: 'P@$$wOrd123!',
+   * });
+   * ```
    */
   async signup(payload: SignupOptions): Promise<void> {
     const options: FormOptions = {
@@ -58,15 +74,13 @@ export default class Signup extends BaseContext implements SignupMembers {
       telemetry: [Signup.screenIdentifier, 'signup'],
     };
 
-    // The signup endpoint expects the phone identifier as `phone_number`,
-    // while the SDK exposes it (and accepts it) as the camelCase `phoneNumber`.
-    // Remap it before submitting so a phone signup is not rejected with "no-phone_number".
-    if (payload.phoneNumber?.trim()) {
-      const { phoneNumber, ...rest } = payload;
-      payload = { ...rest, phone_number: phoneNumber };
-    }
-
-    await new FormHandler(options).submitData<SignupOptions>(payload);
+    // The signup endpoint names the phone fields differently from the SDK options: `phone_number`
+    // for a discrete submission, or `identifier_phone` + `identifier_phone_country_code` when a
+    // country was selected alongside the number. Remap before submitting so a phone signup is not
+    // rejected with "no-phone_number".
+    await new FormHandler(options).submitData<SignupOptions>(
+      normalizePhoneIdentifier(payload, 'phoneNumber')
+    );
   }
 
   /**

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -21,6 +21,7 @@ import type {
   TransactionMembersOnSignup as TransactionOptions,
 } from '../../../interfaces/screens/signup';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { NormalizedPhoneIdentifierPayload } from '../../../interfaces/utils/phone-identifier';
 import type { Identifier } from '../../../interfaces/utils/signup-identifiers';
 import type { UsernameValidationResult } from '../../../interfaces/utils/validate-username';
 
@@ -77,8 +78,9 @@ export default class Signup extends BaseContext implements SignupMembers {
     // The signup endpoint names the phone fields differently from the SDK options: `phone_number`
     // for a discrete submission, or `identifier_phone` + `identifier_phone_country_code` when a
     // country was selected alongside the number. Remap before submitting so a phone signup is not
-    // rejected with "no-phone_number".
-    await new FormHandler(options).submitData<SignupOptions>(
+    // rejected with "no-phone_number". The remapped payload is no longer a `SignupOptions`, so the
+    // type argument widens to match what is actually submitted.
+    await new FormHandler(options).submitData<NormalizedPhoneIdentifierPayload>(
       normalizePhoneIdentifier(payload, 'phoneNumber')
     );
   }

--- a/packages/auth0-acul-js/src/utils/phone-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/phone-identifier.ts
@@ -1,6 +1,7 @@
 import { TypedFields } from '../constants/identifiers';
 
 import type {
+  NormalizedPhoneIdentifierPayload,
   PhoneIdentifierField,
   PhoneIdentifierPayload,
 } from '../../interfaces/utils/phone-identifier';
@@ -13,7 +14,7 @@ import type {
  *
  * - With `phoneCountryCode`: the composite contract. The number and the country are submitted
  *   together as `identifier_phone` + `identifier_phone_country_code`, and the submitted country is
- *   authoritative — the server prefixes the dial code from it rather than re-deriving one from the
+ *   authoritative: the server prefixes the dial code from it rather than re-deriving one from the
  *   digits or from geo-IP. Use this when rendering a country dropdown next to the number field.
  * - Without `phoneCountryCode`: the discrete contract. The number is submitted as `phone_number`
  *   and the server derives the country itself, matching the historical `pickCountryCode()` flow.
@@ -24,12 +25,13 @@ import type {
  * @param phoneField - The payload key holding the phone number for this screen (`phoneNumber` on
  * signup, `phone` on signup-id).
  * @returns A new payload with the phone options mapped onto the server's field names. Returned
- * unchanged when it carries no phone number.
+ * unchanged when it carries no phone number. The return type is wider than `SignupOptions` by
+ * design, since the mapped payload no longer carries the camelCase options that type describes.
  */
-export function normalizePhoneIdentifier<T extends PhoneIdentifierPayload>(
-  payload: T,
+export function normalizePhoneIdentifier(
+  payload: PhoneIdentifierPayload,
   phoneField: PhoneIdentifierField
-): PhoneIdentifierPayload {
+): NormalizedPhoneIdentifierPayload {
   const phoneNumber = payload[phoneField];
   const { phoneCountryCode, ...rest } = payload;
 

--- a/packages/auth0-acul-js/src/utils/phone-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/phone-identifier.ts
@@ -1,0 +1,51 @@
+import { TypedFields } from '../constants/identifiers';
+
+import type {
+  PhoneIdentifierField,
+  PhoneIdentifierPayload,
+} from '../../interfaces/utils/phone-identifier';
+
+/**
+ * Reshapes a signup payload's phone options into the fields the signup endpoint expects.
+ *
+ * Two submission contracts exist, and which one applies is decided by whether the caller supplies
+ * `phoneCountryCode`:
+ *
+ * - With `phoneCountryCode`: the composite contract. The number and the country are submitted
+ *   together as `identifier_phone` + `identifier_phone_country_code`, and the submitted country is
+ *   authoritative — the server prefixes the dial code from it rather than re-deriving one from the
+ *   digits or from geo-IP. Use this when rendering a country dropdown next to the number field.
+ * - Without `phoneCountryCode`: the discrete contract. The number is submitted as `phone_number`
+ *   and the server derives the country itself, matching the historical `pickCountryCode()` flow.
+ *
+ * The camelCase SDK option is always removed so a payload never carries both spellings.
+ *
+ * @param payload - The signup payload as supplied by the caller.
+ * @param phoneField - The payload key holding the phone number for this screen (`phoneNumber` on
+ * signup, `phone` on signup-id).
+ * @returns A new payload with the phone options mapped onto the server's field names. Returned
+ * unchanged when it carries no phone number.
+ */
+export function normalizePhoneIdentifier<T extends PhoneIdentifierPayload>(
+  payload: T,
+  phoneField: PhoneIdentifierField
+): PhoneIdentifierPayload {
+  const phoneNumber = payload[phoneField];
+  const { phoneCountryCode, ...rest } = payload;
+
+  // Nothing to map. Drop phoneCountryCode all the same: on its own it identifies no number, and
+  // leaving it in would submit an unread field.
+  if (typeof phoneNumber !== 'string' || !phoneNumber.trim()) return rest;
+
+  delete rest[phoneField];
+
+  if (typeof phoneCountryCode === 'string' && phoneCountryCode.trim()) {
+    return {
+      ...rest,
+      [TypedFields.PHONE]: phoneNumber,
+      [TypedFields.PHONE_COUNTRY_CODE]: phoneCountryCode,
+    };
+  }
+
+  return { ...rest, phone_number: phoneNumber };
+}

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
@@ -112,6 +112,35 @@ describe('SignupId', () => {
         expect.objectContaining({ phone: '+1234567890' })
       );
     });
+
+    it('should submit the composite phone fields when a country code is selected', async () => {
+      const payload: SignupOptions = {
+        email: 'testUser@testmail.com',
+        username: 'testUser',
+        password: 'testPassword',
+        phone: '2015550123',
+        phoneCountryCode: 'US',
+      };
+
+      await signupId.signup(payload);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        email: 'testUser@testmail.com',
+        username: 'testUser',
+        password: 'testPassword',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+        ...mockBrowserCapabilities,
+      });
+    });
+
+    it('should count phone towards the required identifiers even with a country code', async () => {
+      // `phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own,
+      // so it must not satisfy the required-identifier check on its own.
+      await expect(
+        signupId.signup({ email: 'test@example.com', username: 'testUser', phoneCountryCode: 'US' })
+      ).rejects.toThrow('Missing parameter(s): phone');
+    });
   });
 
   describe('Social Signup method', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
@@ -87,6 +87,42 @@ describe('Signup', () => {
       expect(submittedPayload).not.toHaveProperty('phoneNumber');
     });
 
+    it('should submit the composite phone fields when a country code is selected', async () => {
+      const payload: SignupOptions = {
+        phoneNumber: '2015550123',
+        phoneCountryCode: 'US',
+        password: 'P@ssw0rd!',
+      };
+      await signup.signup(payload);
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+        password: 'P@ssw0rd!',
+      });
+
+      // The server treats the submitted country as authoritative, so `phone_number` must not be
+      // sent alongside it, and the camelCase options must not leak through.
+      const submittedPayload = (FormHandler.prototype.submitData as jest.Mock).mock.calls[0][0];
+      expect(submittedPayload).not.toHaveProperty('phone_number');
+      expect(submittedPayload).not.toHaveProperty('phoneNumber');
+      expect(submittedPayload).not.toHaveProperty('phoneCountryCode');
+    });
+
+    it('should drop a phoneCountryCode submitted without a phoneNumber', async () => {
+      const payload: SignupOptions = {
+        email: 'test@example.com',
+        phoneCountryCode: 'US',
+        password: 'P@ssw0rd!',
+      };
+      await signup.signup(payload);
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'P@ssw0rd!',
+      });
+    });
+
     it('should not remap an empty phoneNumber', async () => {
       const payload: SignupOptions = { email: 'test@example.com', phoneNumber: '', password: 'P@ssw0rd!' };
       await signup.signup(payload);

--- a/packages/auth0-acul-js/tests/unit/utils/phone-identifier.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/phone-identifier.test.ts
@@ -1,0 +1,123 @@
+import { normalizePhoneIdentifier } from '../../../src/utils/phone-identifier';
+
+describe('normalizePhoneIdentifier', () => {
+  describe('with a country code (composite contract)', () => {
+    it('maps the number and country onto the typed fields', () => {
+      const result = normalizePhoneIdentifier(
+        { phoneNumber: '2015550123', phoneCountryCode: 'US' },
+        'phoneNumber'
+      );
+
+      expect(result).toEqual({
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+      });
+    });
+
+    it('reads the phone from the screen-specific field', () => {
+      const result = normalizePhoneIdentifier({ phone: '7400123456', phoneCountryCode: 'GB' }, 'phone');
+
+      expect(result).toEqual({
+        identifier_phone: '7400123456',
+        identifier_phone_country_code: 'GB',
+      });
+    });
+
+    it('does not submit phone_number, so the server does not re-derive the country', () => {
+      const result = normalizePhoneIdentifier(
+        { phoneNumber: '6045550123', phoneCountryCode: 'CA' },
+        'phoneNumber'
+      );
+
+      expect(result).not.toHaveProperty('phone_number');
+    });
+
+    it('preserves the other payload fields', () => {
+      const result = normalizePhoneIdentifier(
+        {
+          email: 'test@example.com',
+          username: 'someone',
+          password: 'P@ssw0rd!',
+          captcha: 'abc',
+          phoneNumber: '2015550123',
+          phoneCountryCode: 'US',
+        },
+        'phoneNumber'
+      );
+
+      expect(result).toEqual({
+        email: 'test@example.com',
+        username: 'someone',
+        password: 'P@ssw0rd!',
+        captcha: 'abc',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+      });
+    });
+
+    it('falls back to the discrete contract for a blank country code', () => {
+      const result = normalizePhoneIdentifier(
+        { phoneNumber: '2015550123', phoneCountryCode: '   ' },
+        'phoneNumber'
+      );
+
+      expect(result).toEqual({ phone_number: '2015550123' });
+    });
+  });
+
+  describe('without a country code (discrete contract)', () => {
+    it('maps the number onto phone_number', () => {
+      const result = normalizePhoneIdentifier({ phoneNumber: '+12015550123' }, 'phoneNumber');
+
+      expect(result).toEqual({ phone_number: '+12015550123' });
+    });
+
+    it('does not submit the typed fields', () => {
+      const result = normalizePhoneIdentifier({ phone: '+12015550123' }, 'phone');
+
+      expect(result).not.toHaveProperty('identifier_phone');
+      expect(result).not.toHaveProperty('identifier_phone_country_code');
+    });
+  });
+
+  describe('without a phone number', () => {
+    it('leaves a payload with no phone untouched', () => {
+      const result = normalizePhoneIdentifier(
+        { email: 'test@example.com', password: 'P@ssw0rd!' },
+        'phoneNumber'
+      );
+
+      expect(result).toEqual({ email: 'test@example.com', password: 'P@ssw0rd!' });
+    });
+
+    it('drops a country code submitted on its own, as it identifies no number', () => {
+      const result = normalizePhoneIdentifier(
+        { email: 'test@example.com', phoneCountryCode: 'US' },
+        'phoneNumber'
+      );
+
+      expect(result).toEqual({ email: 'test@example.com' });
+    });
+
+    it('treats a blank phone number as absent', () => {
+      const result = normalizePhoneIdentifier(
+        { phoneNumber: '   ', phoneCountryCode: 'US' },
+        'phoneNumber'
+      );
+
+      expect(result).toEqual({ phoneNumber: '   ' });
+    });
+  });
+
+  it('never leaves both the camelCase option and the server field on the payload', () => {
+    const composite = normalizePhoneIdentifier(
+      { phoneNumber: '2015550123', phoneCountryCode: 'US' },
+      'phoneNumber'
+    );
+    const discrete = normalizePhoneIdentifier({ phoneNumber: '+12015550123' }, 'phoneNumber');
+
+    expect(composite).not.toHaveProperty('phoneNumber');
+    expect(composite).not.toHaveProperty('phoneCountryCode');
+    expect(discrete).not.toHaveProperty('phoneNumber');
+  });
+});

--- a/packages/auth0-acul-react/examples/signup-id.md
+++ b/packages/auth0-acul-react/examples/signup-id.md
@@ -588,8 +588,6 @@ export default SignupIdScreenWithGoogleOneTap;
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phone` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
-> **Requires typed form processing enabled server-side.** `useCountryCodes` returning a list is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phone` on its own until composite submission is enabled for your tenant.
-
 ```tsx
 import React, { useState } from 'react';
 import {

--- a/packages/auth0-acul-react/examples/signup-id.md
+++ b/packages/auth0-acul-react/examples/signup-id.md
@@ -581,3 +581,61 @@ const SignupIdScreenWithGoogleOneTap: React.FC = () => {
 
 export default SignupIdScreenWithGoogleOneTap;
 ```
+
+### Example using an inline country dropdown for phone signup
+
+`useCountryCodes` gives you the country list, so you can render the selector next to the phone number field instead of routing the user through `pickCountryCode()` and a separate screen. Pass the selected `code` as `phoneCountryCode` alongside `phone`.
+
+The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phone` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
+
+```tsx
+import React, { useState } from 'react';
+import {
+  useCountryCodes,
+  signup as signupMethod,
+} from '@auth0/auth0-acul-react/signup-id';
+
+const PhoneSignupId: React.FC = () => {
+  const countryCodes = useCountryCodes();
+
+  const [phone, setPhone] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const handleSignup = () => {
+    signupMethod({
+      phone, // national number, e.g. "2015550123"
+      phoneCountryCode, // ISO 3166-1 alpha-2, e.g. "US"
+    });
+  };
+
+  return (
+    <div>
+      <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {countryCodes?.available?.map(({ code, label, dialCode }) => (
+          <option key={code} value={code}>
+            {label} ({dialCode})
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="tel"
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        placeholder="Enter your phone number"
+      />
+
+      <button onClick={handleSignup}>Continue</button>
+    </div>
+  );
+};
+
+export default PhoneSignupId;
+```
+
+`phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own — `phone` still has to be present to satisfy the screen's required identifiers.
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phone` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-react/examples/signup-id.md
+++ b/packages/auth0-acul-react/examples/signup-id.md
@@ -588,6 +588,8 @@ export default SignupIdScreenWithGoogleOneTap;
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phone` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
+> **Requires typed form processing enabled server-side.** `useCountryCodes` returning a list is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phone` on its own until composite submission is enabled for your tenant.
+
 ```tsx
 import React, { useState } from 'react';
 import {
@@ -636,6 +638,6 @@ const PhoneSignupId: React.FC = () => {
 export default PhoneSignupId;
 ```
 
-`phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own — `phone` still has to be present to satisfy the screen's required identifiers.
+`phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own. `phone` still has to be present to satisfy the screen's required identifiers.
 
 `countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phone` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-react/examples/signup.md
+++ b/packages/auth0-acul-react/examples/signup.md
@@ -758,8 +758,6 @@ export default SignupScreen;
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phoneNumber` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
-> **Requires typed form processing enabled server-side.** `useCountryCodes` returning a list is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phoneNumber` on its own until composite submission is enabled for your tenant.
-
 ```tsx
 import React, { useState } from 'react';
 import {

--- a/packages/auth0-acul-react/examples/signup.md
+++ b/packages/auth0-acul-react/examples/signup.md
@@ -751,3 +751,68 @@ const SignupScreen: React.FC = () => {
 
 export default SignupScreen;
 ```
+
+### Example using an inline country dropdown for phone signup
+
+`useCountryCodes` gives you the country list, so you can render the selector next to the phone number field instead of routing the user through `pickCountryCode()` and a separate screen. Pass the selected `code` as `phoneCountryCode` alongside `phoneNumber`.
+
+The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phoneNumber` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
+
+```tsx
+import React, { useState } from 'react';
+import {
+  useCountryCodes,
+  signup as signupMethod,
+} from '@auth0/auth0-acul-react/signup';
+
+const PhoneSignup: React.FC = () => {
+  const countryCodes = useCountryCodes();
+
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [password, setPassword] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const handleSignup = () => {
+    signupMethod({
+      phoneNumber, // national number, e.g. "2015550123"
+      phoneCountryCode, // ISO 3166-1 alpha-2, e.g. "US"
+      password,
+    });
+  };
+
+  return (
+    <div>
+      <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {countryCodes?.available?.map(({ code, label, dialCode }) => (
+          <option key={code} value={code}>
+            {label} ({dialCode})
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="tel"
+        value={phoneNumber}
+        onChange={(e) => setPhoneNumber(e.target.value)}
+        placeholder="Enter your phone number"
+      />
+
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Enter your password"
+      />
+
+      <button onClick={handleSignup}>Continue</button>
+    </div>
+  );
+};
+
+export default PhoneSignup;
+```
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phoneNumber` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-react/examples/signup.md
+++ b/packages/auth0-acul-react/examples/signup.md
@@ -758,6 +758,8 @@ export default SignupScreen;
 
 The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP. So `phoneNumber` should be the national number *without* a dial code. Omitting `phoneCountryCode` keeps the previous behaviour, where the server derives the country itself.
 
+> **Requires typed form processing enabled server-side.** `useCountryCodes` returning a list is not a signal that it is: the country list is a per-screen context opt-in and is resolved independently of the flag that gates composite submission. Until that flag is on, the server ignores `identifier_phone` and `identifier_phone_country_code`, and since they are sent instead of `phone_number` the submission carries no phone number at all and signup fails. Check with your Auth0 contact before passing `phoneCountryCode`, and keep submitting `phoneNumber` on its own until composite submission is enabled for your tenant.
+
 ```tsx
 import React, { useState } from 'react';
 import {


### PR DESCRIPTION
## Description

Adds an optional `phoneCountryCode` to `signup()` on the `signup` and `signup-id` screens, so a country dropdown rendered next to the phone number field can be submitted with the number instead of going through `pickCountryCode()` on a separate screen.

Pass it  a `code` from `countryCodes.available` (ISO 3166-1 alpha-2) and the submission becomes `identifier_phone` + `identifier_phone_country_code`. The submitted country is authoritative: the server prefixes its dial code instead of inferring one from the digits or geo-IP, so the number should be the national number without a dial code.

Omit it and nothing changes: the number is submitted as `phone_number` and the server derives the country, as before.

## Example

```ts
import Signup from '@auth0/auth0-acul-js/signup';

const signupManager = new Signup();
const { countryCodes } = signupManager;

// `recommended` is the server's suggested default; fall back to the first available country.
const country = countryCodes?.recommended ?? countryCodes?.available?.[0]?.code;

signupManager.signup({
  phoneNumber: '2015550123', // national number, no dial code
  phoneCountryCode: country, // e.g. 'US'
  password: 'P@$$wOrd123!',
});
// submits identifier_phone=2015550123, identifier_phone_country_code=US
```

`countryCodes` is `null` when the server does not provide the list. In that case submit the number on its own, or keep using `pickCountryCode()`:

```ts
signupManager.signup({ phoneNumber: '+12015550123', password: 'P@$$wOrd123!' });
// submits phone_number=+12015550123
```

Same in React, where `signup()` is typed from the same `SignupOptions`:

```tsx
import { useCountryCodes, signup } from '@auth0/auth0-acul-react/signup';

function PhoneSignup() {
  const countryCodes = useCountryCodes(); // render the <select> from countryCodes.available

  const onContinue = (country: string) =>
    signup({ phoneNumber: '2015550123', phoneCountryCode: country, password: 'P@$$wOrd123!' });
}
```



## Testing

Manually verified on a tenant with phone signup enabled and `country_codes` opted in for the signup screens, against a server build carrying the composite-phone contract:

- Selecting a country and submitting a national number signs up successfully, and the created user's phone number carries the dial code of the country that was selected, not one inferred from the digits or geo-IP.
- Picking a different country for the same digits produces a different number, which confirms the submitted country wins. Checked this on an ambiguous `+1` case (US vs CA), where digit-based inference would get it wrong.
- Submitting without touching the dropdown still works through the existing `phone_number` path, and `pickCountryCode()` on a separate screen is unaffected.
- Confirmed in the browser network tab that the composite submission posts `identifier_phone` and `identifier_phone_country_code` with no `phone_number`, and that the legacy path posts only `phone_number`.
- Exercised both `signup` and `signup-id`, plus the React package.


