### PR TITLE
feat: expose identifierType and phoneCountryCode on login and login-id screen

### DIFF
--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -248,7 +248,7 @@ This section documents the helper methods and properties exposed by the screen i
 
 - `client`- Application client metadata and settings.
 
-- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup and login screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`. On `login` and `login-id` it is read when `identifierType` is `'phone'`.
+- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup and login screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`. On `login` and `login-id` it is required with `identifierType: 'phone'`.
 
 - `organization`- Organization context when applicable.
 

--- a/packages/auth0-acul-js/README.md
+++ b/packages/auth0-acul-js/README.md
@@ -248,7 +248,7 @@ This section documents the helper methods and properties exposed by the screen i
 
 - `client`- Application client metadata and settings.
 
-- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`.
+- `countryCodes`- Available phone country codes (`available`, each with `code`, `label`, `dialCode`) and the recommended default (`recommended`); `null` when not provided. On the signup and login screens, pass the selected `code` back as `phoneCountryCode` alongside the phone number to submit both from one screen instead of routing through `pickCountryCode()`. On `login` and `login-id` it is read when `identifierType` is `'phone'`.
 
 - `organization`- Organization context when applicable.
 

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -118,7 +118,7 @@ if (config) {
 
 ## activeIdentifierType
 
-When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+`screen.data.activeIdentifierType` is the input the server resolved, for first paint. It is `undefined` when none was resolved, so supply your own default.
 
 ```typescript
 import LoginId from '@auth0/auth0-acul-js/login-id';
@@ -136,9 +136,9 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
+`activeIdentifierType` says which input to *render*; `identifierType` says which one the user *entered*. Pass it when your screen lets the user pick — tabs, a dropdown, or `getLoginIdentifiers()`.
 
-Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
+The value goes in `identifier`, and `identifierType` names what it holds. Omit the type and the identifier is submitted on its own, as before. `username` still works in `identifier`'s place.
 
 ```typescript
 import LoginId from '@auth0/auth0-acul-js/login-id';
@@ -155,7 +155,7 @@ loginIdManager.login({ identifier: 'someone', identifierType: 'username' });
 loginIdManager.login({ identifier: 'someone' });
 ```
 
-For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`, and the inline alternative to `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
+For a phone, pass the national number as `identifier` and the country as `phoneCountryCode` (from `countryCodes.available`, rendered inline). The dial code is added server-side. A typed submission ignores any `pickCountryCode()` selection.
 
 ```tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -134,3 +134,76 @@ if (activeIdentifier === 'phone') {
 }
 ```
 
+## Telling the server which identifier the user chose
+
+`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+
+Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `getLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number.
+
+The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
+
+```typescript
+import LoginId from '@auth0/auth0-acul-js/login-id';
+
+const loginIdManager = new LoginId();
+
+loginIdManager.login({
+  username: 'someone',       // the value the user typed
+  identifierType: 'username' // how the server should read it
+});
+```
+
+For a phone identifier, also pass the selected country as `phoneCountryCode`. This is the inline alternative to routing the user through `pickCountryCode()` and a separate screen. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code.
+
+```tsx
+import React, { useState } from 'react';
+import LoginId from '@auth0/auth0-acul-js/login-id';
+
+const PhoneLoginId: React.FC = () => {
+  const [loginIdManager] = useState(() => new LoginId());
+  const { countryCodes } = loginIdManager;
+
+  const [username, setUsername] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const onContinueClick = () => {
+    loginIdManager.login({
+      username, // national number, e.g. "2015550123"
+      identifierType: 'phone',
+      phoneCountryCode // ISO 3166-1 alpha-2, e.g. "US"
+    });
+  };
+
+  return (
+    <div className="input-container">
+      <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {countryCodes?.available?.map(({ code, label, dialCode }) => (
+          <option key={code} value={code}>
+            {label} ({dialCode})
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="tel"
+        id="username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="Enter your phone number"
+      />
+
+      <button onClick={onContinueClick}>Continue</button>
+    </div>
+  );
+};
+
+export default PhoneLoginId;
+```
+
+Submit only a type the tenant actually allows — one of `getLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.
+

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -136,22 +136,26 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
+`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
 
-The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
+`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
 
 ```typescript
 import LoginId from '@auth0/auth0-acul-js/login-id';
 
 const loginIdManager = new LoginId();
 
-loginIdManager.login({
-  username: 'someone',       // the value the user typed
-  identifierType: 'username' // how the server should read it
-});
+// Read as an email, whatever the value looks like.
+loginIdManager.login({ email: 'someone@example.com' });
+
+// Read as a username — `identifierType` is what types it.
+loginIdManager.login({ username: 'someone', identifierType: 'username' });
+
+// No type at all: the previous contract, with the server inferring one from the value's shape.
+loginIdManager.login({ username: 'someone' });
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`, and the inline alternative to `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so `username` should be the national number *without* one.
+For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`, and the inline alternative to `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
 
 ```tsx
 import React, { useState } from 'react';
@@ -161,7 +165,7 @@ const PhoneLoginId: React.FC = () => {
   const [loginIdManager] = useState(() => new LoginId());
   const { countryCodes } = loginIdManager;
 
-  const [username, setUsername] = useState('');
+  const [phone, setPhone] = useState('');
   // `recommended` is the server's suggested default; fall back to the first available country.
   const [phoneCountryCode, setPhoneCountryCode] = useState(
     countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
@@ -169,8 +173,7 @@ const PhoneLoginId: React.FC = () => {
 
   const onContinueClick = () => {
     loginIdManager.login({
-      username, // national number, e.g. "2015550123"
-      identifierType: 'phone',
+      phone, // national number, e.g. "2015550123"
       phoneCountryCode // ISO 3166-1 alpha-2, e.g. "US"
     });
   };
@@ -187,9 +190,9 @@ const PhoneLoginId: React.FC = () => {
 
       <input
         type="tel"
-        id="username"
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
+        id="phone"
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
         placeholder="Enter your phone number"
       />
 

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -122,10 +122,17 @@ if (config) {
 
 ```typescript
 import LoginId from '@auth0/auth0-acul-js/login-id';
+import type { IdentifierType } from '@auth0/auth0-acul-js/login-id';
 
 const loginIdManager = new LoginId();
+const allowed = loginIdManager.getLoginIdentifiers() ?? [];
 
-const activeIdentifier = loginIdManager.screen.data?.activeIdentifierType ?? 'email';
+// Fall back to the first of email, username, phone the connection allows. A fixed 'email' paints a
+// field a username-only or phone-only connection rejects.
+const activeIdentifier =
+  loginIdManager.screen.data?.activeIdentifierType ??
+  (['email', 'username', 'phone'] as IdentifierType[]).find((type) => allowed.includes(type)) ??
+  'email';
 
 if (activeIdentifier === 'phone') {
   // render the phone number input with the country code picker
@@ -182,8 +189,9 @@ const PhoneLoginId: React.FC = () => {
   return (
     <div className="input-container">
       <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {/* A country can appear more than once, one entry per dial code, so key on both. */}
         {countryCodes?.available?.map(({ code, label, dialCode }) => (
-          <option key={code} value={code}>
+          <option key={`${code}-${dialCode}`} value={code}>
             {label} ({dialCode})
           </option>
         ))}
@@ -207,5 +215,9 @@ export default PhoneLoginId;
 
 Submit only a type the tenant actually allows — one of `getLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `identifier` on its own, or keep using `pickCountryCode()`.
+Only `code` is submitted, so entries sharing one — a country with several dial codes — are not independently selectable.
+
+`countryCodes.available` is `null`, and the dropdown renders empty, unless the screen's rendering configuration asks for the list: `{ "context_configuration": ["country_codes"] }`. Otherwise submit `identifier` on its own, or keep using `pickCountryCode()`.
+
+Omitting `phoneCountryCode` submits untyped, leaving the server to resolve the country itself.
 

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -136,9 +136,9 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
 
-`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
+Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
 
 ```typescript
 import LoginId from '@auth0/auth0-acul-js/login-id';
@@ -146,16 +146,16 @@ import LoginId from '@auth0/auth0-acul-js/login-id';
 const loginIdManager = new LoginId();
 
 // Read as an email, whatever the value looks like.
-loginIdManager.login({ email: 'someone@example.com' });
+loginIdManager.login({ identifier: 'someone@example.com', identifierType: 'email' });
 
-// Read as a username — `identifierType` is what types it.
-loginIdManager.login({ username: 'someone', identifierType: 'username' });
+// Read as a username rather than resolved from the value's shape.
+loginIdManager.login({ identifier: 'someone', identifierType: 'username' });
 
 // No type at all: the previous contract, with the server inferring one from the value's shape.
-loginIdManager.login({ username: 'someone' });
+loginIdManager.login({ identifier: 'someone' });
 ```
 
-For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`, and the inline alternative to `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
+For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`, and the inline alternative to `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
 
 ```tsx
 import React, { useState } from 'react';
@@ -173,7 +173,8 @@ const PhoneLoginId: React.FC = () => {
 
   const onContinueClick = () => {
     loginIdManager.login({
-      phone, // national number, e.g. "2015550123"
+      identifier: phone, // national number, e.g. "2015550123"
+      identifierType: 'phone',
       phoneCountryCode // ISO 3166-1 alpha-2, e.g. "US"
     });
   };
@@ -206,5 +207,5 @@ export default PhoneLoginId;
 
 Submit only a type the tenant actually allows — one of `getLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `identifier` on its own, or keep using `pickCountryCode()`.
 

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -136,11 +136,9 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
 
-Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `getLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number.
-
-The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
+The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
 
 ```typescript
 import LoginId from '@auth0/auth0-acul-js/login-id';
@@ -153,7 +151,7 @@ loginIdManager.login({
 });
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. This is the inline alternative to routing the user through `pickCountryCode()`, whose selection a typed submission ignores. The server prefixes that country's dial code, so `username` should be the national number *without* one.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`, and the inline alternative to `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so `username` should be the national number *without* one.
 
 ```tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-js/examples/login-id.md
+++ b/packages/auth0-acul-js/examples/login-id.md
@@ -153,7 +153,7 @@ loginIdManager.login({
 });
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode`. This is the inline alternative to routing the user through `pickCountryCode()` and a separate screen. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. This is the inline alternative to routing the user through `pickCountryCode()`, whose selection a typed submission ignores. The server prefixes that country's dial code, so `username` should be the national number *without* one.
 
 ```tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -262,7 +262,7 @@ await loginManager.login({
 });
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode`. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code. Omitting `phoneCountryCode` lets the server derive the country itself.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. The server prefixes that country's dial code, so `username` should be the national number *without* one. Leave it off and the submission falls back to the untyped contract, where `username` must carry its own dial code: a typed phone submission suppresses the server's own country lookup, including any `pickCountryCode()` selection.
 
 ```tsx
 import React, { useMemo, useState } from 'react';
@@ -293,8 +293,8 @@ const TypedLoginScreen: React.FC = () => {
       username, // national number when identifierType is 'phone', e.g. "2015550123"
       password,
       identifierType,
-      // Only read for a phone identifier; harmless to leave off otherwise.
-      ...(identifierType === 'phone' && phoneCountryCode ? { phoneCountryCode } : {})
+      // Required for a phone identifier; ignored for the other types.
+      ...(identifierType === 'phone' ? { phoneCountryCode } : {})
     });
   };
 

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -229,10 +229,17 @@ if (config) {
 
 ```typescript
 import Login from '@auth0/auth0-acul-js/login';
+import type { IdentifierType } from '@auth0/auth0-acul-js/login';
 
 const loginManager = new Login();
+const allowed = loginManager.getLoginIdentifiers() ?? [];
 
-const activeIdentifier = loginManager.screen.data?.activeIdentifierType ?? 'email';
+// Fall back to the first of email, username, phone the connection allows. A fixed 'email' paints a
+// field a username-only or phone-only connection rejects.
+const activeIdentifier =
+  loginManager.screen.data?.activeIdentifierType ??
+  (['email', 'username', 'phone'] as IdentifierType[]).find((type) => allowed.includes(type)) ??
+  'email';
 
 if (activeIdentifier === 'phone') {
   // render the phone number input with the country code picker
@@ -283,9 +290,12 @@ const TypedLoginScreen: React.FC = () => {
 
   const allowed = useMemo(() => loginManager.getLoginIdentifiers() ?? ['email'], [loginManager]);
 
-  // Start on the identifier the server resolved, falling back to the first the tenant allows.
+  // Start on the identifier the server resolved, else the first of email, username, phone the
+  // connection allows, rather than whichever it happens to list first.
   const [identifierType, setIdentifierType] = useState<IdentifierType>(
-    loginManager.screen.data?.activeIdentifierType ?? allowed[0]
+    loginManager.screen.data?.activeIdentifierType ??
+      (['email', 'username', 'phone'] as IdentifierType[]).find((type) => allowed.includes(type)) ??
+      'email'
   );
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
@@ -318,8 +328,9 @@ const TypedLoginScreen: React.FC = () => {
 
       {identifierType === 'phone' && countryCodes?.available && (
         <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+          {/* A country can appear more than once, one entry per dial code, so key on both. */}
           {countryCodes.available.map(({ code, label, dialCode }) => (
-            <option key={code} value={code}>
+            <option key={`${code}-${dialCode}`} value={code}>
               {label} ({dialCode})
             </option>
           ))}
@@ -351,4 +362,8 @@ export default TypedLoginScreen;
 
 Submit only a type the tenant actually allows — one of `getLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `identifier` on its own, or keep using `pickCountryCode()`.
+Only `code` is submitted, so entries sharing one — a country with several dial codes — are not independently selectable.
+
+`countryCodes.available` is `null`, and the dropdown renders empty, unless the screen's rendering configuration asks for the list: `{ "context_configuration": ["country_codes"] }`. Otherwise submit `identifier` on its own, or keep using `pickCountryCode()`.
+
+Omitting `phoneCountryCode` submits untyped, leaving the server to resolve the country itself.

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -243,24 +243,27 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
+`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
 
-The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
+`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
 
 ```typescript
 import Login from '@auth0/auth0-acul-js/login';
-import type { IdentifierType } from '@auth0/auth0-acul-js/login';
 
 const loginManager = new Login();
 
+// Read as an email, whatever the value looks like.
+await loginManager.login({ email: 'someone@example.com', password: 'myPassword123' });
+
+// Read as a username — `identifierType` is what types it.
 await loginManager.login({
-  username: 'someone',      // the value the user typed
+  username: 'someone',
   password: 'myPassword123',
-  identifierType: 'username' // how the server should read it
+  identifierType: 'username'
 });
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. Its dial code is prefixed server-side, so `username` should be the national number *without* one. Leave it off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
+For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
 
 ```tsx
 import React, { useMemo, useState } from 'react';
@@ -277,7 +280,7 @@ const TypedLoginScreen: React.FC = () => {
   const [identifierType, setIdentifierType] = useState<IdentifierType>(
     loginManager.screen.data?.activeIdentifierType ?? allowed[0]
   );
-  const [username, setUsername] = useState('');
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   // `recommended` is the server's suggested default; fall back to the first available country.
   const [phoneCountryCode, setPhoneCountryCode] = useState(
@@ -287,13 +290,15 @@ const TypedLoginScreen: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    await loginManager.login({
-      username, // national number when identifierType is 'phone', e.g. "2015550123"
-      password,
-      identifierType,
-      // Required for a phone identifier; ignored for the other types.
-      ...(identifierType === 'phone' ? { phoneCountryCode } : {})
-    });
+    // `email` and `phone` name their own type; `username` needs `identifierType` to be read as one.
+    const typedIdentifier =
+      identifierType === 'email'
+        ? { email: identifier }
+        : identifierType === 'phone'
+          ? { phone: identifier, phoneCountryCode } // national number, e.g. "2015550123"
+          : { username: identifier, identifierType: 'username' as const };
+
+    await loginManager.login({ ...typedIdentifier, password });
   };
 
   return (
@@ -316,10 +321,10 @@ const TypedLoginScreen: React.FC = () => {
       )}
 
       <input
-        id="username"
+        id="identifier"
         type={identifierType === 'phone' ? 'tel' : 'text'}
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
         placeholder={`Enter your ${identifierType}`}
       />
 

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -243,11 +243,9 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
 
-Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `getLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number and an address-shaped username is not mistaken for an email.
-
-The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
+The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
 
 ```typescript
 import Login from '@auth0/auth0-acul-js/login';
@@ -262,7 +260,7 @@ await loginManager.login({
 });
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. The server prefixes that country's dial code, so `username` should be the national number *without* one. Leave it off and the submission falls back to the untyped contract, where `username` must carry its own dial code: a typed phone submission suppresses the server's own country lookup, including any `pickCountryCode()` selection.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. Its dial code is prefixed server-side, so `username` should be the national number *without* one. Leave it off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
 
 ```tsx
 import React, { useMemo, useState } from 'react';

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -55,7 +55,7 @@ const handleSocialLogin = async (connection: string) => {
 ## React Component Example with TailwindCSS
 
 ```tsx
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Login from '@auth0/auth0-acul-js/login';
 
 const LoginScreen: React.FC = () => {
@@ -65,7 +65,7 @@ const LoginScreen: React.FC = () => {
   
   const loginManager = new Login();
   const { transaction } = loginManager;
-  const activeIdentifiers = useMemo(() => loginManager.getActiveIdentifiers(), []);
+  const activeIdentifiers = useMemo(() => loginManager.getLoginIdentifiers(), []);
 
   const getIdentifierLabel = () => {
     if (activeIdentifiers?.length === 1) return `Enter your ${activeIdentifiers[0]}`;
@@ -240,3 +240,106 @@ if (activeIdentifier === 'phone') {
   // render the email / username input
 }
 ```
+
+## Telling the server which identifier the user chose
+
+`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+
+Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `getLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number and an address-shaped username is not mistaken for an email.
+
+The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
+
+```typescript
+import Login from '@auth0/auth0-acul-js/login';
+import type { IdentifierType } from '@auth0/auth0-acul-js/login';
+
+const loginManager = new Login();
+
+await loginManager.login({
+  username: 'someone',      // the value the user typed
+  password: 'myPassword123',
+  identifierType: 'username' // how the server should read it
+});
+```
+
+For a phone identifier, also pass the selected country as `phoneCountryCode`. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code. Omitting `phoneCountryCode` lets the server derive the country itself.
+
+```tsx
+import React, { useMemo, useState } from 'react';
+import Login from '@auth0/auth0-acul-js/login';
+import type { IdentifierType } from '@auth0/auth0-acul-js/login';
+
+const TypedLoginScreen: React.FC = () => {
+  const [loginManager] = useState(() => new Login());
+  const { countryCodes } = loginManager;
+
+  const allowed = useMemo(() => loginManager.getLoginIdentifiers() ?? ['email'], [loginManager]);
+
+  // Start on the identifier the server resolved, falling back to the first the tenant allows.
+  const [identifierType, setIdentifierType] = useState<IdentifierType>(
+    loginManager.screen.data?.activeIdentifierType ?? allowed[0]
+  );
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    await loginManager.login({
+      username, // national number when identifierType is 'phone', e.g. "2015550123"
+      password,
+      identifierType,
+      // Only read for a phone identifier; harmless to leave off otherwise.
+      ...(identifierType === 'phone' && phoneCountryCode ? { phoneCountryCode } : {})
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {/* One tab per identifier the tenant allows */}
+      {allowed.map((type) => (
+        <button key={type} type="button" onClick={() => setIdentifierType(type)}>
+          {type}
+        </button>
+      ))}
+
+      {identifierType === 'phone' && countryCodes?.available && (
+        <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+          {countryCodes.available.map(({ code, label, dialCode }) => (
+            <option key={code} value={code}>
+              {label} ({dialCode})
+            </option>
+          ))}
+        </select>
+      )}
+
+      <input
+        id="username"
+        type={identifierType === 'phone' ? 'tel' : 'text'}
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder={`Enter your ${identifierType}`}
+      />
+
+      <input
+        id="password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+
+      <button type="submit">Sign in</button>
+    </form>
+  );
+};
+
+export default TypedLoginScreen;
+```
+
+Submit only a type the tenant actually allows — one of `getLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -243,9 +243,9 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
 
-`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
+Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
 
 ```typescript
 import Login from '@auth0/auth0-acul-js/login';
@@ -253,17 +253,24 @@ import Login from '@auth0/auth0-acul-js/login';
 const loginManager = new Login();
 
 // Read as an email, whatever the value looks like.
-await loginManager.login({ email: 'someone@example.com', password: 'myPassword123' });
-
-// Read as a username — `identifierType` is what types it.
 await loginManager.login({
-  username: 'someone',
-  password: 'myPassword123',
-  identifierType: 'username'
+  identifier: 'someone@example.com',
+  identifierType: 'email',
+  password: 'myPassword123'
 });
+
+// Read as a username rather than resolved from the value's shape.
+await loginManager.login({
+  identifier: 'someone',
+  identifierType: 'username',
+  password: 'myPassword123'
+});
+
+// No type named — submitted untyped, as before.
+await loginManager.login({ identifier: 'someone@example.com', password: 'myPassword123' });
 ```
 
-For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
+For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
 
 ```tsx
 import React, { useMemo, useState } from 'react';
@@ -290,15 +297,14 @@ const TypedLoginScreen: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // `email` and `phone` name their own type; `username` needs `identifierType` to be read as one.
-    const typedIdentifier =
-      identifierType === 'email'
-        ? { email: identifier }
-        : identifierType === 'phone'
-          ? { phone: identifier, phoneCountryCode } // national number, e.g. "2015550123"
-          : { username: identifier, identifierType: 'username' as const };
-
-    await loginManager.login({ ...typedIdentifier, password });
+    // One identifier, typed by `identifierType` — the same shape whichever tab is active.
+    await loginManager.login({
+      identifier, // for a phone, the national number, e.g. "2015550123"
+      identifierType,
+      // Only a phone identifier reads a country.
+      ...(identifierType === 'phone' ? { phoneCountryCode } : {}),
+      password
+    });
   };
 
   return (
@@ -345,4 +351,4 @@ export default TypedLoginScreen;
 
 Submit only a type the tenant actually allows — one of `getLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `identifier` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-js/examples/login.md
+++ b/packages/auth0-acul-js/examples/login.md
@@ -225,7 +225,7 @@ if (config) {
 
 ## activeIdentifierType
 
-When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+`screen.data.activeIdentifierType` is the input the server resolved, for first paint. It is `undefined` when none was resolved, so supply your own default.
 
 ```typescript
 import Login from '@auth0/auth0-acul-js/login';
@@ -243,9 +243,9 @@ if (activeIdentifier === 'phone') {
 
 ## Telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `getLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
+`activeIdentifierType` says which input to *render*; `identifierType` says which one the user *entered*. Pass it when your screen lets the user pick — tabs, a dropdown, or `getLoginIdentifiers()`.
 
-Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
+The value goes in `identifier`, and `identifierType` names what it holds. Omit the type and the identifier is submitted on its own, as before. `username` still works in `identifier`'s place.
 
 ```typescript
 import Login from '@auth0/auth0-acul-js/login';
@@ -270,7 +270,7 @@ await loginManager.login({
 await loginManager.login({ identifier: 'someone@example.com', password: 'myPassword123' });
 ```
 
-For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
+For a phone, pass the national number as `identifier` and the country as `phoneCountryCode` (from `countryCodes.available`). The dial code is added server-side. Without a country the submission falls back to untyped.
 
 ```tsx
 import React, { useMemo, useState } from 'react';

--- a/packages/auth0-acul-js/examples/signup-id.md
+++ b/packages/auth0-acul-js/examples/signup-id.md
@@ -306,8 +306,9 @@ const PhoneSignupId: React.FC = () => {
   return (
     <div className="input-container">
       <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {/* A country can appear more than once, one entry per dial code, so key on both. */}
         {countryCodes?.available?.map(({ code, label, dialCode }) => (
-          <option key={code} value={code}>
+          <option key={`${code}-${dialCode}`} value={code}>
             {label} ({dialCode})
           </option>
         ))}
@@ -331,4 +332,6 @@ export default PhoneSignupId;
 
 `phoneCountryCode` is an extra field on the phone identifier, not an identifier of its own. `phone` still has to be present to satisfy `transaction.getRequiredIdentifiers()`.
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phone` on its own, or keep using `pickCountryCode()`.
+Only `code` is submitted, so entries sharing one — a country with several dial codes — are not independently selectable.
+
+`countryCodes.available` is `null`, and the dropdown renders empty, unless the screen's rendering configuration asks for the list: `{ "context_configuration": ["country_codes"] }`. Otherwise submit `phone` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-js/examples/signup.md
+++ b/packages/auth0-acul-js/examples/signup.md
@@ -275,8 +275,9 @@ const PhoneSignup: React.FC = () => {
   return (
     <div className="input-container">
       <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {/* A country can appear more than once, one entry per dial code, so key on both. */}
         {countryCodes?.available?.map(({ code, label, dialCode }) => (
-          <option key={code} value={code}>
+          <option key={`${code}-${dialCode}`} value={code}>
             {label} ({dialCode})
           </option>
         ))}
@@ -306,4 +307,6 @@ const PhoneSignup: React.FC = () => {
 export default PhoneSignup;
 ```
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `phoneNumber` on its own, or keep using `pickCountryCode()`.
+Only `code` is submitted, so entries sharing one — a country with several dial codes — are not independently selectable.
+
+`countryCodes.available` is `null`, and the dropdown renders empty, unless the screen's rendering configuration asks for the list: `{ "context_configuration": ["country_codes"] }`. Otherwise submit `phoneNumber` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-js/interfaces/export/common.ts
+++ b/packages/auth0-acul-js/interfaces/export/common.ts
@@ -12,3 +12,4 @@ export type { Organizations } from '../models/user';
 export type { PasswordValidationResult } from '../utils/validate-password';
 export type { Identifier, IdentifierType as ScreenIdentifierType } from '../utils/signup-identifiers';
 export type { UsernameValidationResult, UsernameValidationError } from '../utils/validate-username';
+export type { LoginIdentifierOptions } from '../utils/typed-identifier';

--- a/packages/auth0-acul-js/interfaces/models/country-codes.ts
+++ b/packages/auth0-acul-js/interfaces/models/country-codes.ts
@@ -10,13 +10,25 @@ export interface CountryCodesContext {
 }
 
 export interface AvailableCountryCode {
+  /** ISO 3166-1 alpha-2, e.g. `"US"`. Submitted as `phoneCountryCode`. Not unique across the list. */
   code: string;
+  /** The country name, localized to the render locale. */
   label: string;
+  /** The dial code with its leading plus, e.g. `"+1"`. Display only. */
   dialCode: string;
 }
 
 /* @namespace CountryCodes */
 export interface CountryCodesMembers {
+  /**
+   * Countries available for phone entry, sorted by localized `label`. `null` unless the screen's
+   * rendering configuration asks for them: `{ "context_configuration": ["country_codes"] }`.
+   *
+   * `code` is not unique — a country with several dial codes contributes one entry per code — so key a
+   * rendered list on `code` and `dialCode` together. Only `code` is submitted, so those entries are not
+   * independently selectable.
+   */
   available: AvailableCountryCode[] | null;
+  /** ISO 3166-1 alpha-2 code to preselect, not an index into `available`. `null` when unresolved. */
   recommended: string | null;
 }

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -48,18 +48,13 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   resetPasswordLink: string | null;
   publicKey: PasskeyRead['public_key'] | null;
   googleOneTapConfig: GoogleOneTapConfig | null;
-  /**
-   * Intersected with the inherited `data` record rather than replacing it, so reads of any
-   * other `screen.data` key keep compiling for existing consumers.
-   */
+  /** Intersected with the inherited `data`, so reads of other `screen.data` keys keep compiling. */
   data:
     | (NonNullable<ScreenMembers['data']> & {
         /**
-         * The identifier input the screen should pre-select, as resolved by the server.
-         *
-         * Absent when the server has not resolved one — do not treat absence as `'email'`;
-         * fall back to your own default instead. Mapped from the server's
-         * `active_identifier_type`, which is not surfaced.
+         * The identifier input to pre-select, resolved by the server and mapped from its
+         * `active_identifier_type`. Absent when none was resolved — supply your own default rather
+         * than assuming `'email'`.
          */
         activeIdentifierType?: IdentifierType;
       })
@@ -80,25 +75,19 @@ export interface LoginOptions {
   username: string;
   captcha?: string;
   /**
-   * Which identifier `username` holds (for example `'phone'`).
-   *
-   * Supply it when your screen lets the user choose the identifier rather than typing an arbitrary
-   * value — typically driven by `screen.data.activeIdentifierType` and `transaction.allowedIdentifiers`.
-   * The server then reads the value as that type instead of inferring one from its shape, though on
-   * this screen the shape still decides which authentication method the user is routed to.
-   *
-   * Omit it to keep the existing behaviour, where `username` is submitted on its own and the server
-   * infers what it is.
+   * Which identifier `username` holds (for example `'phone'`) — typically from
+   * `screen.data.activeIdentifierType` or `transaction.allowedIdentifiers`. The server reads the
+   * value as that type instead of inferring one from its shape, though on this screen the shape still
+   * decides which authentication method the user is routed to. Omit it and `username` is submitted on
+   * its own, as before, with the server inferring the type.
    */
   identifierType?: IdentifierType;
   /**
-   * The ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `identifierType: 'phone'`; ignored for other types.
-   *
-   * The server prefixes this country's dial code, so `username` should be the national number
-   * without one. Omit it and the submission falls back to the untyped contract, where `username`
-   * must carry its own dial code: a typed phone submission suppresses the server's own country
-   * lookup, including any `pickCountryCode()` selection.
+   * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
+   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
+   * code is prefixed server-side, so `username` should be the national number without one. Omitted,
+   * the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection
+   * only on a phone-only connection.
    */
   phoneCountryCode?: string;
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -52,7 +52,10 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   /** Intersected with the inherited `data`, so other `screen.data` reads keep compiling. */
   data:
     | (NonNullable<ScreenMembers['data']> & {
-        /** The identifier input to pre-select. Absent when the server resolved none — use your own default. */
+        /**
+         * The identifier input to pre-select. Absent when the server resolved none — fall back to
+         * the first of `email`, `username`, `phone` in `getLoginIdentifiers()`.
+         */
         activeIdentifierType?: IdentifierType;
       })
     | null;
@@ -80,7 +83,8 @@ export type LoginOptions = LoginIdentifierOptions & {
   /**
    * ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`.
    * Required with `identifierType: 'phone'`. The dial code is prefixed server-side, so pass the
-   * national number.
+   * national number — unparenthesized, as `(201) 555-0123` is submitted unprefixed. Omitting the
+   * country submits untyped, leaving the server to resolve one.
    */
   phoneCountryCode?: string;
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -4,6 +4,7 @@ import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers, PasskeyRead } from '../models/screen';
 import type { TransactionMembers, UsernamePolicy, DBConnection } from '../models/transaction';
 import type { UntrustedDataContext } from '../models/untrusted-data';
+import type { LoginIdentifierOptions } from '../utils/typed-identifier';
 
 /**
  * Extended DBConnection interface for login-id screen with passkey autofill support
@@ -71,38 +72,32 @@ export interface TransactionMembersOnLoginId extends TransactionMembers {
   allowedIdentifiers: IdentifierType[] | null;
 }
 
-export interface LoginOptions {
-  /**
-   * The email address to continue with, read as an email rather than inferred from the value's shape.
-   * On this screen the shape still decides which authentication method the user is routed to.
-   */
-  email?: string;
-  /**
-   * The phone number to continue with, as the national number without a dial code. Pair it with
-   * `phoneCountryCode`, whose dial code the server prefixes; without one the submission degrades to
-   * the untyped contract.
-   */
-  phone?: string;
-  /**
-   * The username to continue with. On its own it is submitted untyped and the server infers the type —
-   * the behaviour that predates `email`/`phone`. Pair it with `identifierType: 'username'` to type it.
-   */
-  username?: string;
+/**
+ * @remarks
+ * The identifier itself is described by {@link LoginIdentifierOptions}: whichever type it is — email
+ * address, phone number or username — it goes in the one field, and `identifierType` names what that
+ * field holds. On this screen the value's shape still decides which authentication method the user is
+ * routed to. For `identifierType: 'phone'` it should be the national number, with the country named
+ * in `phoneCountryCode`.
+ */
+export type LoginOptions = LoginIdentifierOptions & {
   captcha?: string;
   /**
-   * Which identifier `username` holds (for example `'phone'`) — typically from
-   * `screen.data.activeIdentifierType`. Superseded by `email`/`phone`, which name their own type;
-   * this remains the way to submit a typed `username`.
+   * Which identifier the `identifier` field holds (for example `'phone'`) — typically from
+   * `screen.data.activeIdentifierType`. The server then reads the value as that type instead of
+   * inferring one from its shape. Omit it and the identifier is submitted on its own, as before.
    */
   identifierType?: IdentifierType;
   /**
    * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `phone`, ignored otherwise. Its dial code is prefixed
-   * server-side, so the number should carry none; omitted, the submission degrades to untyped.
+   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
+   * code is prefixed server-side, so the identifier should be the national number without one.
+   * Omitted, the submission degrades to the untyped contract, which prefixes a `pickCountryCode()`
+   * selection only on a phone-only connection.
    */
   phoneCountryCode?: string;
   [key: string]: string | number | boolean | undefined;
-}
+};
 
 export interface FederatedLoginOptions {
   connection: string;

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -72,22 +72,33 @@ export interface TransactionMembersOnLoginId extends TransactionMembers {
 }
 
 export interface LoginOptions {
-  username: string;
+  /**
+   * The email address to continue with, read as an email rather than inferred from the value's shape.
+   * On this screen the shape still decides which authentication method the user is routed to.
+   */
+  email?: string;
+  /**
+   * The phone number to continue with, as the national number without a dial code. Pair it with
+   * `phoneCountryCode`, whose dial code the server prefixes; without one the submission degrades to
+   * the untyped contract.
+   */
+  phone?: string;
+  /**
+   * The username to continue with. On its own it is submitted untyped and the server infers the type —
+   * the behaviour that predates `email`/`phone`. Pair it with `identifierType: 'username'` to type it.
+   */
+  username?: string;
   captcha?: string;
   /**
    * Which identifier `username` holds (for example `'phone'`) — typically from
-   * `screen.data.activeIdentifierType` or `transaction.allowedIdentifiers`. The server reads the
-   * value as that type instead of inferring one from its shape, though on this screen the shape still
-   * decides which authentication method the user is routed to. Omit it and `username` is submitted on
-   * its own, as before, with the server inferring the type.
+   * `screen.data.activeIdentifierType`. Superseded by `email`/`phone`, which name their own type;
+   * this remains the way to submit a typed `username`.
    */
   identifierType?: IdentifierType;
   /**
    * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
-   * code is prefixed server-side, so `username` should be the national number without one. Omitted,
-   * the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection
-   * only on a phone-only connection.
+   * `countryCodes.available`. Required with `phone`, ignored otherwise. Its dial code is prefixed
+   * server-side, so the number should carry none; omitted, the submission degrades to untyped.
    */
   phoneCountryCode?: string;
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -49,14 +49,10 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   resetPasswordLink: string | null;
   publicKey: PasskeyRead['public_key'] | null;
   googleOneTapConfig: GoogleOneTapConfig | null;
-  /** Intersected with the inherited `data`, so reads of other `screen.data` keys keep compiling. */
+  /** Intersected with the inherited `data`, so other `screen.data` reads keep compiling. */
   data:
     | (NonNullable<ScreenMembers['data']> & {
-        /**
-         * The identifier input to pre-select, resolved by the server and mapped from its
-         * `active_identifier_type`. Absent when none was resolved — supply your own default rather
-         * than assuming `'email'`.
-         */
+        /** The identifier input to pre-select. Absent when the server resolved none — use your own default. */
         activeIdentifierType?: IdentifierType;
       })
     | null;
@@ -74,26 +70,17 @@ export interface TransactionMembersOnLoginId extends TransactionMembers {
 
 /**
  * @remarks
- * The identifier itself is described by {@link LoginIdentifierOptions}: whichever type it is — email
- * address, phone number or username — it goes in the one field, and `identifierType` names what that
- * field holds. On this screen the value's shape still decides which authentication method the user is
- * routed to. For `identifierType: 'phone'` it should be the national number, with the country named
- * in `phoneCountryCode`.
+ * The identifier is described by {@link LoginIdentifierOptions}. On this screen its shape still
+ * decides which authentication method the user is routed to.
  */
 export type LoginOptions = LoginIdentifierOptions & {
   captcha?: string;
-  /**
-   * Which identifier the `identifier` field holds (for example `'phone'`) — typically from
-   * `screen.data.activeIdentifierType`. The server then reads the value as that type instead of
-   * inferring one from its shape. Omit it and the identifier is submitted on its own, as before.
-   */
+  /** What `identifier` holds — typically from `screen.data.activeIdentifierType`. Omit to submit untyped. */
   identifierType?: IdentifierType;
   /**
-   * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
-   * code is prefixed server-side, so the identifier should be the national number without one.
-   * Omitted, the submission degrades to the untyped contract, which prefixes a `pickCountryCode()`
-   * selection only on a phone-only connection.
+   * ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`.
+   * Required with `identifierType: 'phone'`. The dial code is prefixed server-side, so pass the
+   * national number.
    */
   phoneCountryCode?: string;
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -84,24 +84,21 @@ export interface LoginOptions {
    *
    * Supply it when your screen lets the user choose the identifier rather than typing an arbitrary
    * value — typically driven by `screen.data.activeIdentifierType` and `transaction.allowedIdentifiers`.
-   * The submitted type is then authoritative: the server reads the value as that type instead of
-   * inferring one from its shape, so an all-digits username is not mistaken for a phone number.
+   * The server then reads the value as that type instead of inferring one from its shape, though on
+   * this screen the shape still decides which authentication method the user is routed to.
    *
    * Omit it to keep the existing behaviour, where `username` is submitted on its own and the server
    * infers what it is.
    */
   identifierType?: IdentifierType;
   /**
-   * The ISO 3166-1 alpha-2 country the user selected for a phone identifier (for example `'US'`).
+   * The ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
+   * `countryCodes.available`. Required with `identifierType: 'phone'`; ignored for other types.
    *
-   * Read only when `identifierType` is `'phone'`. Supply it when your screen renders a country
-   * dropdown next to the phone number field, using a `code` from `countryCodes.available`. The
-   * submitted country is then authoritative: the server prefixes its dial code rather than
-   * inferring a country from the digits or from geo-IP, so `username` should be the national number
-   * without a dial code.
-   *
-   * Omit it to have the server derive the country itself, with `pickCountryCode()` changing the
-   * selection on a separate screen.
+   * The server prefixes this country's dial code, so `username` should be the national number
+   * without one. Omit it and the submission falls back to the untyped contract, where `username`
+   * must carry its own dial code: a typed phone submission suppresses the server's own country
+   * lookup, including any `pickCountryCode()` selection.
    */
   phoneCountryCode?: string;
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/interfaces/screens/login-id.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login-id.ts
@@ -79,6 +79,31 @@ export interface TransactionMembersOnLoginId extends TransactionMembers {
 export interface LoginOptions {
   username: string;
   captcha?: string;
+  /**
+   * Which identifier `username` holds (for example `'phone'`).
+   *
+   * Supply it when your screen lets the user choose the identifier rather than typing an arbitrary
+   * value — typically driven by `screen.data.activeIdentifierType` and `transaction.allowedIdentifiers`.
+   * The submitted type is then authoritative: the server reads the value as that type instead of
+   * inferring one from its shape, so an all-digits username is not mistaken for a phone number.
+   *
+   * Omit it to keep the existing behaviour, where `username` is submitted on its own and the server
+   * infers what it is.
+   */
+  identifierType?: IdentifierType;
+  /**
+   * The ISO 3166-1 alpha-2 country the user selected for a phone identifier (for example `'US'`).
+   *
+   * Read only when `identifierType` is `'phone'`. Supply it when your screen renders a country
+   * dropdown next to the phone number field, using a `code` from `countryCodes.available`. The
+   * submitted country is then authoritative: the server prefixes its dial code rather than
+   * inferring a country from the digits or from geo-IP, so `username` should be the national number
+   * without a dial code.
+   *
+   * Omit it to have the server derive the country itself, with `pickCountryCode()` changing the
+   * selection on a separate screen.
+   */
+  phoneCountryCode?: string;
   [key: string]: string | number | boolean | undefined;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -21,14 +21,11 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
   googleOneTapConfig: GoogleOneTapConfig | null;
-  /** Intersected with the inherited `data`, so reads of other `screen.data` keys keep compiling. */
+  /** Intersected with the inherited `data`, so other `screen.data` reads keep compiling. */
   data:
     | (NonNullable<ScreenMembers['data']> & {
         username?: string;
-        /**
-         * The identifier input to pre-select, from the server's `active_identifier_type`. Absent when
-         * none was resolved — supply your own default rather than assuming `'email'`.
-         */
+        /** The identifier input to pre-select. Absent when the server resolved none — use your own default. */
         activeIdentifierType?: IdentifierType;
       })
     | null;
@@ -64,28 +61,19 @@ export interface Login extends BaseContext {
  * Options for performing login operations
  *
  * @remarks
- * The identifier itself is described by {@link LoginIdentifierOptions}: whichever type it is — email
- * address, phone number or username — it goes in the one field, and `identifierType` names what that
- * field holds. For `identifierType: 'phone'` it should be the national number, with the country named
- * in `phoneCountryCode`.
+ * The identifier is described by {@link LoginIdentifierOptions}.
  */
 export type LoginOptions = LoginIdentifierOptions & {
   /** The password for authentication */
   password: string;
   /** Optional captcha value if required */
   captcha?: string;
-  /**
-   * Which identifier the `identifier` field holds (for example `'phone'`) — typically from
-   * `screen.data.activeIdentifierType`. The server then reads the value as that type instead of
-   * inferring one from its shape. Omit it and the identifier is submitted on its own, as before.
-   */
+  /** What `identifier` holds — typically from `screen.data.activeIdentifierType`. Omit to submit untyped. */
   identifierType?: IdentifierType;
   /**
-   * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
-   * code is prefixed server-side, so the identifier should be the national number without one.
-   * Omitted, the submission degrades to the untyped contract, which prefixes a `pickCountryCode()`
-   * selection only on a phone-only connection.
+   * ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`.
+   * Required with `identifierType: 'phone'`. The dial code is prefixed server-side, so pass the
+   * national number.
    */
   phoneCountryCode?: string;
   /** Any additional custom options */

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -25,9 +25,8 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
     | (NonNullable<ScreenMembers['data']> & {
         username?: string;
         /**
-         * The identifier input to pre-select, resolved by the server and mapped from its
-         * `active_identifier_type`. Absent when none was resolved — supply your own default rather
-         * than assuming `'email'`.
+         * The identifier input to pre-select, from the server's `active_identifier_type`. Absent when
+         * none was resolved — supply your own default rather than assuming `'email'`.
          */
         activeIdentifierType?: IdentifierType;
       })
@@ -64,25 +63,33 @@ export interface Login extends BaseContext {
  * Options for performing login operations
  */
 export interface LoginOptions {
-  /** The username/email to login with */
-  username: string;
+  /** The email address to login with, read as an email rather than inferred from the value's shape. */
+  email?: string;
+  /**
+   * The phone number to login with, as the national number without a dial code. Pair it with
+   * `phoneCountryCode`, whose dial code the server prefixes; without one the submission degrades to
+   * the untyped contract.
+   */
+  phone?: string;
+  /**
+   * The username to login with. On its own it is submitted untyped and the server infers the type —
+   * the behaviour that predates `email`/`phone`. Pair it with `identifierType: 'username'` to type it.
+   */
+  username?: string;
   /** The password for authentication */
   password: string;
   /** Optional captcha value if required */
   captcha?: string;
   /**
    * Which identifier `username` holds (for example `'phone'`) — typically from
-   * `screen.data.activeIdentifierType` or `transaction.allowedIdentifiers`. The server reads the
-   * value as that type instead of inferring one from its shape. Omit it and `username` is submitted
-   * on its own, as before, with the server inferring the type.
+   * `screen.data.activeIdentifierType`. Superseded by `email`/`phone`, which name their own type;
+   * this remains the way to submit a typed `username`.
    */
   identifierType?: IdentifierType;
   /**
    * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
-   * code is prefixed server-side, so `username` should be the national number without one. Omitted,
-   * the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection
-   * only on a phone-only connection.
+   * `countryCodes.available`. Required with `phone`, ignored otherwise. Its dial code is prefixed
+   * server-side, so the number should carry none; omitted, the submission degrades to untyped.
    */
   phoneCountryCode?: string;
   /** Any additional custom options */

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -20,19 +20,14 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
   googleOneTapConfig: GoogleOneTapConfig | null;
-  /**
-   * Intersected with the inherited `data` record rather than replacing it, so reads of any
-   * other `screen.data` key keep compiling for existing consumers.
-   */
+  /** Intersected with the inherited `data`, so reads of other `screen.data` keys keep compiling. */
   data:
     | (NonNullable<ScreenMembers['data']> & {
         username?: string;
         /**
-         * The identifier input the screen should pre-select, as resolved by the server.
-         *
-         * Absent when the server has not resolved one — do not treat absence as `'email'`;
-         * fall back to your own default instead. Mapped from the server's
-         * `active_identifier_type`, which is not surfaced.
+         * The identifier input to pre-select, resolved by the server and mapped from its
+         * `active_identifier_type`. Absent when none was resolved — supply your own default rather
+         * than assuming `'email'`.
          */
         activeIdentifierType?: IdentifierType;
       })
@@ -76,25 +71,18 @@ export interface LoginOptions {
   /** Optional captcha value if required */
   captcha?: string;
   /**
-   * Which identifier `username` holds (for example `'phone'`).
-   *
-   * Supply it when your screen lets the user choose the identifier rather than typing an arbitrary
-   * value — typically driven by `screen.data.activeIdentifierType` and `transaction.allowedIdentifiers`.
-   * The server then reads the value as that type when resolving the identifier, instead of inferring
-   * one from its shape.
-   *
-   * Omit it to keep the existing behaviour, where `username` is submitted on its own and the server
-   * infers what it is.
+   * Which identifier `username` holds (for example `'phone'`) — typically from
+   * `screen.data.activeIdentifierType` or `transaction.allowedIdentifiers`. The server reads the
+   * value as that type instead of inferring one from its shape. Omit it and `username` is submitted
+   * on its own, as before, with the server inferring the type.
    */
   identifierType?: IdentifierType;
   /**
-   * The ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `identifierType: 'phone'`; ignored for other types.
-   *
-   * The server prefixes this country's dial code, so `username` should be the national number
-   * without one. Omit it and the submission falls back to the untyped contract, where `username`
-   * must carry its own dial code: a typed phone submission suppresses the server's own country
-   * lookup, including any `pickCountryCode()` selection.
+   * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
+   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
+   * code is prefixed server-side, so `username` should be the national number without one. Omitted,
+   * the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection
+   * only on a phone-only connection.
    */
   phoneCountryCode?: string;
   /** Any additional custom options */

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -75,6 +75,31 @@ export interface LoginOptions {
   password: string;
   /** Optional captcha value if required */
   captcha?: string;
+  /**
+   * Which identifier `username` holds (for example `'phone'`).
+   *
+   * Supply it when your screen lets the user choose the identifier rather than typing an arbitrary
+   * value — typically driven by `screen.data.activeIdentifierType` and `transaction.allowedIdentifiers`.
+   * The submitted type is then authoritative: the server reads the value as that type instead of
+   * inferring one from its shape, so an all-digits username is not mistaken for a phone number.
+   *
+   * Omit it to keep the existing behaviour, where `username` is submitted on its own and the server
+   * infers what it is.
+   */
+  identifierType?: IdentifierType;
+  /**
+   * The ISO 3166-1 alpha-2 country the user selected for a phone identifier (for example `'US'`).
+   *
+   * Read only when `identifierType` is `'phone'`. Supply it when your screen renders a country
+   * dropdown next to the phone number field, using a `code` from `countryCodes.available`. The
+   * submitted country is then authoritative: the server prefixes its dial code rather than
+   * inferring a country from the digits or from geo-IP, so `username` should be the national number
+   * without a dial code.
+   *
+   * Omit it to have the server derive the country itself, with `pickCountryCode()` changing the
+   * selection on a separate screen.
+   */
+  phoneCountryCode?: string;
   /** Any additional custom options */
   [key: string]: string | number | boolean | undefined;
 }

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -3,6 +3,7 @@ import type { CustomOptions, GoogleOneTapConfig, GoogleOneTapOptions } from '../
 import type { BaseContext, BaseMembers } from '../models/base-context';
 import type { ScreenContext, ScreenMembers } from '../models/screen';
 import type { TransactionContext, TransactionMembers, DBConnection, PasswordPolicy } from '../models/transaction';
+import type { LoginIdentifierOptions } from '../utils/typed-identifier';
 /**
  * Extended screen context interface for the login screen
  */
@@ -61,40 +62,35 @@ export interface Login extends BaseContext {
 
 /**
  * Options for performing login operations
+ *
+ * @remarks
+ * The identifier itself is described by {@link LoginIdentifierOptions}: whichever type it is — email
+ * address, phone number or username — it goes in the one field, and `identifierType` names what that
+ * field holds. For `identifierType: 'phone'` it should be the national number, with the country named
+ * in `phoneCountryCode`.
  */
-export interface LoginOptions {
-  /** The email address to login with, read as an email rather than inferred from the value's shape. */
-  email?: string;
-  /**
-   * The phone number to login with, as the national number without a dial code. Pair it with
-   * `phoneCountryCode`, whose dial code the server prefixes; without one the submission degrades to
-   * the untyped contract.
-   */
-  phone?: string;
-  /**
-   * The username to login with. On its own it is submitted untyped and the server infers the type —
-   * the behaviour that predates `email`/`phone`. Pair it with `identifierType: 'username'` to type it.
-   */
-  username?: string;
+export type LoginOptions = LoginIdentifierOptions & {
   /** The password for authentication */
   password: string;
   /** Optional captcha value if required */
   captcha?: string;
   /**
-   * Which identifier `username` holds (for example `'phone'`) — typically from
-   * `screen.data.activeIdentifierType`. Superseded by `email`/`phone`, which name their own type;
-   * this remains the way to submit a typed `username`.
+   * Which identifier the `identifier` field holds (for example `'phone'`) — typically from
+   * `screen.data.activeIdentifierType`. The server then reads the value as that type instead of
+   * inferring one from its shape. Omit it and the identifier is submitted on its own, as before.
    */
   identifierType?: IdentifierType;
   /**
    * ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
-   * `countryCodes.available`. Required with `phone`, ignored otherwise. Its dial code is prefixed
-   * server-side, so the number should carry none; omitted, the submission degrades to untyped.
+   * `countryCodes.available`. Required with `identifierType: 'phone'`, ignored otherwise. Its dial
+   * code is prefixed server-side, so the identifier should be the national number without one.
+   * Omitted, the submission degrades to the untyped contract, which prefixes a `pickCountryCode()`
+   * selection only on a phone-only connection.
    */
   phoneCountryCode?: string;
   /** Any additional custom options */
   [key: string]: string | number | boolean | undefined;
-}
+};
 
 /**
  * Options for performing social login operations

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -25,7 +25,10 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
   data:
     | (NonNullable<ScreenMembers['data']> & {
         username?: string;
-        /** The identifier input to pre-select. Absent when the server resolved none — use your own default. */
+        /**
+         * The identifier input to pre-select. Absent when the server resolved none — fall back to
+         * the first of `email`, `username`, `phone` in `getLoginIdentifiers()`.
+         */
         activeIdentifierType?: IdentifierType;
       })
     | null;
@@ -73,7 +76,8 @@ export type LoginOptions = LoginIdentifierOptions & {
   /**
    * ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`.
    * Required with `identifierType: 'phone'`. The dial code is prefixed server-side, so pass the
-   * national number.
+   * national number — unparenthesized, as `(201) 555-0123` is submitted unprefixed. Omitting the
+   * country submits untyped, leaving the server to resolve one.
    */
   phoneCountryCode?: string;
   /** Any additional custom options */

--- a/packages/auth0-acul-js/interfaces/screens/login.ts
+++ b/packages/auth0-acul-js/interfaces/screens/login.ts
@@ -80,24 +80,21 @@ export interface LoginOptions {
    *
    * Supply it when your screen lets the user choose the identifier rather than typing an arbitrary
    * value — typically driven by `screen.data.activeIdentifierType` and `transaction.allowedIdentifiers`.
-   * The submitted type is then authoritative: the server reads the value as that type instead of
-   * inferring one from its shape, so an all-digits username is not mistaken for a phone number.
+   * The server then reads the value as that type when resolving the identifier, instead of inferring
+   * one from its shape.
    *
    * Omit it to keep the existing behaviour, where `username` is submitted on its own and the server
    * infers what it is.
    */
   identifierType?: IdentifierType;
   /**
-   * The ISO 3166-1 alpha-2 country the user selected for a phone identifier (for example `'US'`).
+   * The ISO 3166-1 alpha-2 country for a phone identifier (for example `'US'`), from a `code` in
+   * `countryCodes.available`. Required with `identifierType: 'phone'`; ignored for other types.
    *
-   * Read only when `identifierType` is `'phone'`. Supply it when your screen renders a country
-   * dropdown next to the phone number field, using a `code` from `countryCodes.available`. The
-   * submitted country is then authoritative: the server prefixes its dial code rather than
-   * inferring a country from the digits or from geo-IP, so `username` should be the national number
-   * without a dial code.
-   *
-   * Omit it to have the server derive the country itself, with `pickCountryCode()` changing the
-   * selection on a separate screen.
+   * The server prefixes this country's dial code, so `username` should be the national number
+   * without one. Omit it and the submission falls back to the untyped contract, where `username`
+   * must carry its own dial code: a typed phone submission suppresses the server's own country
+   * lookup, including any `pickCountryCode()` selection.
    */
   phoneCountryCode?: string;
   /** Any additional custom options */

--- a/packages/auth0-acul-js/interfaces/utils/phone-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/phone-identifier.ts
@@ -1,10 +1,4 @@
-/**
- * A signup payload as supplied by the caller, before its phone options are reshaped for
- * submission.
- *
- * Matches the index signature `SignupOptions` carries on both the signup and signup-id screens, so
- * either screen's options are assignable here without a cast.
- */
+/** A signup payload as supplied by the caller, before its phone options are reshaped. */
 export interface PhoneIdentifierPayload {
   [key: string]: string | number | boolean | undefined;
 }
@@ -17,22 +11,15 @@ export type PhoneIdentifierField = 'phone' | 'phoneNumber';
 
 /**
  * A signup payload with its phone options mapped onto the field names the signup endpoint reads.
- *
- * Deliberately widened from `SignupOptions`: the mapped payload is no longer one, since the
- * camelCase options are gone and the wire fields (`identifier_phone`,
- * `identifier_phone_country_code`, `phone_number`) have taken their place. The known signup fields
- * that were not touched still ride along under the index signature.
+ * Wider than `SignupOptions`, which no longer describes the mapped result.
  */
 export interface NormalizedPhoneIdentifierPayload extends PhoneIdentifierPayload {
-  /**
-   * The national phone number, submitted with a country. Paired with
-   * `identifier_phone_country_code`.
-   */
+  /** The national phone number. Pairs with `identifier_phone_country_code`. */
   identifier_phone?: string;
 
   /** The ISO 3166-1 alpha-2 country the server prefixes the dial code from. */
   identifier_phone_country_code?: string;
 
-  /** The phone number submitted on its own, for the server to derive the country from. */
+  /** The phone number. Always present when the payload carries one. */
   phone_number?: string;
 }

--- a/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
@@ -1,28 +1,36 @@
 import type { IdentifierType } from '../../src/constants';
 
 /**
+ * The identifier to login with, under either of its names. Exactly one is required: `identifier`,
+ * which pairs with `identifierType`, or `username`, its original spelling, which remains accepted so
+ * existing callers keep working. Supplying both is not an error — `identifier` wins.
+ *
+ * @remarks
+ * Shared by the `login` and `login-id` screens, whose `LoginOptions` each intersect it with their own
+ * remaining fields.
+ */
+export type LoginIdentifierOptions =
+  | { identifier: string; username?: string }
+  | { username: string; identifier?: string };
+
+/**
  * A login payload as supplied by the caller, before its identifier options are mapped for submission.
  * Matches the index signature both screens' `LoginOptions` carry, so either is assignable without a
  * cast.
  */
 export interface TypedIdentifierPayload {
-  /** The email address. Supplying it selects the typed contract with the `email` type. */
-  email?: string;
-
   /**
-   * The phone number. Supplying it selects the typed contract with the `phone` type, and it pairs
-   * with `phoneCountryCode`.
+   * The identifier, whatever its type; `identifierType` names what it holds. Submitted as
+   * `username`, the only identifier field the endpoint reads.
    */
-  phone?: string;
+  identifier?: string;
 
-  /**
-   * The username. It doubles as the legacy carrier — on its own it is submitted untyped, with the
-   * server inferring the type — so pair it with `identifierType` to submit it as a typed username.
-   */
+  /** The identifier's original spelling, still accepted. Superseded by `identifier`. */
   username?: string;
 
   /**
-   * The type `username` holds. Superseded by `email` and `phone`, which name their own type.
+   * The type `username` holds. Its absence submits the payload untyped, with the server inferring
+   * the type from the value's shape.
    */
   identifierType?: IdentifierType;
 

--- a/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
@@ -6,10 +6,24 @@ import type { IdentifierType } from '../../src/constants';
  * cast.
  */
 export interface TypedIdentifierPayload {
-  /** The identifier value, whatever type it represents. */
+  /** The email address. Supplying it selects the typed contract with the `email` type. */
+  email?: string;
+
+  /**
+   * The phone number. Supplying it selects the typed contract with the `phone` type, and it pairs
+   * with `phoneCountryCode`.
+   */
+  phone?: string;
+
+  /**
+   * The username. It doubles as the legacy carrier — on its own it is submitted untyped, with the
+   * server inferring the type — so pair it with `identifierType` to submit it as a typed username.
+   */
   username?: string;
 
-  /** The type `username` holds. Its presence selects the typed contract. */
+  /**
+   * The type `username` holds. Superseded by `email` and `phone`, which name their own type.
+   */
   identifierType?: IdentifierType;
 
   /** The ISO 3166-1 alpha-2 country for a phone identifier. Required when the type is `phone`. */

--- a/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
@@ -1,12 +1,9 @@
 import type { IdentifierType } from '../../src/constants';
 
 /**
- * A login payload as supplied by the caller, before its identifier options are reshaped for
- * submission.
- *
- * Matches the index signature `LoginOptions` carries on both the login and login-id screens, so
- * either screen's options are assignable here without a cast. `username` is optional here but
- * required on both `LoginOptions`, which is the stricter side of the assignment.
+ * A login payload as supplied by the caller, before its identifier options are mapped for submission.
+ * Matches the index signature both screens' `LoginOptions` carry, so either is assignable without a
+ * cast.
  */
 export interface TypedIdentifierPayload {
   /** The identifier value, whatever type it represents. */
@@ -23,16 +20,10 @@ export interface TypedIdentifierPayload {
 
 /**
  * A login payload with its identifier options mapped onto the field names the login endpoint reads.
- *
- * Deliberately widened from `LoginOptions`: the mapped payload is no longer one, since the
- * camelCase options are gone and the wire fields have taken their place. The known login fields
- * that were not touched still ride along under the index signature.
+ * Deliberately wider than `LoginOptions`, which no longer describes the mapped result.
  */
 export interface NormalizedTypedIdentifierPayload extends TypedIdentifierPayload {
-  /**
-   * The type the submitted identifier represents. The server treats its presence as the signal to
-   * read the typed fields at all, so it is never omitted from a typed submission.
-   */
+  /** The submitted type. Its presence is the server's signal to read the typed fields at all. */
   identifier_type?: IdentifierType;
 
   /** The email address, submitted when the type is `email`. */
@@ -44,9 +35,6 @@ export interface NormalizedTypedIdentifierPayload extends TypedIdentifierPayload
   /** The phone number, submitted when the type is `phone`. */
   identifier_phone?: string;
 
-  /**
-   * The ISO 3166-1 alpha-2 country the server prefixes the dial code from. Paired with
-   * `identifier_phone`.
-   */
+  /** The ISO 3166-1 alpha-2 country whose dial code the server prefixes. Pairs with `identifier_phone`. */
   identifier_phone_country_code?: string;
 }

--- a/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
@@ -1,0 +1,52 @@
+import type { IdentifierType } from '../../src/constants';
+
+/**
+ * A login payload as supplied by the caller, before its identifier options are reshaped for
+ * submission.
+ *
+ * Matches the index signature `LoginOptions` carries on both the login and login-id screens, so
+ * either screen's options are assignable here without a cast. `username` is optional here but
+ * required on both `LoginOptions`, which is the stricter side of the assignment.
+ */
+export interface TypedIdentifierPayload {
+  /** The identifier value, whatever type it represents. */
+  username?: string;
+
+  /** The type `username` holds. Its presence selects the typed contract. */
+  identifierType?: IdentifierType;
+
+  /** The ISO 3166-1 alpha-2 country for a phone identifier. Read only when the type is `phone`. */
+  phoneCountryCode?: string;
+
+  [key: string]: string | number | boolean | undefined;
+}
+
+/**
+ * A login payload with its identifier options mapped onto the field names the login endpoint reads.
+ *
+ * Deliberately widened from `LoginOptions`: the mapped payload is no longer one, since the
+ * camelCase options are gone and the wire fields have taken their place. The known login fields
+ * that were not touched still ride along under the index signature.
+ */
+export interface NormalizedTypedIdentifierPayload extends TypedIdentifierPayload {
+  /**
+   * The type the submitted identifier represents. The server treats its presence as the signal to
+   * read the typed fields at all, so it is never omitted from a typed submission.
+   */
+  identifier_type?: IdentifierType;
+
+  /** The email address, submitted when the type is `email`. */
+  identifier_email?: string;
+
+  /** The username, submitted when the type is `username`. */
+  identifier_username?: string;
+
+  /** The phone number, submitted when the type is `phone`. */
+  identifier_phone?: string;
+
+  /**
+   * The ISO 3166-1 alpha-2 country the server prefixes the dial code from. Paired with
+   * `identifier_phone`.
+   */
+  identifier_phone_country_code?: string;
+}

--- a/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/interfaces/utils/typed-identifier.ts
@@ -15,7 +15,7 @@ export interface TypedIdentifierPayload {
   /** The type `username` holds. Its presence selects the typed contract. */
   identifierType?: IdentifierType;
 
-  /** The ISO 3166-1 alpha-2 country for a phone identifier. Read only when the type is `phone`. */
+  /** The ISO 3166-1 alpha-2 country for a phone identifier. Required when the type is `phone`. */
   phoneCountryCode?: string;
 
   [key: string]: string | number | boolean | undefined;

--- a/packages/auth0-acul-js/src/constants/identifiers.ts
+++ b/packages/auth0-acul-js/src/constants/identifiers.ts
@@ -15,19 +15,12 @@ export const Fields = {
 }
 
 /**
- * Form field names for the typed identifier submission contract, where the identifier is submitted
- * together with the type it represents instead of the server inferring the type from the value.
+ * Server field names for the typed identifier contract, where the identifier is submitted with the
+ * type it represents instead of the server inferring it from the value. `TYPE` is the signal: the
+ * server reads the other fields only when it is present.
  *
- * The `identifier_` prefix is the server-side contract and avoids colliding with the discrete
- * `email` / `username` / `phone_number` fields.
- *
- * `TYPE` is the version signal: the server only reads the other fields when it is present, so a
- * typed submission must always carry it. `PHONE_COUNTRY_CODE` additionally selects the composite
- * phone contract, where the country is submitted alongside the national number instead of being
- * picked on a separate screen.
- *
- * The signup and signup-id screens read only `PHONE` and `PHONE_COUNTRY_CODE`; they ignore `TYPE`,
- * `EMAIL` and `USERNAME`. All five apply on login and login-id.
+ * All five apply on login and login-id; signup and signup-id read only `PHONE` and
+ * `PHONE_COUNTRY_CODE`.
  */
 export const TypedFields = {
   TYPE: 'identifier_type' as const,

--- a/packages/auth0-acul-js/src/constants/identifiers.ts
+++ b/packages/auth0-acul-js/src/constants/identifiers.ts
@@ -15,13 +15,24 @@ export const Fields = {
 }
 
 /**
- * Form field names for the composite phone submission contract, where the country code is
- * submitted alongside the national number instead of being picked on a separate screen.
+ * Form field names for the typed identifier submission contract, where the identifier is submitted
+ * together with the type it represents instead of the server inferring the type from the value.
  *
  * The `identifier_` prefix is the server-side contract and avoids colliding with the discrete
  * `email` / `username` / `phone_number` fields.
+ *
+ * `TYPE` is the version signal: the server only reads the other fields when it is present, so a
+ * typed submission must always carry it. `PHONE_COUNTRY_CODE` additionally selects the composite
+ * phone contract, where the country is submitted alongside the national number instead of being
+ * picked on a separate screen.
+ *
+ * The signup and signup-id screens read only `PHONE` and `PHONE_COUNTRY_CODE`; they ignore `TYPE`,
+ * `EMAIL` and `USERNAME`. All five apply on login and login-id.
  */
 export const TypedFields = {
+  TYPE: 'identifier_type' as const,
+  EMAIL: 'identifier_email' as const,
+  USERNAME: 'identifier_username' as const,
   PHONE: 'identifier_phone' as const,
   PHONE_COUNTRY_CODE: 'identifier_phone_country_code' as const,
 } as const;

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -82,10 +82,9 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
     };
 
     const browserCapabilities = await getBrowserCapabilities();
-    // The login endpoint names the typed identifier fields differently from the SDK options, and
-    // reads them only when `identifier_type` is present. Remap before submitting so a typed
-    // submission is not silently treated as a legacy one. The remapped payload is no longer a
-    // `LoginOptions`, so the type argument widens to match what is actually submitted.
+    // The endpoint names the typed identifier fields differently and reads them only when
+    // `identifier_type` is present, so remap before submitting. The result is no longer a
+    // `LoginOptions`, hence the wider type argument.
     await new FormHandler(options).submitData<NormalizedTypedIdentifierPayload>({
       ...normalizeTypedIdentifier(payload),
       ...browserCapabilities

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -54,37 +54,33 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * const loginIdManager = new LoginId();
    *
    * loginIdManager.login({
-   *   username: <usernameFieldValue>
+   *   identifier: <identifierFieldValue>
    * });
    *
    * @example
-   * // Email login. The discrete option stops the server inferring the type from the value's shape.
+   * // An email read as one, rather than inferred from the value's shape. `identifierType` is
+   * // typically `screen.data.activeIdentifierType`.
    *
    * loginIdManager.login({
-   *   email: <emailFieldValue>
+   *   identifier: <emailFieldValue>,
+   *   identifierType: 'email'
    * });
    *
    * @example
    * // Phone login with a country dropdown, using a code from `countryCodes.available`. Submit the
-   * // national number; the dial code is prefixed server-side.
+   * // national number as the identifier; the dial code is prefixed server-side.
    *
    * loginIdManager.login({
-   *   phone: '2015550123',
+   *   identifier: '2015550123',
+   *   identifierType: 'phone',
    *   phoneCountryCode: 'US'
    * });
    *
-   * @example
-   * // A username read as one, rather than inferred from its shape. `username` has no discrete
-   * // option of its own — it predates them as the untyped field — so pair it with `identifierType`.
-   *
-   * loginIdManager.login({
-   *   username: <usernameFieldValue>,
-   *   identifierType: 'username'
-   * });
-   *
    * @remarks
-   * Login submits a single identifier. Supplying more than one of `email`, `phone` or `username`
-   * resolves to the first by that precedence and warns; the rest are ignored.
+   * Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and
+   * `identifierType` names what it holds. Omitting `identifierType` submits the identifier on its
+   * own, exactly as before, with the server inferring the type. `username` is `identifier`'s original
+   * spelling and still accepted in its place.
    */
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = {

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -6,6 +6,7 @@ import { FormHandler } from '../../utils/form-handler';
 import { getLoginIdentifiers as _getLoginIdentifiers } from '../../utils/login-identifiers';
 import { getPasskeyCredentials } from '../../utils/passkeys';
 import { registerPasskeyAutofill } from '../../utils/passkeys';
+import { normalizeTypedIdentifier } from '../../utils/typed-identifier';
 
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
@@ -21,6 +22,7 @@ import type {
   FederatedLoginOptions,
 } from '../../../interfaces/screens/login-id';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { NormalizedTypedIdentifierPayload } from '../../../interfaces/utils/typed-identifier';
 import type { IdentifierType } from 'interfaces/utils';
 
 export default class LoginId extends BaseContext implements LoginIdMembers {
@@ -54,6 +56,24 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * loginIdManager.login({
    *   username: <usernameFieldValue>
    * });
+   *
+   * @example
+   * // Typed login, where the screen knows which identifier the user chose. `identifierType` stops
+   * // the server inferring the type from the value's shape.
+   *
+   * loginIdManager.login({
+   *   username: <usernameFieldValue>,
+   *   identifierType: 'username'
+   * });
+   *
+   * @example
+   * // Phone login with a country dropdown, using a code from `countryCodes.available`.
+   *
+   * loginIdManager.login({
+   *   username: '2015550123',
+   *   identifierType: 'phone',
+   *   phoneCountryCode: 'US'
+   * });
    */
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = {
@@ -62,8 +82,12 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
     };
 
     const browserCapabilities = await getBrowserCapabilities();
-    await new FormHandler(options).submitData<LoginOptions>({
-      ...payload,
+    // The login endpoint names the typed identifier fields differently from the SDK options, and
+    // reads them only when `identifier_type` is present. Remap before submitting so a typed
+    // submission is not silently treated as a legacy one. The remapped payload is no longer a
+    // `LoginOptions`, so the type argument widens to match what is actually submitted.
+    await new FormHandler(options).submitData<NormalizedTypedIdentifierPayload>({
+      ...normalizeTypedIdentifier(payload),
       ...browserCapabilities
     });
   }

--- a/packages/auth0-acul-js/src/screens/login-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/index.ts
@@ -58,22 +58,33 @@ export default class LoginId extends BaseContext implements LoginIdMembers {
    * });
    *
    * @example
-   * // Typed login, where the screen knows which identifier the user chose. `identifierType` stops
-   * // the server inferring the type from the value's shape.
+   * // Email login. The discrete option stops the server inferring the type from the value's shape.
+   *
+   * loginIdManager.login({
+   *   email: <emailFieldValue>
+   * });
+   *
+   * @example
+   * // Phone login with a country dropdown, using a code from `countryCodes.available`. Submit the
+   * // national number; the dial code is prefixed server-side.
+   *
+   * loginIdManager.login({
+   *   phone: '2015550123',
+   *   phoneCountryCode: 'US'
+   * });
+   *
+   * @example
+   * // A username read as one, rather than inferred from its shape. `username` has no discrete
+   * // option of its own — it predates them as the untyped field — so pair it with `identifierType`.
    *
    * loginIdManager.login({
    *   username: <usernameFieldValue>,
    *   identifierType: 'username'
    * });
    *
-   * @example
-   * // Phone login with a country dropdown, using a code from `countryCodes.available`.
-   *
-   * loginIdManager.login({
-   *   username: '2015550123',
-   *   identifierType: 'phone',
-   *   phoneCountryCode: 'US'
-   * });
+   * @remarks
+   * Login submits a single identifier. Supplying more than one of `email`, `phone` or `username`
+   * resolves to the first by that precedence and warns; the rest are ignored.
    */
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = {

--- a/packages/auth0-acul-js/src/screens/login-id/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login-id/screen-override.ts
@@ -21,9 +21,8 @@ export class ScreenOverride extends Screen implements OverrideOptions {
   }
 
   /**
-   * Extracts the screen data, renaming the server's `active_identifier_type` to the camelCase
-   * `activeIdentifierType`. The raw snake_case key is dropped so consumers see a single
-   * camelCase field, matching the declared type.
+   * Extracts the screen data, renaming `active_identifier_type` to `activeIdentifierType`. The
+   * snake_case key is dropped so consumers see a single field, matching the declared type.
    */
   static getScreenData(screenContext: ScreenContext): OverrideOptions['data'] {
     const data = screenContext.data;

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -55,8 +55,28 @@ export default class Login extends BaseContext implements LoginMembers {
    *
    * @example
    * ```typescript
-   * // Typed login, where the screen knows which identifier the user chose. `identifierType` stops
-   * // the server inferring the type from the value's shape.
+   * // Email login. The discrete option stops the server inferring the type from the value's shape.
+   * loginManager.login({
+   *   email: "test@example.com",
+   *   password: "testPassword"
+   * });
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Phone login with a country dropdown, using a code from `countryCodes.available`. Submit the
+   * // national number; the dial code is prefixed server-side.
+   * loginManager.login({
+   *   phone: "2015550123",
+   *   phoneCountryCode: "US",
+   *   password: "testPassword"
+   * });
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // A username read as one, rather than inferred from its shape. `username` has no discrete
+   * // option of its own — it predates them as the untyped field — so pair it with `identifierType`.
    * loginManager.login({
    *   username: "testUser",
    *   identifierType: "username",
@@ -64,16 +84,9 @@ export default class Login extends BaseContext implements LoginMembers {
    * });
    * ```
    *
-   * @example
-   * ```typescript
-   * // Phone login with a country dropdown, using a code from `countryCodes.available`.
-   * loginManager.login({
-   *   username: "2015550123",
-   *   identifierType: "phone",
-   *   phoneCountryCode: "US",
-   *   password: "testPassword"
-   * });
-   * ```
+   * @remarks
+   * Login submits a single identifier. Supplying more than one of `email`, `phone` or `username`
+   * resolves to the first by that precedence and warns; the rest are ignored.
    */
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'login'] };

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -2,6 +2,7 @@ import { ScreenIds, FormActions } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 import { getLoginIdentifiers as _getLoginIdentifiers } from '../../utils/login-identifiers';
+import { normalizeTypedIdentifier } from '../../utils/typed-identifier';
 
 import { ScreenOverride } from './screen-override';
 import { TransactionOverride } from './transaction-override';
@@ -17,6 +18,7 @@ import type {
   FederatedLoginOptions,
 } from '../../../interfaces/screens/login';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
+import type { NormalizedTypedIdentifierPayload } from '../../../interfaces/utils/typed-identifier';
 import type { IdentifierType } from 'interfaces/utils';
 
 /**
@@ -50,11 +52,37 @@ export default class Login extends BaseContext implements LoginMembers {
    *   password: "testPassword"
    * });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Typed login, where the screen knows which identifier the user chose. `identifierType` stops
+   * // the server inferring the type from the value's shape.
+   * loginManager.login({
+   *   username: "testUser",
+   *   identifierType: "username",
+   *   password: "testPassword"
+   * });
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Phone login with a country dropdown, using a code from `countryCodes.available`.
+   * loginManager.login({
+   *   username: "2015550123",
+   *   identifierType: "phone",
+   *   phoneCountryCode: "US",
+   *   password: "testPassword"
+   * });
+   * ```
    */
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'login'] };
-    await new FormHandler(options).submitData<LoginOptions>({
-      ...payload,
+    // The login endpoint names the typed identifier fields differently from the SDK options, and
+    // reads them only when `identifier_type` is present. Remap before submitting so a typed
+    // submission is not silently treated as a legacy one. The remapped payload is no longer a
+    // `LoginOptions`, so the type argument widens to match what is actually submitted.
+    await new FormHandler(options).submitData<NormalizedTypedIdentifierPayload>({
+      ...normalizeTypedIdentifier(payload),
       action: FormActions.DEFAULT
     });
   }

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -55,9 +55,11 @@ export default class Login extends BaseContext implements LoginMembers {
    *
    * @example
    * ```typescript
-   * // Email login. The discrete option stops the server inferring the type from the value's shape.
+   * // An email read as one, rather than inferred from the value's shape. `identifierType` is
+   * // typically `screen.data.activeIdentifierType`.
    * loginManager.login({
-   *   email: "test@example.com",
+   *   identifier: "test@example.com",
+   *   identifierType: "email",
    *   password: "testPassword"
    * });
    * ```
@@ -65,28 +67,20 @@ export default class Login extends BaseContext implements LoginMembers {
    * @example
    * ```typescript
    * // Phone login with a country dropdown, using a code from `countryCodes.available`. Submit the
-   * // national number; the dial code is prefixed server-side.
+   * // national number as the identifier; the dial code is prefixed server-side.
    * loginManager.login({
-   *   phone: "2015550123",
+   *   identifier: "2015550123",
+   *   identifierType: "phone",
    *   phoneCountryCode: "US",
    *   password: "testPassword"
    * });
    * ```
    *
-   * @example
-   * ```typescript
-   * // A username read as one, rather than inferred from its shape. `username` has no discrete
-   * // option of its own — it predates them as the untyped field — so pair it with `identifierType`.
-   * loginManager.login({
-   *   username: "testUser",
-   *   identifierType: "username",
-   *   password: "testPassword"
-   * });
-   * ```
-   *
    * @remarks
-   * Login submits a single identifier. Supplying more than one of `email`, `phone` or `username`
-   * resolves to the first by that precedence and warns; the rest are ignored.
+   * Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and
+   * `identifierType` names what it holds. Omitting `identifierType` submits the identifier on its
+   * own, exactly as before, with the server inferring the type. `username` is `identifier`'s original
+   * spelling and still accepted in its place.
    */
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'login'] };

--- a/packages/auth0-acul-js/src/screens/login/index.ts
+++ b/packages/auth0-acul-js/src/screens/login/index.ts
@@ -77,10 +77,9 @@ export default class Login extends BaseContext implements LoginMembers {
    */
   async login(payload: LoginOptions): Promise<void> {
     const options: FormOptions = { state: this.transaction.state, telemetry: [Login.screenIdentifier, 'login'] };
-    // The login endpoint names the typed identifier fields differently from the SDK options, and
-    // reads them only when `identifier_type` is present. Remap before submitting so a typed
-    // submission is not silently treated as a legacy one. The remapped payload is no longer a
-    // `LoginOptions`, so the type argument widens to match what is actually submitted.
+    // The endpoint names the typed identifier fields differently and reads them only when
+    // `identifier_type` is present, so remap before submitting. The result is no longer a
+    // `LoginOptions`, hence the wider type argument.
     await new FormHandler(options).submitData<NormalizedTypedIdentifierPayload>({
       ...normalizeTypedIdentifier(payload),
       action: FormActions.DEFAULT

--- a/packages/auth0-acul-js/src/screens/login/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/login/screen-override.ts
@@ -22,9 +22,8 @@ export class ScreenOverride extends Screen implements OverrideOptions {
   }
 
   /**
-   * Extracts the screen data, renaming the server's `active_identifier_type` to the camelCase
-   * `activeIdentifierType`. The raw snake_case key is dropped so consumers see a single
-   * camelCase field, matching the declared type.
+   * Extracts the screen data, renaming `active_identifier_type` to `activeIdentifierType`. The
+   * snake_case key is dropped so consumers see a single field, matching the declared type.
    */
   static getScreenData(screenContext: ScreenContext): OverrideOptions['data'] {
     const data = screenContext.data;

--- a/packages/auth0-acul-js/src/screens/signup-id/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-id/index.ts
@@ -83,9 +83,10 @@ export default class SignupId extends BaseContext implements SignupIdMembers {
       throw new Error(`Missing parameter(s): ${missingParameters.join(', ')}`);
     }
 
-    // The signup endpoint names the phone fields differently from the SDK options: `phone_number`
-    // for a discrete submission, or `identifier_phone` + `identifier_phone_country_code` when a
-    // country was selected alongside the number. The remapped payload is no longer a
+    // The signup endpoint names the phone fields differently from the SDK options: `phone_number`,
+    // plus `identifier_phone` + `identifier_phone_country_code` when a country was selected
+    // alongside the number. `phone_number` rides along with the composite fields as the carrier a
+    // tenant that does not process them falls back to. The remapped payload is no longer a
     // `SignupOptions`, so the type argument widens to match what is actually submitted.
     const normalizedPayload = normalizePhoneIdentifier(payload, 'phone');
 

--- a/packages/auth0-acul-js/src/screens/signup/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup/index.ts
@@ -75,11 +75,12 @@ export default class Signup extends BaseContext implements SignupMembers {
       telemetry: [Signup.screenIdentifier, 'signup'],
     };
 
-    // The signup endpoint names the phone fields differently from the SDK options: `phone_number`
-    // for a discrete submission, or `identifier_phone` + `identifier_phone_country_code` when a
-    // country was selected alongside the number. Remap before submitting so a phone signup is not
-    // rejected with "no-phone_number". The remapped payload is no longer a `SignupOptions`, so the
-    // type argument widens to match what is actually submitted.
+    // The signup endpoint names the phone fields differently from the SDK options: `phone_number`,
+    // plus `identifier_phone` + `identifier_phone_country_code` when a country was selected
+    // alongside the number. Remap before submitting so a phone signup is not rejected with
+    // "no-phone_number". `phone_number` rides along with the composite fields as the carrier a
+    // tenant that does not process them falls back to. The remapped payload is no longer a
+    // `SignupOptions`, so the type argument widens to match what is actually submitted.
     await new FormHandler(options).submitData<NormalizedPhoneIdentifierPayload>(
       normalizePhoneIdentifier(payload, 'phoneNumber')
     );

--- a/packages/auth0-acul-js/src/utils/phone-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/phone-identifier.ts
@@ -7,26 +7,15 @@ import type {
 } from '../../interfaces/utils/phone-identifier';
 
 /**
- * Reshapes a signup payload's phone options into the fields the signup endpoint expects.
+ * Maps a signup payload's phone options onto the fields the signup endpoint reads.
  *
- * Two submission contracts exist, and which one applies is decided by whether the caller supplies
- * `phoneCountryCode`:
- *
- * - With `phoneCountryCode`: the composite contract. The number and the country are submitted
- *   together as `identifier_phone` + `identifier_phone_country_code`, and the submitted country is
- *   authoritative: the server prefixes the dial code from it rather than re-deriving one from the
- *   digits or from geo-IP. Use this when rendering a country dropdown next to the number field.
- * - Without `phoneCountryCode`: the discrete contract. The number is submitted as `phone_number`
- *   and the server derives the country itself, matching the historical `pickCountryCode()` flow.
- *
- * The camelCase SDK option is always removed so a payload never carries both spellings.
+ * `phone_number` is always submitted. A `phoneCountryCode` additionally sends
+ * `identifier_phone` + `identifier_phone_country_code`, letting the server prefix the dial code
+ * from the given country instead of deriving one itself.
  *
  * @param payload - The signup payload as supplied by the caller.
- * @param phoneField - The payload key holding the phone number for this screen (`phoneNumber` on
- * signup, `phone` on signup-id).
- * @returns A new payload with the phone options mapped onto the server's field names. Returned
- * unchanged when it carries no phone number. The return type is wider than `SignupOptions` by
- * design, since the mapped payload no longer carries the camelCase options that type describes.
+ * @param phoneField - The key holding the phone number (`phoneNumber` on signup, `phone` on signup-id).
+ * @returns A new payload, unchanged when it carries no phone number.
  */
 export function normalizePhoneIdentifier(
   payload: PhoneIdentifierPayload,
@@ -35,8 +24,7 @@ export function normalizePhoneIdentifier(
   const phoneNumber = payload[phoneField];
   const { phoneCountryCode, ...rest } = payload;
 
-  // Nothing to map. Drop phoneCountryCode all the same: on its own it identifies no number, and
-  // leaving it in would submit an unread field.
+  // No number to map. phoneCountryCode still goes, since alone it identifies nothing.
   if (typeof phoneNumber !== 'string' || !phoneNumber.trim()) return rest;
 
   delete rest[phoneField];
@@ -44,6 +32,7 @@ export function normalizePhoneIdentifier(
   if (typeof phoneCountryCode === 'string' && phoneCountryCode.trim()) {
     return {
       ...rest,
+      phone_number: phoneNumber,
       [TypedFields.PHONE]: phoneNumber,
       [TypedFields.PHONE_COUNTRY_CODE]: phoneCountryCode,
     };

--- a/packages/auth0-acul-js/src/utils/phone-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/phone-identifier.ts
@@ -23,11 +23,13 @@ export function normalizePhoneIdentifier(
 ): NormalizedPhoneIdentifierPayload {
   const phoneNumber = payload[phoneField];
   const { phoneCountryCode, ...rest } = payload;
-
-  // No number to map. phoneCountryCode still goes, since alone it identifies nothing.
-  if (typeof phoneNumber !== 'string' || !phoneNumber.trim()) return rest;
-
+  // Dropped whether or not it holds a number: it is the SDK's name for the field, never one the
+  // endpoint reads.
   delete rest[phoneField];
+
+  // No number to map, so nothing to type. phoneCountryCode is dropped with it, since the server reads
+  // it only beside a phone.
+  if (typeof phoneNumber !== 'string' || !phoneNumber.trim()) return rest;
 
   if (typeof phoneCountryCode === 'string' && phoneCountryCode.trim()) {
     return {

--- a/packages/auth0-acul-js/src/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/typed-identifier.ts
@@ -6,12 +6,7 @@ import type {
 } from '../../interfaces/utils/typed-identifier';
 import type { IdentifierType } from '../constants/identifiers';
 
-/**
- * The submitted field that carries the identifier, per type. Mirrors the server's own
- * `ACTIVE_FIELD_BY_TYPE`, which covers all three types — that is the field the server validates as
- * the identifier and reads the value from. Phone is submitted in its own branch below because it
- * carries an additional country code, which the server reads separately from this field.
- */
+/** The field carrying the identifier, per type. Mirrors the server's own `ACTIVE_FIELD_BY_TYPE`. */
 const FIELD_BY_IDENTIFIER_TYPE = {
   [Identifiers.EMAIL]: TypedFields.EMAIL,
   [Identifiers.USERNAME]: TypedFields.USERNAME,
@@ -26,30 +21,23 @@ function isIdentifierType(value: unknown): value is IdentifierType {
 }
 
 /**
- * Reshapes a login payload's identifier options into the fields the login endpoint expects.
+ * Maps the identifier options onto the login endpoint's own field names: `identifier_type` plus the
+ * `identifier_*` field for that type, and `identifier_phone_country_code` for phone. The server then
+ * reads the value as that type instead of inferring one from its shape.
  *
- * With `identifierType`, the value in `username` is also submitted as `identifier_email`,
- * `identifier_username` or `identifier_phone` alongside `identifier_type`, and the server reads it as
- * that type rather than guessing from its shape. `phone` additionally needs a `phoneCountryCode`,
- * whose dial code the server prefixes, so `username` should be the national number without one.
- *
- * Everything else degrades to the legacy contract, where `username` is submitted alone and the server
- * infers the type: no `identifierType`, an unrecognized one, or a `phone` with no country code, which
- * the typed path would otherwise leave unprefixed. `username` is kept on typed payloads for the same
- * reason — a tenant without typed processing enabled ignores the typed fields. Fields already passed
- * under the server's own names are forwarded untouched; the camelCase options are always removed.
+ * Degrades to the legacy contract — `username` alone, type inferred — for no or unrecognized
+ * `identifierType`, and for a `phone` with no country code, which the typed path would leave
+ * unprefixed. `username` is always kept: a tenant without typed processing reads only it.
  *
  * @param payload - The login payload as supplied by the caller.
- * @returns A new payload with the identifier options mapped onto the server's field names. Wider
- * than `LoginOptions`, which no longer describes the mapped result.
+ * @returns A new payload using the server's field names. Wider than `LoginOptions`.
  */
 export function normalizeTypedIdentifier(
   payload: TypedIdentifierPayload
 ): NormalizedTypedIdentifierPayload {
   const { identifierType, phoneCountryCode, ...rest } = payload;
 
-  // Not a typed submission. Drop phoneCountryCode all the same: without a type the server reads no
-  // country code on these screens, and leaving it in would submit an unread field.
+  // Not typed. phoneCountryCode goes too: with no type, nothing reads it.
   if (!isIdentifierType(identifierType)) return rest;
 
   const identifier = typeof rest.username === 'string' ? rest.username : '';
@@ -57,9 +45,8 @@ export function normalizeTypedIdentifier(
   if (identifierType === Identifiers.PHONE) {
     const country = typeof phoneCountryCode === 'string' ? phoneCountryCode.trim() : '';
 
-    // `identifier_type` suppresses the server's own country-code prefixing, and the typed path
-    // prefixes nothing when the country is blank or unrecognized — the number would be submitted
-    // with no dial code and match no user. Fall back to the contract that still derives a country.
+    // `identifier_type` suppresses the server's own prefixing, and the typed path prefixes nothing
+    // without a country — the number would be submitted with no dial code and match no user.
     if (!country) return rest;
 
     return {

--- a/packages/auth0-acul-js/src/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/typed-identifier.ts
@@ -13,21 +13,74 @@ const FIELD_BY_IDENTIFIER_TYPE = {
   [Identifiers.PHONE]: TypedFields.PHONE,
 } as const;
 
+/** The type the caller asked for, the value to submit as it, and whether a discrete option named it. */
+interface ResolvedIdentifier {
+  type: IdentifierType;
+  value: string;
+  fromDiscreteOption: boolean;
+}
+
 /**
- * Narrows an arbitrary option value to a supported identifier type.
+ * Reads an option only when it holds a string, so a caller's stray number or boolean is treated as
+ * absent rather than submitted as an identifier.
  */
+function readOption(payload: TypedIdentifierPayload, key: string): string | undefined {
+  const value = payload[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Narrows an arbitrary option value to a supported identifier type. */
 function isIdentifierType(value: unknown): value is IdentifierType {
   return typeof value === 'string' && (ALL_IDENTIFIERS as string[]).includes(value);
 }
 
 /**
- * Maps the identifier options onto the login endpoint's own field names: `identifier_type` plus the
+ * Decides which type to submit the identifier as, or `null` when no option names one — the payload
+ * then goes out untyped and the server infers the type from the value's shape.
+ *
+ * Ordered, most specific first; first match wins. That order also picks between several filled
+ * options, which are ignored rather than rejected — throwing would turn a payload the previous
+ * contract submitted into a rejected promise.
+ *  1. A filled `email` or `phone` — each names its own type, and beats a blank sibling.
+ *  2. A filled `username` — names no type, so `identifierType` decides. Typing it by default would
+ *     make every caller passing an email through it submit `identifier_type: 'username'`.
+ *  3. A blank `email` or `phone` — still selects its type, earning `identifier-required` naming the
+ *     empty field. A blank `phone` with no country code degrades to untyped instead, since a typed
+ *     phone with no dial code matches no user.
+ *  4. `identifierType` with no value — submits the type with an empty identifier.
+ */
+function resolveIdentifier(
+  email: string | undefined,
+  phone: string | undefined,
+  username: string | undefined,
+  identifierType: unknown
+): ResolvedIdentifier | null {
+  if (email?.trim()) return { type: Identifiers.EMAIL, value: email, fromDiscreteOption: true };
+  if (phone?.trim()) return { type: Identifiers.PHONE, value: phone, fromDiscreteOption: true };
+
+  if (username?.trim()) {
+    if (!isIdentifierType(identifierType)) return null;
+    return { type: identifierType, value: username, fromDiscreteOption: false };
+  }
+
+  if (email !== undefined) return { type: Identifiers.EMAIL, value: email, fromDiscreteOption: true };
+  if (phone !== undefined) return { type: Identifiers.PHONE, value: phone, fromDiscreteOption: true };
+
+  if (!isIdentifierType(identifierType)) return null;
+  return { type: identifierType, value: username ?? '', fromDiscreteOption: false };
+}
+
+/**
+ * Maps the identifier options onto the login endpoint's field names: `identifier_type`, the
  * `identifier_*` field for that type, and `identifier_phone_country_code` for phone. The server then
  * reads the value as that type instead of inferring one from its shape.
  *
- * Degrades to the legacy contract — `username` alone, type inferred — for no or unrecognized
- * `identifierType`, and for a `phone` with no country code, which the typed path would leave
- * unprefixed. `username` is always kept: a tenant without typed processing reads only it.
+ * Degrades to the legacy contract — `username` alone, type inferred — when no option names a type,
+ * and for a `phone` with no country code, which the typed path would leave unprefixed. `username` is
+ * always kept: a tenant without typed processing reads only it.
+ *
+ * More than one identifier is a caller mistake; it resolves by the precedence in
+ * {@link resolveIdentifier} and warns rather than throwing.
  *
  * @param payload - The login payload as supplied by the caller.
  * @returns A new payload using the server's field names. Wider than `LoginOptions`.
@@ -35,31 +88,60 @@ function isIdentifierType(value: unknown): value is IdentifierType {
 export function normalizeTypedIdentifier(
   payload: TypedIdentifierPayload
 ): NormalizedTypedIdentifierPayload {
-  const { identifierType, phoneCountryCode, ...rest } = payload;
+  const email = readOption(payload, 'email');
+  const phone = readOption(payload, 'phone');
+  const username = readOption(payload, 'username');
+  const phoneCountryCode = readOption(payload, 'phoneCountryCode');
 
-  // Not typed. phoneCountryCode goes too: with no type, nothing reads it.
-  if (!isIdentifierType(identifierType)) return rest;
+  // Login submits a single identifier, unlike signup, which legitimately collects several at once.
+  // Only a genuine mistake reaches here: a screen passing every option it renders leaves the
+  // inactive ones blank, and blanks do not count.
+  const filled = (
+    [
+      ['email', email],
+      ['phone', phone],
+      ['username', username],
+    ] as const
+  ).filter(([, value]) => value?.trim());
 
-  const identifier = typeof rest.username === 'string' ? rest.username : '';
+  if (filled.length > 1) {
+    console.warn(
+      `Login submits a single identifier, but ${filled.map(([name]) => name).join(', ')} all hold a value. ` +
+        'Submitting the first by precedence (email, then phone, then username) and ignoring the rest.'
+    );
+  }
 
-  if (identifierType === Identifiers.PHONE) {
-    const country = typeof phoneCountryCode === 'string' ? phoneCountryCode.trim() : '';
+  // The endpoint reads none of these under their SDK names: the resolved value is submitted as the
+  // `identifier_*` field for its type instead. Removed so a payload never carries both spellings.
+  const rest = { ...payload };
+  delete rest.email;
+  delete rest.phone;
+  delete rest.identifierType;
+  delete rest.phoneCountryCode;
 
-    // `identifier_type` suppresses the server's own prefixing, and the typed path prefixes nothing
-    // without a country — the number would be submitted with no dial code and match no user.
-    if (!country) return rest;
+  const resolved = resolveIdentifier(email, phone, username, payload.identifierType);
 
-    return {
-      ...rest,
-      [TypedFields.TYPE]: identifierType,
-      [FIELD_BY_IDENTIFIER_TYPE[identifierType]]: identifier,
-      [TypedFields.PHONE_COUNTRY_CODE]: country,
-    };
+  // No option names a type, so submit untyped and let the server infer it. Neither `email` nor
+  // `phone` can reach here — either would have resolved a type.
+  if (!resolved) return rest;
+
+  // A discrete option's value is copied into `username`, which remains the legacy carrier: a tenant
+  // without typed processing reads only that field. A `username` of its own is already in `rest`.
+  const carrier = resolved.fromDiscreteOption ? { username: resolved.value } : {};
+
+  // `identifier_type` suppresses the server's own prefixing, and the typed path prefixes nothing
+  // without a country — the number would be submitted with no dial code and match no user.
+  if (resolved.type === Identifiers.PHONE && !phoneCountryCode?.trim()) {
+    return { ...rest, ...carrier };
   }
 
   return {
     ...rest,
-    [TypedFields.TYPE]: identifierType,
-    [FIELD_BY_IDENTIFIER_TYPE[identifierType]]: identifier,
+    ...carrier,
+    [TypedFields.TYPE]: resolved.type,
+    [FIELD_BY_IDENTIFIER_TYPE[resolved.type]]: resolved.value,
+    ...(resolved.type === Identifiers.PHONE
+      ? { [TypedFields.PHONE_COUNTRY_CODE]: phoneCountryCode?.trim() }
+      : {}),
   };
 }

--- a/packages/auth0-acul-js/src/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/typed-identifier.ts
@@ -7,8 +7,10 @@ import type {
 import type { IdentifierType } from '../constants/identifiers';
 
 /**
- * The submitted field that carries the identifier, per type. Phone is absent because it also needs
- * the country code, so it is handled separately.
+ * The submitted field that carries the identifier, per type. Mirrors the server's own
+ * `ACTIVE_FIELD_BY_TYPE`, which covers all three types — that is the field the server validates as
+ * the identifier and reads the value from. Phone is submitted in its own branch below because it
+ * carries an additional country code, which the server reads separately from this field.
  */
 const FIELD_BY_IDENTIFIER_TYPE = {
   [Identifiers.EMAIL]: TypedFields.EMAIL,
@@ -26,30 +28,20 @@ function isIdentifierType(value: unknown): value is IdentifierType {
 /**
  * Reshapes a login payload's identifier options into the fields the login endpoint expects.
  *
- * Which contract applies is decided by whether the caller supplies `identifierType`:
+ * With `identifierType`, the value in `username` is also submitted as `identifier_email`,
+ * `identifier_username` or `identifier_phone` alongside `identifier_type`, and the server reads it as
+ * that type rather than guessing from its shape. `phone` additionally needs a `phoneCountryCode`,
+ * whose dial code the server prefixes, so `username` should be the national number without one.
  *
- * - With `identifierType`: the typed contract. The value in `username` is submitted under the field
- *   for that type (`identifier_email`, `identifier_username` or `identifier_phone`) alongside
- *   `identifier_type`, and the server stops inferring a type from the value's shape. For `phone`,
- *   a `phoneCountryCode` is submitted as `identifier_phone_country_code` and the server prefixes
- *   that country's dial code, so `username` should be the national number without one.
- * - Without `identifierType`: the legacy contract. `username` is submitted on its own and the
- *   server infers what it is.
- *
- * `username` is deliberately left on a typed payload rather than moved. The server overwrites it
- * from the typed field when typed processing is enabled, so it is redundant there — but when a
- * tenant has not enabled typed processing the server ignores the typed fields entirely, and a
- * payload without `username` would then be rejected for a missing identifier. Keeping it makes an
- * unflagged tenant degrade to the legacy contract instead of failing.
- *
- * An unrecognized `identifierType` degrades to the legacy contract, matching how
- * `normalizePhoneIdentifier` treats a blank country code. The camelCase options are always removed
- * so a payload never carries both spellings.
+ * Everything else degrades to the legacy contract, where `username` is submitted alone and the server
+ * infers the type: no `identifierType`, an unrecognized one, or a `phone` with no country code, which
+ * the typed path would otherwise leave unprefixed. `username` is kept on typed payloads for the same
+ * reason — a tenant without typed processing enabled ignores the typed fields. Fields already passed
+ * under the server's own names are forwarded untouched; the camelCase options are always removed.
  *
  * @param payload - The login payload as supplied by the caller.
- * @returns A new payload with the identifier options mapped onto the server's field names. The
- * return type is wider than `LoginOptions` by design, since the mapped payload no longer carries
- * the camelCase options that type describes.
+ * @returns A new payload with the identifier options mapped onto the server's field names. Wider
+ * than `LoginOptions`, which no longer describes the mapped result.
  */
 export function normalizeTypedIdentifier(
   payload: TypedIdentifierPayload
@@ -65,13 +57,16 @@ export function normalizeTypedIdentifier(
   if (identifierType === Identifiers.PHONE) {
     const country = typeof phoneCountryCode === 'string' ? phoneCountryCode.trim() : '';
 
+    // `identifier_type` suppresses the server's own country-code prefixing, and the typed path
+    // prefixes nothing when the country is blank or unrecognized — the number would be submitted
+    // with no dial code and match no user. Fall back to the contract that still derives a country.
+    if (!country) return rest;
+
     return {
       ...rest,
       [TypedFields.TYPE]: identifierType,
-      [TypedFields.PHONE]: identifier,
-      // Omitted when blank: on the typed contract an empty country code would have the server
-      // prefix nothing, whereas omitting it lets the server derive the country itself.
-      ...(country ? { [TypedFields.PHONE_COUNTRY_CODE]: country } : {}),
+      [FIELD_BY_IDENTIFIER_TYPE[identifierType]]: identifier,
+      [TypedFields.PHONE_COUNTRY_CODE]: country,
     };
   }
 

--- a/packages/auth0-acul-js/src/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/typed-identifier.ts
@@ -13,13 +13,6 @@ const FIELD_BY_IDENTIFIER_TYPE = {
   [Identifiers.PHONE]: TypedFields.PHONE,
 } as const;
 
-/** The type the caller asked for, the value to submit as it, and whether a discrete option named it. */
-interface ResolvedIdentifier {
-  type: IdentifierType;
-  value: string;
-  fromDiscreteOption: boolean;
-}
-
 /**
  * Reads an option only when it holds a string, so a caller's stray number or boolean is treated as
  * absent rather than submitted as an identifier.
@@ -35,52 +28,20 @@ function isIdentifierType(value: unknown): value is IdentifierType {
 }
 
 /**
- * Decides which type to submit the identifier as, or `null` when no option names one — the payload
- * then goes out untyped and the server infers the type from the value's shape.
+ * Maps the identifier and `identifierType` onto the login endpoint's field names: `identifier_type`,
+ * the `identifier_*` field for that type, and `identifier_phone_country_code` for phone. The server
+ * then reads the value as that type instead of inferring one from its shape, and collapses it back
+ * onto `username` internally.
  *
- * Ordered, most specific first; first match wins. That order also picks between several filled
- * options, which are ignored rather than rejected — throwing would turn a payload the previous
- * contract submitted into a rejected promise.
- *  1. A filled `email` or `phone` — each names its own type, and beats a blank sibling.
- *  2. A filled `username` — names no type, so `identifierType` decides. Typing it by default would
- *     make every caller passing an email through it submit `identifier_type: 'username'`.
- *  3. A blank `email` or `phone` — still selects its type, earning `identifier-required` naming the
- *     empty field. A blank `phone` with no country code degrades to untyped instead, since a typed
- *     phone with no dial code matches no user.
- *  4. `identifierType` with no value — submits the type with an empty identifier.
- */
-function resolveIdentifier(
-  email: string | undefined,
-  phone: string | undefined,
-  username: string | undefined,
-  identifierType: unknown
-): ResolvedIdentifier | null {
-  if (email?.trim()) return { type: Identifiers.EMAIL, value: email, fromDiscreteOption: true };
-  if (phone?.trim()) return { type: Identifiers.PHONE, value: phone, fromDiscreteOption: true };
-
-  if (username?.trim()) {
-    if (!isIdentifierType(identifierType)) return null;
-    return { type: identifierType, value: username, fromDiscreteOption: false };
-  }
-
-  if (email !== undefined) return { type: Identifiers.EMAIL, value: email, fromDiscreteOption: true };
-  if (phone !== undefined) return { type: Identifiers.PHONE, value: phone, fromDiscreteOption: true };
-
-  if (!isIdentifierType(identifierType)) return null;
-  return { type: identifierType, value: username ?? '', fromDiscreteOption: false };
-}
-
-/**
- * Maps the identifier options onto the login endpoint's field names: `identifier_type`, the
- * `identifier_*` field for that type, and `identifier_phone_country_code` for phone. The server then
- * reads the value as that type instead of inferring one from its shape.
+ * The identifier stays denormalized on the way in — one value, its type named separately — which
+ * mirrors how the endpoint models it. Callers name that value `identifier`, which pairs with
+ * `identifierType`; `username` is its original spelling and still accepted, so `identifier` wins when
+ * both are supplied. Either way the value goes out as `username`, the only identifier field the
+ * endpoint reads and the only one a tenant without typed processing sees.
  *
- * Degrades to the legacy contract — `username` alone, type inferred — when no option names a type,
- * and for a `phone` with no country code, which the typed path would leave unprefixed. `username` is
- * always kept: a tenant without typed processing reads only it.
- *
- * More than one identifier is a caller mistake; it resolves by the precedence in
- * {@link resolveIdentifier} and warns rather than throwing.
+ * Degrades to that untyped contract, leaving the payload as supplied, when `identifierType` names no
+ * supported type, and for `'phone'` with no country code — a typed phone suppresses the server's own
+ * prefixing, so it would go out with no dial code and match no user.
  *
  * @param payload - The login payload as supplied by the caller.
  * @returns A new payload using the server's field names. Wider than `LoginOptions`.
@@ -88,59 +49,31 @@ function resolveIdentifier(
 export function normalizeTypedIdentifier(
   payload: TypedIdentifierPayload
 ): NormalizedTypedIdentifierPayload {
-  const email = readOption(payload, 'email');
-  const phone = readOption(payload, 'phone');
-  const username = readOption(payload, 'username');
+  const identifierType = payload.identifierType;
   const phoneCountryCode = readOption(payload, 'phoneCountryCode');
+  const identifier = readOption(payload, 'identifier') ?? readOption(payload, 'username');
 
-  // Login submits a single identifier, unlike signup, which legitimately collects several at once.
-  // Only a genuine mistake reaches here: a screen passing every option it renders leaves the
-  // inactive ones blank, and blanks do not count.
-  const filled = (
-    [
-      ['email', email],
-      ['phone', phone],
-      ['username', username],
-    ] as const
-  ).filter(([, value]) => value?.trim());
-
-  if (filled.length > 1) {
-    console.warn(
-      `Login submits a single identifier, but ${filled.map(([name]) => name).join(', ')} all hold a value. ` +
-        'Submitting the first by precedence (email, then phone, then username) and ignoring the rest.'
-    );
-  }
-
-  // The endpoint reads none of these under their SDK names: the resolved value is submitted as the
-  // `identifier_*` field for its type instead. Removed so a payload never carries both spellings.
+  // None of these is a field the endpoint reads: `identifier` is submitted as `username`, and the
+  // other two become `identifier_type` and `identifier_phone_country_code` on the typed path.
+  // Removed so a payload never carries both spellings of the same value.
   const rest = { ...payload };
-  delete rest.email;
-  delete rest.phone;
+  delete rest.identifier;
   delete rest.identifierType;
   delete rest.phoneCountryCode;
+  if (identifier !== undefined) rest.username = identifier;
 
-  const resolved = resolveIdentifier(email, phone, username, payload.identifierType);
-
-  // No option names a type, so submit untyped and let the server infer it. Neither `email` nor
-  // `phone` can reach here — either would have resolved a type.
-  if (!resolved) return rest;
-
-  // A discrete option's value is copied into `username`, which remains the legacy carrier: a tenant
-  // without typed processing reads only that field. A `username` of its own is already in `rest`.
-  const carrier = resolved.fromDiscreteOption ? { username: resolved.value } : {};
+  // No type named, so submit untyped and let the server infer one from the value's shape.
+  if (!isIdentifierType(identifierType)) return rest;
 
   // `identifier_type` suppresses the server's own prefixing, and the typed path prefixes nothing
   // without a country — the number would be submitted with no dial code and match no user.
-  if (resolved.type === Identifiers.PHONE && !phoneCountryCode?.trim()) {
-    return { ...rest, ...carrier };
-  }
+  if (identifierType === Identifiers.PHONE && !phoneCountryCode?.trim()) return rest;
 
   return {
     ...rest,
-    ...carrier,
-    [TypedFields.TYPE]: resolved.type,
-    [FIELD_BY_IDENTIFIER_TYPE[resolved.type]]: resolved.value,
-    ...(resolved.type === Identifiers.PHONE
+    [TypedFields.TYPE]: identifierType,
+    [FIELD_BY_IDENTIFIER_TYPE[identifierType]]: identifier ?? '',
+    ...(identifierType === Identifiers.PHONE
       ? { [TypedFields.PHONE_COUNTRY_CODE]: phoneCountryCode?.trim() }
       : {}),
   };

--- a/packages/auth0-acul-js/src/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/typed-identifier.ts
@@ -1,0 +1,83 @@
+import { ALL_IDENTIFIERS, Identifiers, TypedFields } from '../constants/identifiers';
+
+import type {
+  NormalizedTypedIdentifierPayload,
+  TypedIdentifierPayload,
+} from '../../interfaces/utils/typed-identifier';
+import type { IdentifierType } from '../constants/identifiers';
+
+/**
+ * The submitted field that carries the identifier, per type. Phone is absent because it also needs
+ * the country code, so it is handled separately.
+ */
+const FIELD_BY_IDENTIFIER_TYPE = {
+  [Identifiers.EMAIL]: TypedFields.EMAIL,
+  [Identifiers.USERNAME]: TypedFields.USERNAME,
+  [Identifiers.PHONE]: TypedFields.PHONE,
+} as const;
+
+/**
+ * Narrows an arbitrary option value to a supported identifier type.
+ */
+function isIdentifierType(value: unknown): value is IdentifierType {
+  return typeof value === 'string' && (ALL_IDENTIFIERS as string[]).includes(value);
+}
+
+/**
+ * Reshapes a login payload's identifier options into the fields the login endpoint expects.
+ *
+ * Which contract applies is decided by whether the caller supplies `identifierType`:
+ *
+ * - With `identifierType`: the typed contract. The value in `username` is submitted under the field
+ *   for that type (`identifier_email`, `identifier_username` or `identifier_phone`) alongside
+ *   `identifier_type`, and the server stops inferring a type from the value's shape. For `phone`,
+ *   a `phoneCountryCode` is submitted as `identifier_phone_country_code` and the server prefixes
+ *   that country's dial code, so `username` should be the national number without one.
+ * - Without `identifierType`: the legacy contract. `username` is submitted on its own and the
+ *   server infers what it is.
+ *
+ * `username` is deliberately left on a typed payload rather than moved. The server overwrites it
+ * from the typed field when typed processing is enabled, so it is redundant there — but when a
+ * tenant has not enabled typed processing the server ignores the typed fields entirely, and a
+ * payload without `username` would then be rejected for a missing identifier. Keeping it makes an
+ * unflagged tenant degrade to the legacy contract instead of failing.
+ *
+ * An unrecognized `identifierType` degrades to the legacy contract, matching how
+ * `normalizePhoneIdentifier` treats a blank country code. The camelCase options are always removed
+ * so a payload never carries both spellings.
+ *
+ * @param payload - The login payload as supplied by the caller.
+ * @returns A new payload with the identifier options mapped onto the server's field names. The
+ * return type is wider than `LoginOptions` by design, since the mapped payload no longer carries
+ * the camelCase options that type describes.
+ */
+export function normalizeTypedIdentifier(
+  payload: TypedIdentifierPayload
+): NormalizedTypedIdentifierPayload {
+  const { identifierType, phoneCountryCode, ...rest } = payload;
+
+  // Not a typed submission. Drop phoneCountryCode all the same: without a type the server reads no
+  // country code on these screens, and leaving it in would submit an unread field.
+  if (!isIdentifierType(identifierType)) return rest;
+
+  const identifier = typeof rest.username === 'string' ? rest.username : '';
+
+  if (identifierType === Identifiers.PHONE) {
+    const country = typeof phoneCountryCode === 'string' ? phoneCountryCode.trim() : '';
+
+    return {
+      ...rest,
+      [TypedFields.TYPE]: identifierType,
+      [TypedFields.PHONE]: identifier,
+      // Omitted when blank: on the typed contract an empty country code would have the server
+      // prefix nothing, whereas omitting it lets the server derive the country itself.
+      ...(country ? { [TypedFields.PHONE_COUNTRY_CODE]: country } : {}),
+    };
+  }
+
+  return {
+    ...rest,
+    [TypedFields.TYPE]: identifierType,
+    [FIELD_BY_IDENTIFIER_TYPE[identifierType]]: identifier,
+  };
+}

--- a/packages/auth0-acul-js/src/utils/typed-identifier.ts
+++ b/packages/auth0-acul-js/src/utils/typed-identifier.ts
@@ -28,20 +28,15 @@ function isIdentifierType(value: unknown): value is IdentifierType {
 }
 
 /**
- * Maps the identifier and `identifierType` onto the login endpoint's field names: `identifier_type`,
- * the `identifier_*` field for that type, and `identifier_phone_country_code` for phone. The server
- * then reads the value as that type instead of inferring one from its shape, and collapses it back
- * onto `username` internally.
+ * Maps the identifier and `identifierType` onto the endpoint's field names — `identifier_type`, the
+ * `identifier_*` field for that type, and `identifier_phone_country_code` for phone — so the server
+ * reads the value as that type rather than inferring one from its shape. The value itself always goes
+ * out as `username`, the only identifier field the endpoint reads; `identifier` is the name that pairs
+ * with `identifierType`, `username` its original spelling, and `identifier` wins when both are given.
  *
- * The identifier stays denormalized on the way in — one value, its type named separately — which
- * mirrors how the endpoint models it. Callers name that value `identifier`, which pairs with
- * `identifierType`; `username` is its original spelling and still accepted, so `identifier` wins when
- * both are supplied. Either way the value goes out as `username`, the only identifier field the
- * endpoint reads and the only one a tenant without typed processing sees.
- *
- * Degrades to that untyped contract, leaving the payload as supplied, when `identifierType` names no
- * supported type, and for `'phone'` with no country code — a typed phone suppresses the server's own
- * prefixing, so it would go out with no dial code and match no user.
+ * Degrades to the untyped contract when `identifierType` names no supported type, and for `'phone'`
+ * with no country — a typed phone suppresses the server's prefixing, so it would go out with no dial
+ * code and match no user, whereas untyped still resolves a country on a phone-only connection.
  *
  * @param payload - The login payload as supplied by the caller.
  * @returns A new payload using the server's field names. Wider than `LoginOptions`.

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
@@ -80,63 +80,8 @@ describe('LoginId', () => {
       });
     });
 
-    it('maps a discrete email onto the typed fields the login endpoint reads', async () => {
-      await loginId.login({ email: 'test@example.com' });
-
-      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          username: 'test@example.com',
-          identifier_type: 'email',
-          identifier_email: 'test@example.com',
-        })
-      );
-    });
-
-    it('maps a discrete phone and country onto the typed fields', async () => {
-      await loginId.login({ phone: '2015550123', phoneCountryCode: 'US' });
-
-      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          username: '2015550123',
-          identifier_type: 'phone',
-          identifier_phone: '2015550123',
-          identifier_phone_country_code: 'US',
-        })
-      );
-    });
-
-    it('does not submit the discrete option names', async () => {
-      await loginId.login({ email: 'test@example.com' });
-
-      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
-        expect.not.objectContaining({
-          email: expect.anything() as unknown,
-          phone: expect.anything() as unknown,
-        })
-      );
-    });
-
-    // Login submits a single identifier, so the extra one is dropped by precedence rather than
-    // rejected: a screen handler does not catch a rejection, and the previous contract submitted this
-    // payload.
-    it('submits the first identifier by precedence when more than one is supplied', async () => {
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-      await loginId.login({ email: 'test@example.com', username: 'someone' });
-
-      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          username: 'test@example.com',
-          identifier_type: 'email',
-          identifier_email: 'test@example.com',
-        })
-      );
-      expect(warn).toHaveBeenCalled();
-      warn.mockRestore();
-    });
-
     it('maps identifierType onto the typed fields the login endpoint reads', async () => {
-      const payload: LoginOptions = { username: 'test@example.com', identifierType: 'email' };
+      const payload: LoginOptions = { identifier: 'test@example.com', identifierType: 'email' };
 
       await loginId.login(payload);
 
@@ -151,7 +96,7 @@ describe('LoginId', () => {
 
     it('maps a phone identifier and country onto the typed fields', async () => {
       const payload: LoginOptions = {
-        username: '2015550123',
+        identifier: '2015550123',
         identifierType: 'phone',
         phoneCountryCode: 'US',
       };
@@ -168,11 +113,28 @@ describe('LoginId', () => {
       );
     });
 
+    // `username` is the identifier's original spelling, so a caller written against the previous
+    // contract must keep submitting the same payload it always did.
+    it('accepts the username spelling of the identifier', async () => {
+      const payload: LoginOptions = { username: 'test@example.com', identifierType: 'email' };
+
+      await loginId.login(payload);
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'test@example.com',
+          identifier_type: 'email',
+          identifier_email: 'test@example.com',
+        })
+      );
+    });
+
     it('does not submit the camelCase options', async () => {
-      await loginId.login({ username: '2015550123', identifierType: 'phone', phoneCountryCode: 'US' });
+      await loginId.login({ identifier: '2015550123', identifierType: 'phone', phoneCountryCode: 'US' });
 
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
         expect.not.objectContaining({
+          identifier: expect.anything() as unknown,
           identifierType: expect.anything() as unknown,
           phoneCountryCode: expect.anything() as unknown,
         })
@@ -180,7 +142,7 @@ describe('LoginId', () => {
     });
 
     it('submits no typed field when identifierType is omitted', async () => {
-      await loginId.login({ username: 'testuser' });
+      await loginId.login({ identifier: 'testuser' });
 
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
         expect.not.objectContaining({

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
@@ -80,6 +80,61 @@ describe('LoginId', () => {
       });
     });
 
+    it('maps a discrete email onto the typed fields the login endpoint reads', async () => {
+      await loginId.login({ email: 'test@example.com' });
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'test@example.com',
+          identifier_type: 'email',
+          identifier_email: 'test@example.com',
+        })
+      );
+    });
+
+    it('maps a discrete phone and country onto the typed fields', async () => {
+      await loginId.login({ phone: '2015550123', phoneCountryCode: 'US' });
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: '2015550123',
+          identifier_type: 'phone',
+          identifier_phone: '2015550123',
+          identifier_phone_country_code: 'US',
+        })
+      );
+    });
+
+    it('does not submit the discrete option names', async () => {
+      await loginId.login({ email: 'test@example.com' });
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          email: expect.anything() as unknown,
+          phone: expect.anything() as unknown,
+        })
+      );
+    });
+
+    // Login submits a single identifier, so the extra one is dropped by precedence rather than
+    // rejected: a screen handler does not catch a rejection, and the previous contract submitted this
+    // payload.
+    it('submits the first identifier by precedence when more than one is supplied', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await loginId.login({ email: 'test@example.com', username: 'someone' });
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'test@example.com',
+          identifier_type: 'email',
+          identifier_email: 'test@example.com',
+        })
+      );
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
     it('maps identifierType onto the typed fields the login endpoint reads', async () => {
       const payload: LoginOptions = { username: 'test@example.com', identifierType: 'email' };
 

--- a/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login-id/index.test.ts
@@ -79,6 +79,61 @@ describe('LoginId', () => {
         'allow-passkeys': expect.any(Boolean) as unknown,
       });
     });
+
+    it('maps identifierType onto the typed fields the login endpoint reads', async () => {
+      const payload: LoginOptions = { username: 'test@example.com', identifierType: 'email' };
+
+      await loginId.login(payload);
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'test@example.com',
+          identifier_type: 'email',
+          identifier_email: 'test@example.com',
+        })
+      );
+    });
+
+    it('maps a phone identifier and country onto the typed fields', async () => {
+      const payload: LoginOptions = {
+        username: '2015550123',
+        identifierType: 'phone',
+        phoneCountryCode: 'US',
+      };
+
+      await loginId.login(payload);
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: '2015550123',
+          identifier_type: 'phone',
+          identifier_phone: '2015550123',
+          identifier_phone_country_code: 'US',
+        })
+      );
+    });
+
+    it('does not submit the camelCase options', async () => {
+      await loginId.login({ username: '2015550123', identifierType: 'phone', phoneCountryCode: 'US' });
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          identifierType: expect.anything() as unknown,
+          phoneCountryCode: expect.anything() as unknown,
+        })
+      );
+    });
+
+    it('submits no typed field when identifierType is omitted', async () => {
+      await loginId.login({ username: 'testuser' });
+
+      expect(FormHandler.prototype.submitData).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          identifier_type: expect.anything() as unknown,
+          identifier_username: expect.anything() as unknown,
+        })
+      );
+    });
   });
 
   describe('federatedLogin', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -76,6 +76,64 @@ describe('Login', () => {
       };
       await expect(login.login(payload)).rejects.toThrow('Invalid password');
     });
+
+    it('should map identifierType onto the typed fields the login endpoint reads', async () => {
+      const payload: LoginOptions = {
+        username: 'test@example.com',
+        password: 'testPassword',
+        identifierType: 'email',
+      };
+      await login.login(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        username: 'test@example.com',
+        password: 'testPassword',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should map a phone identifier and country onto the typed fields', async () => {
+      const payload: LoginOptions = {
+        username: '2015550123',
+        password: 'testPassword',
+        identifierType: 'phone',
+        phoneCountryCode: 'US',
+      };
+      await login.login(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        username: '2015550123',
+        password: 'testPassword',
+        identifier_type: 'phone',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should not submit the camelCase options', async () => {
+      await login.login({
+        username: '2015550123',
+        password: 'testPassword',
+        identifierType: 'phone',
+        phoneCountryCode: 'US',
+      });
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          identifierType: expect.anything() as unknown,
+          phoneCountryCode: expect.anything() as unknown,
+        })
+      );
+    });
+
+    it('should submit no typed field when identifierType is omitted', async () => {
+      await login.login({ username: 'testUser', password: 'testPassword' });
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        username: 'testUser',
+        password: 'testPassword',
+        action: FormActions.DEFAULT,
+      });
+    });
   });
 
   describe('Social Login method', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -77,51 +77,9 @@ describe('Login', () => {
       await expect(login.login(payload)).rejects.toThrow('Invalid password');
     });
 
-    it('should map a discrete email onto the typed fields the login endpoint reads', async () => {
-      await login.login({ email: 'test@example.com', password: 'testPassword' });
-      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
-        username: 'test@example.com',
-        password: 'testPassword',
-        identifier_type: 'email',
-        identifier_email: 'test@example.com',
-        action: FormActions.DEFAULT,
-      });
-    });
-
-    it('should map a discrete phone and country onto the typed fields', async () => {
-      await login.login({ phone: '2015550123', phoneCountryCode: 'US', password: 'testPassword' });
-      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
-        username: '2015550123',
-        password: 'testPassword',
-        identifier_type: 'phone',
-        identifier_phone: '2015550123',
-        identifier_phone_country_code: 'US',
-        action: FormActions.DEFAULT,
-      });
-    });
-
-    // Login submits a single identifier, so the extra one is dropped by precedence rather than
-    // rejected: a screen handler does not catch a rejection, and the previous contract submitted this
-    // payload.
-    it('should submit the first identifier by precedence when more than one is supplied', async () => {
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-      await login.login({ email: 'test@example.com', username: 'someone', password: 'testPassword' });
-
-      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
-        username: 'test@example.com',
-        password: 'testPassword',
-        identifier_type: 'email',
-        identifier_email: 'test@example.com',
-        action: FormActions.DEFAULT,
-      });
-      expect(warn).toHaveBeenCalled();
-      warn.mockRestore();
-    });
-
     it('should map identifierType onto the typed fields the login endpoint reads', async () => {
       const payload: LoginOptions = {
-        username: 'test@example.com',
+        identifier: 'test@example.com',
         password: 'testPassword',
         identifierType: 'email',
       };
@@ -137,7 +95,7 @@ describe('Login', () => {
 
     it('should map a phone identifier and country onto the typed fields', async () => {
       const payload: LoginOptions = {
-        username: '2015550123',
+        identifier: '2015550123',
         password: 'testPassword',
         identifierType: 'phone',
         phoneCountryCode: 'US',
@@ -153,15 +111,34 @@ describe('Login', () => {
       });
     });
 
+    // `username` is the identifier's original spelling, so a caller written against the previous
+    // contract must keep submitting the same payload it always did.
+    it('should accept the username spelling of the identifier', async () => {
+      const payload: LoginOptions = {
+        username: 'test@example.com',
+        password: 'testPassword',
+        identifierType: 'email',
+      };
+      await login.login(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        username: 'test@example.com',
+        password: 'testPassword',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        action: FormActions.DEFAULT,
+      });
+    });
+
     it('should not submit the camelCase options', async () => {
       await login.login({
-        username: '2015550123',
+        identifier: '2015550123',
         password: 'testPassword',
         identifierType: 'phone',
         phoneCountryCode: 'US',
       });
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
         expect.not.objectContaining({
+          identifier: expect.anything() as unknown,
           identifierType: expect.anything() as unknown,
           phoneCountryCode: expect.anything() as unknown,
         })
@@ -169,7 +146,7 @@ describe('Login', () => {
     });
 
     it('should submit no typed field when identifierType is omitted', async () => {
-      await login.login({ username: 'testUser', password: 'testPassword' });
+      await login.login({ identifier: 'testUser', password: 'testPassword' });
       expect(mockFormHandler.submitData).toHaveBeenCalledWith({
         username: 'testUser',
         password: 'testPassword',

--- a/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/login/index.test.ts
@@ -77,6 +77,48 @@ describe('Login', () => {
       await expect(login.login(payload)).rejects.toThrow('Invalid password');
     });
 
+    it('should map a discrete email onto the typed fields the login endpoint reads', async () => {
+      await login.login({ email: 'test@example.com', password: 'testPassword' });
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        username: 'test@example.com',
+        password: 'testPassword',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should map a discrete phone and country onto the typed fields', async () => {
+      await login.login({ phone: '2015550123', phoneCountryCode: 'US', password: 'testPassword' });
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        username: '2015550123',
+        password: 'testPassword',
+        identifier_type: 'phone',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    // Login submits a single identifier, so the extra one is dropped by precedence rather than
+    // rejected: a screen handler does not catch a rejection, and the previous contract submitted this
+    // payload.
+    it('should submit the first identifier by precedence when more than one is supplied', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await login.login({ email: 'test@example.com', username: 'someone', password: 'testPassword' });
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        username: 'test@example.com',
+        password: 'testPassword',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        action: FormActions.DEFAULT,
+      });
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
     it('should map identifierType onto the typed fields the login endpoint reads', async () => {
       const payload: LoginOptions = {
         username: 'test@example.com',

--- a/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-id/index.test.ts
@@ -128,6 +128,7 @@ describe('SignupId', () => {
         email: 'testUser@testmail.com',
         username: 'testUser',
         password: 'testPassword',
+        phone_number: '2015550123',
         identifier_phone: '2015550123',
         identifier_phone_country_code: 'US',
         ...mockBrowserCapabilities,

--- a/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
@@ -124,13 +124,13 @@ describe('Signup', () => {
       });
     });
 
-    it('should not remap an empty phoneNumber', async () => {
+    it('should drop an empty phoneNumber rather than submit either spelling of it', async () => {
       const payload: SignupOptions = { email: 'test@example.com', phoneNumber: '', password: 'P@ssw0rd!' };
       await signup.signup(payload);
 
       const submittedPayload = (FormHandler.prototype.submitData as jest.Mock).mock.calls[0][0];
       expect(submittedPayload).not.toHaveProperty('phone_number');
-      expect(submittedPayload).toHaveProperty('phoneNumber', '');
+      expect(submittedPayload).not.toHaveProperty('phoneNumber');
     });
 
     it('should leave a payload without phoneNumber untouched', async () => {

--- a/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup/index.test.ts
@@ -96,15 +96,16 @@ describe('Signup', () => {
       await signup.signup(payload);
 
       expect(FormHandler.prototype.submitData).toHaveBeenCalledWith({
+        phone_number: '2015550123',
         identifier_phone: '2015550123',
         identifier_phone_country_code: 'US',
         password: 'P@ssw0rd!',
       });
 
-      // The server treats the submitted country as authoritative, so `phone_number` must not be
-      // sent alongside it, and the camelCase options must not leak through.
+      // `phone_number` rides along as the carrier a tenant that does not process the composite
+      // fields falls back to; where they are processed the server overwrites it with the prefixed
+      // value. The camelCase options must not leak through either way.
       const submittedPayload = (FormHandler.prototype.submitData as jest.Mock).mock.calls[0][0];
-      expect(submittedPayload).not.toHaveProperty('phone_number');
       expect(submittedPayload).not.toHaveProperty('phoneNumber');
       expect(submittedPayload).not.toHaveProperty('phoneCountryCode');
     });

--- a/packages/auth0-acul-js/tests/unit/utils/phone-identifier.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/phone-identifier.test.ts
@@ -9,6 +9,7 @@ describe('normalizePhoneIdentifier', () => {
       );
 
       expect(result).toEqual({
+        phone_number: '2015550123',
         identifier_phone: '2015550123',
         identifier_phone_country_code: 'US',
       });
@@ -18,18 +19,22 @@ describe('normalizePhoneIdentifier', () => {
       const result = normalizePhoneIdentifier({ phone: '7400123456', phoneCountryCode: 'GB' }, 'phone');
 
       expect(result).toEqual({
+        phone_number: '7400123456',
         identifier_phone: '7400123456',
         identifier_phone_country_code: 'GB',
       });
     });
 
-    it('does not submit phone_number, so the server does not re-derive the country', () => {
+    // A tenant that does not process the composite fields reads only phone_number. Submitting it
+    // alongside them is what keeps the number from being dropped there; where they are processed,
+    // the server overwrites phone_number with the prefixed value before anything reads it.
+    it('also submits phone_number, as the carrier the discrete contract falls back to', () => {
       const result = normalizePhoneIdentifier(
         { phoneNumber: '6045550123', phoneCountryCode: 'CA' },
         'phoneNumber'
       );
 
-      expect(result).not.toHaveProperty('phone_number');
+      expect(result).toHaveProperty('phone_number', '6045550123');
     });
 
     it('preserves the other payload fields', () => {
@@ -50,6 +55,7 @@ describe('normalizePhoneIdentifier', () => {
         username: 'someone',
         password: 'P@ssw0rd!',
         captcha: 'abc',
+        phone_number: '2015550123',
         identifier_phone: '2015550123',
         identifier_phone_country_code: 'US',
       });

--- a/packages/auth0-acul-js/tests/unit/utils/phone-identifier.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/phone-identifier.test.ts
@@ -105,13 +105,13 @@ describe('normalizePhoneIdentifier', () => {
       expect(result).toEqual({ email: 'test@example.com' });
     });
 
-    it('treats a blank phone number as absent', () => {
+    it('treats a blank phone number as absent, submitting neither spelling of the field', () => {
       const result = normalizePhoneIdentifier(
         { phoneNumber: '   ', phoneCountryCode: 'US' },
         'phoneNumber'
       );
 
-      expect(result).toEqual({ phoneNumber: '   ' });
+      expect(result).toEqual({});
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
@@ -1,218 +1,10 @@
 import { normalizeTypedIdentifier } from '../../../src/utils/typed-identifier';
 
 describe('normalizeTypedIdentifier', () => {
-  describe('with a discrete identifier option (typed contract)', () => {
-    it('maps an email onto the typed fields', () => {
-      const result = normalizeTypedIdentifier({ email: 'test@example.com', password: 'P@ssw0rd!' });
-
-      expect(result).toEqual({
-        username: 'test@example.com',
-        identifier_type: 'email',
-        identifier_email: 'test@example.com',
-        password: 'P@ssw0rd!',
-      });
-    });
-
-    it('maps a phone and country onto the typed fields', () => {
-      const result = normalizeTypedIdentifier({ phone: '2015550123', phoneCountryCode: 'US' });
-
-      expect(result).toEqual({
-        username: '2015550123',
-        identifier_type: 'phone',
-        identifier_phone: '2015550123',
-        identifier_phone_country_code: 'US',
-      });
-    });
-
-    // The endpoint reads neither name, so leaving them in would submit unread fields that the
-    // custom-prompt-field handling would then have to ignore.
-    it('does not submit the discrete option names', () => {
-      const result = normalizeTypedIdentifier({ email: 'test@example.com' });
-
-      expect(result).not.toHaveProperty('email');
-      expect(result).not.toHaveProperty('phone');
-    });
-
-    it('copies the value into username so an unflagged tenant falls back to the legacy contract', () => {
-      expect(normalizeTypedIdentifier({ email: 'test@example.com' }).username).toBe('test@example.com');
-      expect(normalizeTypedIdentifier({ phone: '2015550123', phoneCountryCode: 'US' }).username).toBe(
-        '2015550123'
-      );
-    });
-
-    it('degrades a phone submitted without a country code to the legacy contract', () => {
-      const result = normalizeTypedIdentifier({ phone: '+12015550123', password: 'P@ssw0rd!' });
-
-      expect(result).toEqual({ username: '+12015550123', password: 'P@ssw0rd!' });
-    });
-
-    it('names its own type, superseding a conflicting identifierType', () => {
-      const result = normalizeTypedIdentifier({ email: 'test@example.com', identifierType: 'username' });
-
-      expect(result).toMatchObject({
-        identifier_type: 'email',
-        identifier_email: 'test@example.com',
-      });
-      expect(result).not.toHaveProperty('identifier_username');
-    });
-
-    // A screen driven by React state may pass every option it renders, leaving the inactive ones as
-    // empty strings. The filled one is the identifier the user actually entered.
-    it('resolves the option holding a value when a blank sibling is also passed', () => {
-      const result = normalizeTypedIdentifier({ email: '', phone: '2015550123', phoneCountryCode: 'US' });
-
-      expect(result).toMatchObject({
-        identifier_type: 'phone',
-        identifier_phone: '2015550123',
-      });
-    });
-
-    // Submitting the blank field typed is what earns the server's `identifier-required` error, which
-    // names the field the user left empty. Dropping it would earn a vaguer one.
-    it('submits a blank option as its type rather than dropping it', () => {
-      const result = normalizeTypedIdentifier({ email: '' });
-
-      expect(result).toEqual({ username: '', identifier_type: 'email', identifier_email: '' });
-    });
-
-    // A blank phone still selects its type, but the typed path prefixes no dial code without a
-    // country, so it degrades like a filled one rather than submitting `identifier_phone: ''`.
-    it('degrades a blank phone with no country code to the legacy contract', () => {
-      const result = normalizeTypedIdentifier({ phone: '' });
-
-      expect(result).toEqual({ username: '' });
-    });
-
-    it('submits a blank phone as its type once a country code selects it', () => {
-      const result = normalizeTypedIdentifier({ phone: '', phoneCountryCode: 'US' });
-
-      expect(result).toEqual({
-        username: '',
-        identifier_type: 'phone',
-        identifier_phone: '',
-        identifier_phone_country_code: 'US',
-      });
-    });
-
-    it('does not let a blank option discard the value another option carries', () => {
-      const result = normalizeTypedIdentifier({ phone: '', username: 'someone', identifierType: 'username' });
-
-      expect(result).toEqual({
-        username: 'someone',
-        identifier_type: 'username',
-        identifier_username: 'someone',
-      });
-    });
-
-    it('preserves the other payload fields', () => {
-      const result = normalizeTypedIdentifier({
-        email: 'test@example.com',
-        password: 'P@ssw0rd!',
-        captcha: 'abc',
-        customField: 'customValue',
-      });
-
-      expect(result).toMatchObject({
-        password: 'P@ssw0rd!',
-        captcha: 'abc',
-        customField: 'customValue',
-      });
-    });
-
-    it('does not mutate the payload it was given', () => {
-      const payload = { phone: '2015550123', phoneCountryCode: 'US' };
-      normalizeTypedIdentifier(payload);
-
-      expect(payload).toEqual({ phone: '2015550123', phoneCountryCode: 'US' });
-    });
-  });
-
-  // Login submits one identifier, so supplying several is a caller mistake. It resolves by
-  // precedence rather than throwing: rejecting would turn a payload the previous contract submitted
-  // into a rejected promise, and screen handlers do not catch one.
-  describe('with more than one identifier option', () => {
-    let warn: jest.SpyInstance;
-
-    beforeEach(() => {
-      warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    });
-
-    afterEach(() => {
-      warn.mockRestore();
-    });
-
-    it('does not throw', () => {
-      expect(() =>
-        normalizeTypedIdentifier({ email: 'test@example.com', phone: '2015550123', username: 'someone' })
-      ).not.toThrow();
-    });
-
-    it('resolves email ahead of phone', () => {
-      const result = normalizeTypedIdentifier({ email: 'test@example.com', phone: '2015550123' });
-
-      expect(result).toEqual({
-        username: 'test@example.com',
-        identifier_type: 'email',
-        identifier_email: 'test@example.com',
-      });
-    });
-
-    it('resolves email ahead of username', () => {
-      const result = normalizeTypedIdentifier({ email: 'test@example.com', username: 'someone' });
-
-      expect(result).toEqual({
-        username: 'test@example.com',
-        identifier_type: 'email',
-        identifier_email: 'test@example.com',
-      });
-    });
-
-    // Phone wins, and with no country code it degrades to the legacy contract — which carries the
-    // number, not the discarded username.
-    it('resolves phone ahead of username', () => {
-      const result = normalizeTypedIdentifier({ phone: '+12015550123', username: 'someone' });
-
-      expect(result).toEqual({ username: '+12015550123' });
-    });
-
-    it('resolves email when all three hold a value', () => {
-      const result = normalizeTypedIdentifier({
-        email: 'test@example.com',
-        phone: '2015550123',
-        username: 'someone',
-      });
-
-      expect(result).toMatchObject({
-        identifier_type: 'email',
-        identifier_email: 'test@example.com',
-      });
-    });
-
-    it('warns, naming the options that hold a value', () => {
-      normalizeTypedIdentifier({ email: 'test@example.com', username: 'someone' });
-
-      expect(warn).toHaveBeenCalledTimes(1);
-      expect(warn.mock.calls[0][0]).toContain('email, username');
-    });
-
-    it('does not warn when only one of them holds a value', () => {
-      normalizeTypedIdentifier({ email: 'test@example.com', phone: '', username: '  ' });
-
-      expect(warn).not.toHaveBeenCalled();
-    });
-
-    // identifierType names a type for `username`, so the two are one identifier, not two.
-    it('does not warn for a username paired with its identifierType', () => {
-      normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
-
-      expect(warn).not.toHaveBeenCalled();
-    });
-  });
-
   describe('with an identifier type (typed contract)', () => {
     it('maps an email onto the typed fields', () => {
       const result = normalizeTypedIdentifier({
-        username: 'test@example.com',
+        identifier: 'test@example.com',
         identifierType: 'email',
         password: 'P@ssw0rd!',
       });
@@ -226,7 +18,7 @@ describe('normalizeTypedIdentifier', () => {
     });
 
     it('maps a username onto the typed fields', () => {
-      const result = normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
+      const result = normalizeTypedIdentifier({ identifier: 'someone', identifierType: 'username' });
 
       expect(result).toEqual({
         username: 'someone',
@@ -237,7 +29,7 @@ describe('normalizeTypedIdentifier', () => {
 
     it('maps a phone and country onto the typed fields', () => {
       const result = normalizeTypedIdentifier({
-        username: '2015550123',
+        identifier: '2015550123',
         identifierType: 'phone',
         phoneCountryCode: 'US',
       });
@@ -251,27 +43,21 @@ describe('normalizeTypedIdentifier', () => {
     });
 
     it('always submits identifier_type, since the server reads the typed fields only when present', () => {
-      expect(normalizeTypedIdentifier({ username: 'a@b.com', identifierType: 'email' })).toHaveProperty(
+      expect(normalizeTypedIdentifier({ identifier: 'a@b.com', identifierType: 'email' })).toHaveProperty(
         'identifier_type',
         'email'
       );
-      expect(normalizeTypedIdentifier({ username: 'x', identifierType: 'username' })).toHaveProperty(
+      expect(normalizeTypedIdentifier({ identifier: 'x', identifierType: 'username' })).toHaveProperty(
         'identifier_type',
         'username'
       );
       expect(
-        normalizeTypedIdentifier({ username: '123', identifierType: 'phone', phoneCountryCode: 'US' })
+        normalizeTypedIdentifier({ identifier: '123', identifierType: 'phone', phoneCountryCode: 'US' })
       ).toHaveProperty('identifier_type', 'phone');
     });
 
-    it('keeps username so an unflagged tenant falls back to the legacy contract', () => {
-      const result = normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
-
-      expect(result.username).toBe('someone');
-    });
-
-    it('submits only the field for the resolved type', () => {
-      const result = normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
+    it('submits only the field for the named type', () => {
+      const result = normalizeTypedIdentifier({ identifier: 'someone', identifierType: 'username' });
 
       expect(result).not.toHaveProperty('identifier_email');
       expect(result).not.toHaveProperty('identifier_phone');
@@ -280,16 +66,16 @@ describe('normalizeTypedIdentifier', () => {
 
     // A typed phone submission suppresses the server's own country-code prefixing, and the typed
     // path prefixes nothing when the country is missing, so submitting one would send a national
-    // number with no dial code. The legacy contract is the only one that still resolves a country.
-    it('degrades a phone submitted without a country code to the legacy contract', () => {
-      const result = normalizeTypedIdentifier({ username: '+12015550123', identifierType: 'phone' });
+    // number with no dial code. The untyped contract is the only one that still resolves a country.
+    it('degrades a phone submitted without a country code to the untyped contract', () => {
+      const result = normalizeTypedIdentifier({ identifier: '+12015550123', identifierType: 'phone' });
 
       expect(result).toEqual({ username: '+12015550123' });
     });
 
-    it('degrades a phone submitted with a blank country code to the legacy contract', () => {
+    it('degrades a phone submitted with a blank country code to the untyped contract', () => {
       const result = normalizeTypedIdentifier({
-        username: '2015550123',
+        identifier: '2015550123',
         identifierType: 'phone',
         phoneCountryCode: '   ',
       });
@@ -297,9 +83,9 @@ describe('normalizeTypedIdentifier', () => {
       expect(result).toEqual({ username: '2015550123' });
     });
 
-    it('keeps the other payload fields when a phone degrades to the legacy contract', () => {
+    it('keeps the other payload fields when a phone degrades to the untyped contract', () => {
       const result = normalizeTypedIdentifier({
-        username: '+12015550123',
+        identifier: '+12015550123',
         identifierType: 'phone',
         password: 'P@ssw0rd!',
       });
@@ -309,7 +95,7 @@ describe('normalizeTypedIdentifier', () => {
 
     it('drops a country code supplied with a non-phone type, as the server does not read it', () => {
       const result = normalizeTypedIdentifier({
-        username: 'test@example.com',
+        identifier: 'test@example.com',
         identifierType: 'email',
         phoneCountryCode: 'US',
       });
@@ -320,7 +106,7 @@ describe('normalizeTypedIdentifier', () => {
 
     it('preserves the other payload fields', () => {
       const result = normalizeTypedIdentifier({
-        username: 'test@example.com',
+        identifier: 'test@example.com',
         identifierType: 'email',
         password: 'P@ssw0rd!',
         captcha: 'abc',
@@ -336,23 +122,110 @@ describe('normalizeTypedIdentifier', () => {
         customField: 'customValue',
       });
     });
-
-    it('submits an empty identifier when username is absent, rather than omitting the field', () => {
-      const result = normalizeTypedIdentifier({ identifierType: 'email' });
-
-      expect(result).toEqual({ identifier_type: 'email', identifier_email: '' });
-    });
   });
 
-  describe('without an identifier type (legacy contract)', () => {
-    it('leaves the payload untouched', () => {
+  // `identifier` is the name that pairs with `identifierType`; `username` is its original spelling,
+  // still accepted so callers written against the previous contract keep working unchanged. Either
+  // way the value goes out as `username`, the only identifier field the endpoint reads.
+  describe('under either name for the identifier', () => {
+    it('submits the identifier as username', () => {
+      const result = normalizeTypedIdentifier({ identifier: 'someone', identifierType: 'username' });
+
+      expect(result.username).toBe('someone');
+      expect(result).not.toHaveProperty('identifier');
+    });
+
+    it('accepts the username spelling and submits the same payload', () => {
+      const viaIdentifier = normalizeTypedIdentifier({ identifier: 'a@b.com', identifierType: 'email' });
+      const viaUsername = normalizeTypedIdentifier({ username: 'a@b.com', identifierType: 'email' });
+
+      expect(viaUsername).toEqual(viaIdentifier);
+    });
+
+    it('accepts the username spelling on the untyped contract', () => {
       const result = normalizeTypedIdentifier({ username: 'testUser', password: 'P@ssw0rd!' });
 
       expect(result).toEqual({ username: 'testUser', password: 'P@ssw0rd!' });
     });
 
+    it('lets identifier win when both names are supplied', () => {
+      const result = normalizeTypedIdentifier({
+        identifier: 'a@b.com',
+        username: 'stale',
+        identifierType: 'email',
+      });
+
+      expect(result).toEqual({
+        username: 'a@b.com',
+        identifier_type: 'email',
+        identifier_email: 'a@b.com',
+      });
+    });
+
+    it('falls back to username when identifier does not hold a string', () => {
+      const result = normalizeTypedIdentifier({
+        identifier: 12345 as never,
+        username: 'someone',
+        identifierType: 'username',
+      });
+
+      expect(result).toMatchObject({ username: 'someone', identifier_username: 'someone' });
+    });
+  });
+
+  // Submitting the blank identifier typed is what earns the server's `identifier-required` error,
+  // which names the type the user left empty. Dropping the typed fields would earn a vaguer one.
+  describe('with a blank identifier', () => {
+    it('submits it as its type rather than degrading to the untyped contract', () => {
+      const result = normalizeTypedIdentifier({ identifier: '', identifierType: 'email' });
+
+      expect(result).toEqual({ username: '', identifier_type: 'email', identifier_email: '' });
+    });
+
+    it('submits an empty identifier when neither name is supplied, rather than omitting the field', () => {
+      const result = normalizeTypedIdentifier({ identifierType: 'email' });
+
+      expect(result).toEqual({ identifier_type: 'email', identifier_email: '' });
+    });
+
+    it('submits a blank phone as its type once a country code is selected', () => {
+      const result = normalizeTypedIdentifier({
+        identifier: '',
+        identifierType: 'phone',
+        phoneCountryCode: 'US',
+      });
+
+      expect(result).toEqual({
+        username: '',
+        identifier_type: 'phone',
+        identifier_phone: '',
+        identifier_phone_country_code: 'US',
+      });
+    });
+
+    // A blank phone degrades for the same reason a filled one does: no country, no dial code.
+    it('degrades a blank phone with no country code to the untyped contract', () => {
+      const result = normalizeTypedIdentifier({ identifier: '', identifierType: 'phone' });
+
+      expect(result).toEqual({ username: '' });
+    });
+
+    it('treats a non-string identifier as an empty one rather than submitting it typed', () => {
+      const result = normalizeTypedIdentifier({ identifier: 12345 as never, identifierType: 'email' });
+
+      expect(result.identifier_email).toBe('');
+    });
+  });
+
+  describe('without an identifier type (untyped contract)', () => {
+    it('leaves the payload untouched apart from the identifier name', () => {
+      const result = normalizeTypedIdentifier({ identifier: 'testUser', password: 'P@ssw0rd!' });
+
+      expect(result).toEqual({ username: 'testUser', password: 'P@ssw0rd!' });
+    });
+
     it('does not submit any typed field', () => {
-      const result = normalizeTypedIdentifier({ username: 'testUser' });
+      const result = normalizeTypedIdentifier({ identifier: 'testUser' });
 
       expect(result).not.toHaveProperty('identifier_type');
       expect(result).not.toHaveProperty('identifier_email');
@@ -360,28 +233,48 @@ describe('normalizeTypedIdentifier', () => {
       expect(result).not.toHaveProperty('identifier_phone');
     });
 
-    // Unlike `email`/`phone`, a bare `username` names no type. It predates them as the untyped
-    // identifier field, and every caller passing an email address through it would otherwise start
-    // submitting identifier_type: 'username' and be rejected where username is not enabled.
-    it('leaves a bare username untyped even though it is a known identifier name', () => {
-      const result = normalizeTypedIdentifier({ username: 'test@example.com' });
+    // The identifier names no type of its own. Typing it as a username by default would make every
+    // caller passing an email address through it submit identifier_type: 'username' and be rejected
+    // where username is not an enabled identifier.
+    it('leaves a bare identifier untyped even when it holds an email address', () => {
+      const result = normalizeTypedIdentifier({ identifier: 'test@example.com' });
 
       expect(result).toEqual({ username: 'test@example.com' });
     });
 
     it('drops a country code submitted on its own, as no type selects it', () => {
-      const result = normalizeTypedIdentifier({ username: '2015550123', phoneCountryCode: 'US' });
+      const result = normalizeTypedIdentifier({ identifier: '2015550123', phoneCountryCode: 'US' });
 
       expect(result).toEqual({ username: '2015550123' });
     });
 
-    it('degrades an unrecognized identifier type to the legacy contract', () => {
+    it('degrades an unrecognized identifier type to the untyped contract', () => {
       const result = normalizeTypedIdentifier({
-        username: 'testUser',
+        identifier: 'testUser',
         identifierType: 'phone_number' as never,
       });
 
       expect(result).toEqual({ username: 'testUser' });
+    });
+  });
+
+  // The endpoint has no `email` or `phone` field — the identifier is a single value typed by
+  // `identifier_type`. Fields by those names are ordinary custom prompt fields and must be left
+  // alone rather than read as identifier options.
+  it('does not read an email or phone field as an identifier option', () => {
+    const result = normalizeTypedIdentifier({
+      identifier: 'someone',
+      identifierType: 'username',
+      email: 'test@example.com',
+      phone: '2015550123',
+    });
+
+    expect(result).toEqual({
+      username: 'someone',
+      identifier_type: 'username',
+      identifier_username: 'someone',
+      email: 'test@example.com',
+      phone: '2015550123',
     });
   });
 
@@ -423,7 +316,7 @@ describe('normalizeTypedIdentifier', () => {
 
     it('lets the camelCase option win when a caller supplies both spellings', () => {
       const result = normalizeTypedIdentifier({
-        username: 'someone',
+        identifier: 'someone',
         identifierType: 'username',
         identifier_type: 'email',
       });
@@ -437,7 +330,7 @@ describe('normalizeTypedIdentifier', () => {
 
     it('leaves a stale sibling field alone, since identifier_type selects which one is read', () => {
       const result = normalizeTypedIdentifier({
-        username: 'someone',
+        identifier: 'someone',
         identifierType: 'username',
         identifier_email: 'stale@example.com',
       });
@@ -449,27 +342,28 @@ describe('normalizeTypedIdentifier', () => {
     });
   });
 
-  it('never leaves the camelCase options alongside the server fields', () => {
+  it('never leaves the SDK option names alongside the server fields', () => {
     const typed = normalizeTypedIdentifier({
-      username: '2015550123',
+      identifier: '2015550123',
       identifierType: 'phone',
       phoneCountryCode: 'US',
     });
 
+    expect(typed).not.toHaveProperty('identifier');
     expect(typed).not.toHaveProperty('identifierType');
     expect(typed).not.toHaveProperty('phoneCountryCode');
   });
 
   it('does not mutate the payload it was given', () => {
     const payload = {
-      username: '2015550123',
+      identifier: '2015550123',
       identifierType: 'phone' as const,
       phoneCountryCode: 'US',
     };
     normalizeTypedIdentifier(payload);
 
     expect(payload).toEqual({
-      username: '2015550123',
+      identifier: '2015550123',
       identifierType: 'phone',
       phoneCountryCode: 'US',
     });

--- a/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
@@ -51,10 +51,9 @@ describe('normalizeTypedIdentifier', () => {
         'identifier_type',
         'username'
       );
-      expect(normalizeTypedIdentifier({ username: '123', identifierType: 'phone' })).toHaveProperty(
-        'identifier_type',
-        'phone'
-      );
+      expect(
+        normalizeTypedIdentifier({ username: '123', identifierType: 'phone', phoneCountryCode: 'US' })
+      ).toHaveProperty('identifier_type', 'phone');
     });
 
     it('keeps username so an unflagged tenant falls back to the legacy contract', () => {
@@ -71,24 +70,33 @@ describe('normalizeTypedIdentifier', () => {
       expect(result).not.toHaveProperty('identifier_phone_country_code');
     });
 
-    it('omits the country code for a phone submitted without one', () => {
+    // A typed phone submission suppresses the server's own country-code prefixing, and the typed
+    // path prefixes nothing when the country is missing, so submitting one would send a national
+    // number with no dial code. The legacy contract is the only one that still resolves a country.
+    it('degrades a phone submitted without a country code to the legacy contract', () => {
       const result = normalizeTypedIdentifier({ username: '+12015550123', identifierType: 'phone' });
 
-      expect(result).toEqual({
-        username: '+12015550123',
-        identifier_type: 'phone',
-        identifier_phone: '+12015550123',
-      });
+      expect(result).toEqual({ username: '+12015550123' });
     });
 
-    it('omits a blank country code, so the server derives the country itself', () => {
+    it('degrades a phone submitted with a blank country code to the legacy contract', () => {
       const result = normalizeTypedIdentifier({
         username: '2015550123',
         identifierType: 'phone',
         phoneCountryCode: '   ',
       });
 
-      expect(result).not.toHaveProperty('identifier_phone_country_code');
+      expect(result).toEqual({ username: '2015550123' });
+    });
+
+    it('keeps the other payload fields when a phone degrades to the legacy contract', () => {
+      const result = normalizeTypedIdentifier({
+        username: '+12015550123',
+        identifierType: 'phone',
+        password: 'P@ssw0rd!',
+      });
+
+      expect(result).toEqual({ username: '+12015550123', password: 'P@ssw0rd!' });
     });
 
     it('drops a country code supplied with a non-phone type, as the server does not read it', () => {

--- a/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
@@ -1,6 +1,214 @@
 import { normalizeTypedIdentifier } from '../../../src/utils/typed-identifier';
 
 describe('normalizeTypedIdentifier', () => {
+  describe('with a discrete identifier option (typed contract)', () => {
+    it('maps an email onto the typed fields', () => {
+      const result = normalizeTypedIdentifier({ email: 'test@example.com', password: 'P@ssw0rd!' });
+
+      expect(result).toEqual({
+        username: 'test@example.com',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        password: 'P@ssw0rd!',
+      });
+    });
+
+    it('maps a phone and country onto the typed fields', () => {
+      const result = normalizeTypedIdentifier({ phone: '2015550123', phoneCountryCode: 'US' });
+
+      expect(result).toEqual({
+        username: '2015550123',
+        identifier_type: 'phone',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+      });
+    });
+
+    // The endpoint reads neither name, so leaving them in would submit unread fields that the
+    // custom-prompt-field handling would then have to ignore.
+    it('does not submit the discrete option names', () => {
+      const result = normalizeTypedIdentifier({ email: 'test@example.com' });
+
+      expect(result).not.toHaveProperty('email');
+      expect(result).not.toHaveProperty('phone');
+    });
+
+    it('copies the value into username so an unflagged tenant falls back to the legacy contract', () => {
+      expect(normalizeTypedIdentifier({ email: 'test@example.com' }).username).toBe('test@example.com');
+      expect(normalizeTypedIdentifier({ phone: '2015550123', phoneCountryCode: 'US' }).username).toBe(
+        '2015550123'
+      );
+    });
+
+    it('degrades a phone submitted without a country code to the legacy contract', () => {
+      const result = normalizeTypedIdentifier({ phone: '+12015550123', password: 'P@ssw0rd!' });
+
+      expect(result).toEqual({ username: '+12015550123', password: 'P@ssw0rd!' });
+    });
+
+    it('names its own type, superseding a conflicting identifierType', () => {
+      const result = normalizeTypedIdentifier({ email: 'test@example.com', identifierType: 'username' });
+
+      expect(result).toMatchObject({
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+      });
+      expect(result).not.toHaveProperty('identifier_username');
+    });
+
+    // A screen driven by React state may pass every option it renders, leaving the inactive ones as
+    // empty strings. The filled one is the identifier the user actually entered.
+    it('resolves the option holding a value when a blank sibling is also passed', () => {
+      const result = normalizeTypedIdentifier({ email: '', phone: '2015550123', phoneCountryCode: 'US' });
+
+      expect(result).toMatchObject({
+        identifier_type: 'phone',
+        identifier_phone: '2015550123',
+      });
+    });
+
+    // Submitting the blank field typed is what earns the server's `identifier-required` error, which
+    // names the field the user left empty. Dropping it would earn a vaguer one.
+    it('submits a blank option as its type rather than dropping it', () => {
+      const result = normalizeTypedIdentifier({ email: '' });
+
+      expect(result).toEqual({ username: '', identifier_type: 'email', identifier_email: '' });
+    });
+
+    // A blank phone still selects its type, but the typed path prefixes no dial code without a
+    // country, so it degrades like a filled one rather than submitting `identifier_phone: ''`.
+    it('degrades a blank phone with no country code to the legacy contract', () => {
+      const result = normalizeTypedIdentifier({ phone: '' });
+
+      expect(result).toEqual({ username: '' });
+    });
+
+    it('submits a blank phone as its type once a country code selects it', () => {
+      const result = normalizeTypedIdentifier({ phone: '', phoneCountryCode: 'US' });
+
+      expect(result).toEqual({
+        username: '',
+        identifier_type: 'phone',
+        identifier_phone: '',
+        identifier_phone_country_code: 'US',
+      });
+    });
+
+    it('does not let a blank option discard the value another option carries', () => {
+      const result = normalizeTypedIdentifier({ phone: '', username: 'someone', identifierType: 'username' });
+
+      expect(result).toEqual({
+        username: 'someone',
+        identifier_type: 'username',
+        identifier_username: 'someone',
+      });
+    });
+
+    it('preserves the other payload fields', () => {
+      const result = normalizeTypedIdentifier({
+        email: 'test@example.com',
+        password: 'P@ssw0rd!',
+        captcha: 'abc',
+        customField: 'customValue',
+      });
+
+      expect(result).toMatchObject({
+        password: 'P@ssw0rd!',
+        captcha: 'abc',
+        customField: 'customValue',
+      });
+    });
+
+    it('does not mutate the payload it was given', () => {
+      const payload = { phone: '2015550123', phoneCountryCode: 'US' };
+      normalizeTypedIdentifier(payload);
+
+      expect(payload).toEqual({ phone: '2015550123', phoneCountryCode: 'US' });
+    });
+  });
+
+  // Login submits one identifier, so supplying several is a caller mistake. It resolves by
+  // precedence rather than throwing: rejecting would turn a payload the previous contract submitted
+  // into a rejected promise, and screen handlers do not catch one.
+  describe('with more than one identifier option', () => {
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+      warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
+    it('does not throw', () => {
+      expect(() =>
+        normalizeTypedIdentifier({ email: 'test@example.com', phone: '2015550123', username: 'someone' })
+      ).not.toThrow();
+    });
+
+    it('resolves email ahead of phone', () => {
+      const result = normalizeTypedIdentifier({ email: 'test@example.com', phone: '2015550123' });
+
+      expect(result).toEqual({
+        username: 'test@example.com',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+      });
+    });
+
+    it('resolves email ahead of username', () => {
+      const result = normalizeTypedIdentifier({ email: 'test@example.com', username: 'someone' });
+
+      expect(result).toEqual({
+        username: 'test@example.com',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+      });
+    });
+
+    // Phone wins, and with no country code it degrades to the legacy contract — which carries the
+    // number, not the discarded username.
+    it('resolves phone ahead of username', () => {
+      const result = normalizeTypedIdentifier({ phone: '+12015550123', username: 'someone' });
+
+      expect(result).toEqual({ username: '+12015550123' });
+    });
+
+    it('resolves email when all three hold a value', () => {
+      const result = normalizeTypedIdentifier({
+        email: 'test@example.com',
+        phone: '2015550123',
+        username: 'someone',
+      });
+
+      expect(result).toMatchObject({
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+      });
+    });
+
+    it('warns, naming the options that hold a value', () => {
+      normalizeTypedIdentifier({ email: 'test@example.com', username: 'someone' });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('email, username');
+    });
+
+    it('does not warn when only one of them holds a value', () => {
+      normalizeTypedIdentifier({ email: 'test@example.com', phone: '', username: '  ' });
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    // identifierType names a type for `username`, so the two are one identifier, not two.
+    it('does not warn for a username paired with its identifierType', () => {
+      normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('with an identifier type (typed contract)', () => {
     it('maps an email onto the typed fields', () => {
       const result = normalizeTypedIdentifier({
@@ -150,6 +358,15 @@ describe('normalizeTypedIdentifier', () => {
       expect(result).not.toHaveProperty('identifier_email');
       expect(result).not.toHaveProperty('identifier_username');
       expect(result).not.toHaveProperty('identifier_phone');
+    });
+
+    // Unlike `email`/`phone`, a bare `username` names no type. It predates them as the untyped
+    // identifier field, and every caller passing an email address through it would otherwise start
+    // submitting identifier_type: 'username' and be rejected where username is not enabled.
+    it('leaves a bare username untyped even though it is a known identifier name', () => {
+      const result = normalizeTypedIdentifier({ username: 'test@example.com' });
+
+      expect(result).toEqual({ username: 'test@example.com' });
     });
 
     it('drops a country code submitted on its own, as no type selects it', () => {

--- a/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/typed-identifier.test.ts
@@ -1,0 +1,252 @@
+import { normalizeTypedIdentifier } from '../../../src/utils/typed-identifier';
+
+describe('normalizeTypedIdentifier', () => {
+  describe('with an identifier type (typed contract)', () => {
+    it('maps an email onto the typed fields', () => {
+      const result = normalizeTypedIdentifier({
+        username: 'test@example.com',
+        identifierType: 'email',
+        password: 'P@ssw0rd!',
+      });
+
+      expect(result).toEqual({
+        username: 'test@example.com',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        password: 'P@ssw0rd!',
+      });
+    });
+
+    it('maps a username onto the typed fields', () => {
+      const result = normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
+
+      expect(result).toEqual({
+        username: 'someone',
+        identifier_type: 'username',
+        identifier_username: 'someone',
+      });
+    });
+
+    it('maps a phone and country onto the typed fields', () => {
+      const result = normalizeTypedIdentifier({
+        username: '2015550123',
+        identifierType: 'phone',
+        phoneCountryCode: 'US',
+      });
+
+      expect(result).toEqual({
+        username: '2015550123',
+        identifier_type: 'phone',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+      });
+    });
+
+    it('always submits identifier_type, since the server reads the typed fields only when present', () => {
+      expect(normalizeTypedIdentifier({ username: 'a@b.com', identifierType: 'email' })).toHaveProperty(
+        'identifier_type',
+        'email'
+      );
+      expect(normalizeTypedIdentifier({ username: 'x', identifierType: 'username' })).toHaveProperty(
+        'identifier_type',
+        'username'
+      );
+      expect(normalizeTypedIdentifier({ username: '123', identifierType: 'phone' })).toHaveProperty(
+        'identifier_type',
+        'phone'
+      );
+    });
+
+    it('keeps username so an unflagged tenant falls back to the legacy contract', () => {
+      const result = normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
+
+      expect(result.username).toBe('someone');
+    });
+
+    it('submits only the field for the resolved type', () => {
+      const result = normalizeTypedIdentifier({ username: 'someone', identifierType: 'username' });
+
+      expect(result).not.toHaveProperty('identifier_email');
+      expect(result).not.toHaveProperty('identifier_phone');
+      expect(result).not.toHaveProperty('identifier_phone_country_code');
+    });
+
+    it('omits the country code for a phone submitted without one', () => {
+      const result = normalizeTypedIdentifier({ username: '+12015550123', identifierType: 'phone' });
+
+      expect(result).toEqual({
+        username: '+12015550123',
+        identifier_type: 'phone',
+        identifier_phone: '+12015550123',
+      });
+    });
+
+    it('omits a blank country code, so the server derives the country itself', () => {
+      const result = normalizeTypedIdentifier({
+        username: '2015550123',
+        identifierType: 'phone',
+        phoneCountryCode: '   ',
+      });
+
+      expect(result).not.toHaveProperty('identifier_phone_country_code');
+    });
+
+    it('drops a country code supplied with a non-phone type, as the server does not read it', () => {
+      const result = normalizeTypedIdentifier({
+        username: 'test@example.com',
+        identifierType: 'email',
+        phoneCountryCode: 'US',
+      });
+
+      expect(result).not.toHaveProperty('identifier_phone_country_code');
+      expect(result).not.toHaveProperty('phoneCountryCode');
+    });
+
+    it('preserves the other payload fields', () => {
+      const result = normalizeTypedIdentifier({
+        username: 'test@example.com',
+        identifierType: 'email',
+        password: 'P@ssw0rd!',
+        captcha: 'abc',
+        customField: 'customValue',
+      });
+
+      expect(result).toEqual({
+        username: 'test@example.com',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        password: 'P@ssw0rd!',
+        captcha: 'abc',
+        customField: 'customValue',
+      });
+    });
+
+    it('submits an empty identifier when username is absent, rather than omitting the field', () => {
+      const result = normalizeTypedIdentifier({ identifierType: 'email' });
+
+      expect(result).toEqual({ identifier_type: 'email', identifier_email: '' });
+    });
+  });
+
+  describe('without an identifier type (legacy contract)', () => {
+    it('leaves the payload untouched', () => {
+      const result = normalizeTypedIdentifier({ username: 'testUser', password: 'P@ssw0rd!' });
+
+      expect(result).toEqual({ username: 'testUser', password: 'P@ssw0rd!' });
+    });
+
+    it('does not submit any typed field', () => {
+      const result = normalizeTypedIdentifier({ username: 'testUser' });
+
+      expect(result).not.toHaveProperty('identifier_type');
+      expect(result).not.toHaveProperty('identifier_email');
+      expect(result).not.toHaveProperty('identifier_username');
+      expect(result).not.toHaveProperty('identifier_phone');
+    });
+
+    it('drops a country code submitted on its own, as no type selects it', () => {
+      const result = normalizeTypedIdentifier({ username: '2015550123', phoneCountryCode: 'US' });
+
+      expect(result).toEqual({ username: '2015550123' });
+    });
+
+    it('degrades an unrecognized identifier type to the legacy contract', () => {
+      const result = normalizeTypedIdentifier({
+        username: 'testUser',
+        identifierType: 'phone_number' as never,
+      });
+
+      expect(result).toEqual({ username: 'testUser' });
+    });
+  });
+
+  // Before these options existed, the only way to reach the typed contract was to pass the server's
+  // snake_case field names straight through `LoginOptions`' index signature. Consumers may already
+  // be doing that, so those fields must keep flowing through untouched.
+  describe('with the server field names passed directly (pre-existing workaround)', () => {
+    it('passes a hand-built email submission through untouched', () => {
+      const result = normalizeTypedIdentifier({
+        username: 'test@example.com',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        password: 'P@ssw0rd!',
+      });
+
+      expect(result).toEqual({
+        username: 'test@example.com',
+        identifier_type: 'email',
+        identifier_email: 'test@example.com',
+        password: 'P@ssw0rd!',
+      });
+    });
+
+    it('passes a hand-built phone submission through untouched', () => {
+      const result = normalizeTypedIdentifier({
+        username: '2015550123',
+        identifier_type: 'phone',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+      });
+
+      expect(result).toEqual({
+        username: '2015550123',
+        identifier_type: 'phone',
+        identifier_phone: '2015550123',
+        identifier_phone_country_code: 'US',
+      });
+    });
+
+    it('lets the camelCase option win when a caller supplies both spellings', () => {
+      const result = normalizeTypedIdentifier({
+        username: 'someone',
+        identifierType: 'username',
+        identifier_type: 'email',
+      });
+
+      // The mapped value is applied after the caller's fields are spread, so it takes precedence.
+      expect(result).toMatchObject({
+        identifier_type: 'username',
+        identifier_username: 'someone',
+      });
+    });
+
+    it('leaves a stale sibling field alone, since identifier_type selects which one is read', () => {
+      const result = normalizeTypedIdentifier({
+        username: 'someone',
+        identifierType: 'username',
+        identifier_email: 'stale@example.com',
+      });
+
+      // Not stripped: the server reads only the field its identifier_type names, so the stray value
+      // is inert. Documented here so the behaviour is a deliberate contract rather than a surprise.
+      expect(result.identifier_email).toBe('stale@example.com');
+      expect(result.identifier_type).toBe('username');
+    });
+  });
+
+  it('never leaves the camelCase options alongside the server fields', () => {
+    const typed = normalizeTypedIdentifier({
+      username: '2015550123',
+      identifierType: 'phone',
+      phoneCountryCode: 'US',
+    });
+
+    expect(typed).not.toHaveProperty('identifierType');
+    expect(typed).not.toHaveProperty('phoneCountryCode');
+  });
+
+  it('does not mutate the payload it was given', () => {
+    const payload = {
+      username: '2015550123',
+      identifierType: 'phone' as const,
+      phoneCountryCode: 'US',
+    };
+    normalizeTypedIdentifier(payload);
+
+    expect(payload).toEqual({
+      username: '2015550123',
+      identifierType: 'phone',
+      phoneCountryCode: 'US',
+    });
+  });
+});

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -558,7 +558,7 @@ const TypedLoginId: React.FC = () => {
 export default TypedLoginId;
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode`. `useCountryCodes` gives you the list, so you can render the selector inline instead of routing the user through `pickCountryCode()` and a separate screen. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. `useCountryCodes` gives you the list, so you can render the selector inline instead of routing the user through `pickCountryCode()`, whose selection a typed submission ignores. The server prefixes that country's dial code, so `username` should be the national number *without* one.
 
 ```tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -534,7 +534,7 @@ const TypedLoginId: React.FC = () => {
 
   return (
     <div>
-      {allowed.map((type) => (
+      {allowed?.map((type) => (
         <button
           key={type}
           onClick={() =>

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -520,9 +520,9 @@ export default LoginIdScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
 
-`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
+Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
 
 ```tsx
 import React, { useRef } from 'react';
@@ -542,12 +542,12 @@ const TypedLoginId: React.FC = () => {
         <button
           key={type}
           onClick={() => {
-            const value = identifierRef.current?.value ?? '';
-
-            // `email` and `phone` name their own type; `username` needs `identifierType`.
-            if (type === 'email') login({ email: value });
-            else if (type === 'phone') login({ phone: value, phoneCountryCode });
-            else login({ username: value, identifierType: 'username' });
+            // One identifier, typed by `identifierType`; only a phone reads a country.
+            login({
+              identifier: identifierRef.current?.value ?? '',
+              identifierType: type,
+              ...(type === 'phone' ? { phoneCountryCode } : {}),
+            });
           }}
         >
           Continue with {type}
@@ -562,7 +562,7 @@ const TypedLoginId: React.FC = () => {
 export default TypedLoginId;
 ```
 
-For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`; `useCountryCodes` gives you the list, so you can render the selector inline instead of using `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
+For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list, so you can render the selector inline instead of using `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
 
 ```tsx
 import React, { useState } from 'react';
@@ -579,7 +579,8 @@ const PhoneLoginId: React.FC = () => {
 
   const handleContinue = () => {
     login({
-      phone, // national number, e.g. "2015550123"
+      identifier: phone, // national number, e.g. "2015550123"
+      identifierType: 'phone',
       phoneCountryCode, // ISO 3166-1 alpha-2, e.g. "US"
     });
   };
@@ -611,4 +612,4 @@ export default PhoneLoginId;
 
 Submit only a type the tenant actually allows — one of `useLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `identifier` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -517,3 +517,95 @@ const LoginIdScreenWithActiveIdentifier: React.FC = () => {
 
 export default LoginIdScreenWithActiveIdentifier;
 ```
+
+### Example telling the server which identifier the user chose
+
+`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+
+Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `useLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number.
+
+The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
+
+```tsx
+import React, { useRef } from 'react';
+import { useLoginIdentifiers, login } from '@auth0/auth0-acul-react/login-id';
+
+const TypedLoginId: React.FC = () => {
+  const allowed = useLoginIdentifiers();
+  const identifierRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div>
+      {allowed.map((type) => (
+        <button
+          key={type}
+          onClick={() =>
+            login({
+              username: identifierRef.current?.value ?? '',
+              identifierType: type,
+            })
+          }
+        >
+          Continue with {type}
+        </button>
+      ))}
+
+      <input id="identifier" ref={identifierRef} type="text" />
+    </div>
+  );
+};
+
+export default TypedLoginId;
+```
+
+For a phone identifier, also pass the selected country as `phoneCountryCode`. `useCountryCodes` gives you the list, so you can render the selector inline instead of routing the user through `pickCountryCode()` and a separate screen. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code.
+
+```tsx
+import React, { useState } from 'react';
+import { useCountryCodes, login } from '@auth0/auth0-acul-react/login-id';
+
+const PhoneLoginId: React.FC = () => {
+  const countryCodes = useCountryCodes();
+
+  const [username, setUsername] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const handleContinue = () => {
+    login({
+      username, // national number, e.g. "2015550123"
+      identifierType: 'phone',
+      phoneCountryCode, // ISO 3166-1 alpha-2, e.g. "US"
+    });
+  };
+
+  return (
+    <div>
+      <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+        {countryCodes?.available?.map(({ code, label, dialCode }) => (
+          <option key={code} value={code}>
+            {label} ({dialCode})
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="tel"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="Enter your phone number"
+      />
+
+      <button onClick={handleContinue}>Continue</button>
+    </div>
+  );
+};
+
+export default PhoneLoginId;
+```
+
+Submit only a type the tenant actually allows — one of `useLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -485,7 +485,7 @@ export default LoginIdScreenWithGoogleOneTap;
 ```
 ### Example using activeIdentifierType
 
-When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+`screen.data.activeIdentifierType` is the input the server resolved, for first paint. It is `undefined` when none was resolved, so supply your own default.
 
 ```tsx
 import React, { useRef } from 'react';
@@ -520,9 +520,9 @@ export default LoginIdScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
+`activeIdentifierType` says which input to *render*; `identifierType` says which one the user *entered*. Pass it when your screen lets the user pick — tabs, a dropdown, or `useLoginIdentifiers()`.
 
-Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
+The value goes in `identifier`, and `identifierType` names what it holds. Omit the type and the identifier is submitted on its own, as before. `username` still works in `identifier`'s place.
 
 ```tsx
 import React, { useRef } from 'react';
@@ -562,7 +562,7 @@ const TypedLoginId: React.FC = () => {
 export default TypedLoginId;
 ```
 
-For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list, so you can render the selector inline instead of using `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
+For a phone, pass the national number as `identifier` and the country as `phoneCountryCode` (from `useCountryCodes`, rendered inline). The dial code is added server-side. A typed submission ignores any `pickCountryCode()` selection.
 
 ```tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -520,11 +520,9 @@ export default LoginIdScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
 
-Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `useLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number.
-
-The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
+The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
 
 ```tsx
 import React, { useRef } from 'react';
@@ -558,7 +556,7 @@ const TypedLoginId: React.FC = () => {
 export default TypedLoginId;
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. `useCountryCodes` gives you the list, so you can render the selector inline instead of routing the user through `pickCountryCode()`, whose selection a typed submission ignores. The server prefixes that country's dial code, so `username` should be the national number *without* one.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list, so you can render the selector inline instead of using `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so `username` should be the national number *without* one.
 
 ```tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-react/examples/login-id.md
+++ b/packages/auth0-acul-react/examples/login-id.md
@@ -520,29 +520,35 @@ export default LoginIdScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
+`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape, though on this screen the shape still decides which authentication method the user is routed to.
 
-The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
+`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
 
 ```tsx
 import React, { useRef } from 'react';
-import { useLoginIdentifiers, login } from '@auth0/auth0-acul-react/login-id';
+import { useCountryCodes, useLoginIdentifiers, login } from '@auth0/auth0-acul-react/login-id';
 
 const TypedLoginId: React.FC = () => {
   const allowed = useLoginIdentifiers();
+  const countryCodes = useCountryCodes();
   const identifierRef = useRef<HTMLInputElement>(null);
+
+  // Only used for a phone identifier — see the country selector example below.
+  const phoneCountryCode = countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? '';
 
   return (
     <div>
       {allowed?.map((type) => (
         <button
           key={type}
-          onClick={() =>
-            login({
-              username: identifierRef.current?.value ?? '',
-              identifierType: type,
-            })
-          }
+          onClick={() => {
+            const value = identifierRef.current?.value ?? '';
+
+            // `email` and `phone` name their own type; `username` needs `identifierType`.
+            if (type === 'email') login({ email: value });
+            else if (type === 'phone') login({ phone: value, phoneCountryCode });
+            else login({ username: value, identifierType: 'username' });
+          }}
         >
           Continue with {type}
         </button>
@@ -556,7 +562,7 @@ const TypedLoginId: React.FC = () => {
 export default TypedLoginId;
 ```
 
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list, so you can render the selector inline instead of using `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so `username` should be the national number *without* one.
+For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`; `useCountryCodes` gives you the list, so you can render the selector inline instead of using `pickCountryCode()`, whose selection a typed submission ignores. Its dial code is prefixed server-side, so the number should carry none.
 
 ```tsx
 import React, { useState } from 'react';
@@ -565,7 +571,7 @@ import { useCountryCodes, login } from '@auth0/auth0-acul-react/login-id';
 const PhoneLoginId: React.FC = () => {
   const countryCodes = useCountryCodes();
 
-  const [username, setUsername] = useState('');
+  const [phone, setPhone] = useState('');
   // `recommended` is the server's suggested default; fall back to the first available country.
   const [phoneCountryCode, setPhoneCountryCode] = useState(
     countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
@@ -573,8 +579,7 @@ const PhoneLoginId: React.FC = () => {
 
   const handleContinue = () => {
     login({
-      username, // national number, e.g. "2015550123"
-      identifierType: 'phone',
+      phone, // national number, e.g. "2015550123"
       phoneCountryCode, // ISO 3166-1 alpha-2, e.g. "US"
     });
   };
@@ -591,8 +596,8 @@ const PhoneLoginId: React.FC = () => {
 
       <input
         type="tel"
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
         placeholder="Enter your phone number"
       />
 

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -391,3 +391,93 @@ const LoginScreenWithActiveIdentifier: React.FC = () => {
 
 export default LoginScreenWithActiveIdentifier;
 ```
+
+### Example telling the server which identifier the user chose
+
+`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+
+Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `useLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number and an address-shaped username is not mistaken for an email.
+
+The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
+
+For a phone identifier, also pass the selected country as `phoneCountryCode`. `useCountryCodes` gives you the list. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code. Omitting `phoneCountryCode` lets the server derive the country itself.
+
+```tsx
+import React, { useState } from 'react';
+import {
+  useScreen,
+  useCountryCodes,
+  useLoginIdentifiers,
+  login,
+} from '@auth0/auth0-acul-react/login';
+
+const TypedLogin: React.FC = () => {
+  const screen = useScreen();
+  const countryCodes = useCountryCodes();
+  const allowed = useLoginIdentifiers();
+
+  // Start on the identifier the server resolved, falling back to the first the tenant allows.
+  const [identifierType, setIdentifierType] = useState(
+    screen.data?.activeIdentifierType ?? allowed[0] ?? 'email'
+  );
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  // `recommended` is the server's suggested default; fall back to the first available country.
+  const [phoneCountryCode, setPhoneCountryCode] = useState(
+    countryCodes?.recommended ?? countryCodes?.available?.[0]?.code ?? ''
+  );
+
+  const handleLogin = () => {
+    login({
+      username, // national number when identifierType is 'phone', e.g. "2015550123"
+      password,
+      identifierType,
+      // Only read for a phone identifier; harmless to leave off otherwise.
+      ...(identifierType === 'phone' && phoneCountryCode ? { phoneCountryCode } : {}),
+    });
+  };
+
+  return (
+    <div>
+      {/* One tab per identifier the tenant allows */}
+      {allowed.map((type) => (
+        <button key={type} type="button" onClick={() => setIdentifierType(type)}>
+          {type}
+        </button>
+      ))}
+
+      {identifierType === 'phone' && countryCodes?.available && (
+        <select value={phoneCountryCode} onChange={(e) => setPhoneCountryCode(e.target.value)}>
+          {countryCodes.available.map(({ code, label, dialCode }) => (
+            <option key={code} value={code}>
+              {label} ({dialCode})
+            </option>
+          ))}
+        </select>
+      )}
+
+      <input
+        type={identifierType === 'phone' ? 'tel' : 'text'}
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder={`Enter your ${identifierType}`}
+      />
+
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        autoComplete="current-password"
+      />
+
+      <button onClick={handleLogin}>Continue</button>
+    </div>
+  );
+};
+
+export default TypedLogin;
+```
+
+Submit only a type the tenant actually allows — one of `useLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
+
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -394,11 +394,11 @@ export default LoginScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
 
-`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
+Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
 
-For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`; `useCountryCodes` gives you the list. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
+For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
 
 ```tsx
 import React, { useState } from 'react';
@@ -426,15 +426,14 @@ const TypedLogin: React.FC = () => {
   );
 
   const handleLogin = () => {
-    // `email` and `phone` name their own type; `username` needs `identifierType` to be read as one.
-    const typedIdentifier =
-      identifierType === 'email'
-        ? { email: identifier }
-        : identifierType === 'phone'
-          ? { phone: identifier, phoneCountryCode } // national number, e.g. "2015550123"
-          : { username: identifier, identifierType: 'username' as const };
-
-    login({ ...typedIdentifier, password });
+    // One identifier, typed by `identifierType` — the same shape whichever tab is active.
+    login({
+      identifier, // for a phone, the national number, e.g. "2015550123"
+      identifierType,
+      // Only a phone identifier reads a country.
+      ...(identifierType === 'phone' ? { phoneCountryCode } : {}),
+      password,
+    });
   };
 
   return (
@@ -480,4 +479,4 @@ export default TypedLogin;
 
 Submit only a type the tenant actually allows — one of `useLoginIdentifiers()`. The server rejects a type that is not enabled for the connection, and the values line up exactly, so an entry from that array can be passed straight through as `identifierType`.
 
-`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `username` on its own, or keep using `pickCountryCode()`.
+`countryCodes` is `null` when the server does not provide the list. In that case render your own phone input and submit `identifier` on its own, or keep using `pickCountryCode()`.

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -394,13 +394,11 @@ export default LoginScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` above tells you which input to *render*. `identifierType` is the other half: it tells the server which input the user actually *submitted*.
+`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
 
-Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or a single input resolved from `useLoginIdentifiers()`. The submitted type is then authoritative: the server reads the value as that type instead of inferring one from its shape, so an all-digits username is not mistaken for a phone number and an address-shaped username is not mistaken for an email.
+The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
 
-The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
-
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. `useCountryCodes` gives you the list. The server prefixes that country's dial code, so `username` should be the national number *without* one. Leave it off and the submission falls back to the untyped contract, where `username` must carry its own dial code: a typed phone submission suppresses the server's own country lookup, including any `pickCountryCode()` selection.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list. Its dial code is prefixed server-side, so `username` should be the national number *without* one. Leave it off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
 
 ```tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -416,7 +416,7 @@ const TypedLogin: React.FC = () => {
 
   // Start on the identifier the server resolved, falling back to the first the tenant allows.
   const [identifierType, setIdentifierType] = useState(
-    screen.data?.activeIdentifierType ?? allowed[0] ?? 'email'
+    screen.data?.activeIdentifierType ?? allowed?.[0] ?? 'email'
   );
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -394,11 +394,11 @@ export default LoginScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which one the user *submitted*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
+`activeIdentifierType` tells you which input to *render*; the identifier option you submit tells the server which one the user *entered*. Pass one when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
 
-The value always goes in `username`, whatever the type. Omit `identifierType` and `username` is submitted on its own, as before, with the server inferring the type.
+`email` and `phone` name their own type. `username` is the generic field, so it needs `identifierType`; on its own it is submitted untyped, as before, with the server inferring the type. Pass only one of the three — login submits a single identifier.
 
-For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list. Its dial code is prefixed server-side, so `username` should be the national number *without* one. Leave it off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
+For a phone identifier, pass the national number as `phone` and the selected country as `phoneCountryCode` — required with `phone`; `useCountryCodes` gives you the list. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
 
 ```tsx
 import React, { useState } from 'react';
@@ -418,7 +418,7 @@ const TypedLogin: React.FC = () => {
   const [identifierType, setIdentifierType] = useState(
     screen.data?.activeIdentifierType ?? allowed?.[0] ?? 'email'
   );
-  const [username, setUsername] = useState('');
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   // `recommended` is the server's suggested default; fall back to the first available country.
   const [phoneCountryCode, setPhoneCountryCode] = useState(
@@ -426,13 +426,15 @@ const TypedLogin: React.FC = () => {
   );
 
   const handleLogin = () => {
-    login({
-      username, // national number when identifierType is 'phone', e.g. "2015550123"
-      password,
-      identifierType,
-      // Required for a phone identifier; ignored for the other types.
-      ...(identifierType === 'phone' ? { phoneCountryCode } : {}),
-    });
+    // `email` and `phone` name their own type; `username` needs `identifierType` to be read as one.
+    const typedIdentifier =
+      identifierType === 'email'
+        ? { email: identifier }
+        : identifierType === 'phone'
+          ? { phone: identifier, phoneCountryCode } // national number, e.g. "2015550123"
+          : { username: identifier, identifierType: 'username' as const };
+
+    login({ ...typedIdentifier, password });
   };
 
   return (
@@ -456,8 +458,8 @@ const TypedLogin: React.FC = () => {
 
       <input
         type={identifierType === 'phone' ? 'tel' : 'text'}
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
         placeholder={`Enter your ${identifierType}`}
       />
 

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -400,7 +400,7 @@ Pass it when your screen lets the user pick the identifier — tabs, a dropdown,
 
 The value always goes in `username`, whatever type it represents — `identifierType` only says how to read it. Omit `identifierType` to keep the existing behaviour, where `username` is submitted on its own and the server infers what it is.
 
-For a phone identifier, also pass the selected country as `phoneCountryCode`. `useCountryCodes` gives you the list. The submitted country is authoritative: the server prefixes its dial code rather than inferring a country from the digits or from geo-IP, so `username` should be the national number *without* a dial code. Omitting `phoneCountryCode` lets the server derive the country itself.
+For a phone identifier, also pass the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`. `useCountryCodes` gives you the list. The server prefixes that country's dial code, so `username` should be the national number *without* one. Leave it off and the submission falls back to the untyped contract, where `username` must carry its own dial code: a typed phone submission suppresses the server's own country lookup, including any `pickCountryCode()` selection.
 
 ```tsx
 import React, { useState } from 'react';
@@ -432,8 +432,8 @@ const TypedLogin: React.FC = () => {
       username, // national number when identifierType is 'phone', e.g. "2015550123"
       password,
       identifierType,
-      // Only read for a phone identifier; harmless to leave off otherwise.
-      ...(identifierType === 'phone' && phoneCountryCode ? { phoneCountryCode } : {}),
+      // Required for a phone identifier; ignored for the other types.
+      ...(identifierType === 'phone' ? { phoneCountryCode } : {}),
     });
   };
 

--- a/packages/auth0-acul-react/examples/login.md
+++ b/packages/auth0-acul-react/examples/login.md
@@ -350,7 +350,7 @@ export default LoginScreenWithGoogleOneTap;
 ```
 ### Example using activeIdentifierType
 
-When a tenant allows multiple identifiers, `screen.data.activeIdentifierType` tells you which input the server resolved so you can render it on first paint. It is `undefined` when the server has not resolved one, so fall back to your own default rather than assuming `email`.
+`screen.data.activeIdentifierType` is the input the server resolved, for first paint. It is `undefined` when none was resolved, so supply your own default.
 
 ```tsx
 import React, { useRef } from 'react';
@@ -394,11 +394,11 @@ export default LoginScreenWithActiveIdentifier;
 
 ### Example telling the server which identifier the user chose
 
-`activeIdentifierType` tells you which input to *render*; `identifierType` tells the server which identifier the user *entered*. Pass it when your screen lets the user pick the identifier — tabs, a dropdown, or an input resolved from `useLoginIdentifiers()` — and the server reads the value as that type instead of inferring one from its shape.
+`activeIdentifierType` says which input to *render*; `identifierType` says which one the user *entered*. Pass it when your screen lets the user pick — tabs, a dropdown, or `useLoginIdentifiers()`.
 
-Login submits a single identifier, so it stays denormalized: the value goes in `identifier` and `identifierType` names what it holds. Omit `identifierType` and the identifier is submitted on its own, exactly as before, with the server inferring the type. `username` is `identifier`'s original spelling and is still accepted in its place, so payloads written against the previous contract keep working unchanged.
+The value goes in `identifier`, and `identifierType` names what it holds. Omit the type and the identifier is submitted on its own, as before. `username` still works in `identifier`'s place.
 
-For a phone identifier, pass the national number as `identifier` and the selected country as `phoneCountryCode` — required with `identifierType: 'phone'`; `useCountryCodes` gives you the list. Its dial code is prefixed server-side, so the number should carry none. Leave the country off and the submission degrades to the untyped contract, which prefixes a `pickCountryCode()` selection only on a phone-only connection.
+For a phone, pass the national number as `identifier` and the country as `phoneCountryCode` (from `useCountryCodes`). The dial code is added server-side. Without a country the submission falls back to untyped.
 
 ```tsx
 import React, { useState } from 'react';


### PR DESCRIPTION


## Description

Adds the typed identifier contract to `login()` on the `login` and `login-id` screens, and extends it to phone signup on the `signup` screen.

- **`identifier`**: the identifier value. `username` is its original spelling and still accepted, so existing payloads keep working. `identifier` wins when both are given.
- **`identifierType`**: `'email' | 'phone' | 'username'`. Makes the type authoritative, so the server reads the value as that type instead of inferring one from its shape. An all-digits username is no longer taken for a phone number.
- **`phoneCountryCode`**: ISO 3166-1 alpha-2 country, required with `identifierType: 'phone'`.

Omit `identifierType` and nothing changes: the value is submitted on its own, as before. The value always goes out as `username` alongside the typed fields, so a tenant without typed processing degrades to the existing contract instead of failing on a missing identifier.

## Examples

```ts
await loginManager.login({
  identifier: 'someone@example.com',
  password: 'P@$$wOrd123!',
  identifierType: 'email',
});
// submits username=someone@example.com, identifier_type=email,
//         identifier_email=someone@example.com

await loginManager.login({
  identifier: 'someone',
  password: 'P@$$wOrd123!',
  identifierType: 'username',
});
// submits username=someone, identifier_type=username, identifier_username=someone

await loginManager.login({
  identifier: '2015550123', // national number, no dial code
  password: 'P@$$wOrd123!',
  identifierType: 'phone',
  phoneCountryCode: 'US',
});
// submits username=2015550123, identifier_type=phone,
//         identifier_phone=2015550123, identifier_phone_country_code=US

await loginManager.login({ identifier: 'someone', password: 'P@$$wOrd123!' });
// submits username=someone, with no typed fields
```

Falls back to the untyped contract when `identifierType` names no supported type, and for `'phone'` with no country, since a typed phone suppresses the server's prefixing and would match no user.

## Signup

`signup` and `signup-id` now share one normalizer, which maps their phone option onto the field names the signup endpoint reads and adds `phoneCountryCode` support:

```ts
signupManager.signup({ phoneNumber: '620936400', phoneCountryCode: 'ES', password: '…' });
// submits phone_number=620936400, identifier_phone=620936400,
//         identifier_phone_country_code=ES

signupManager.signup({ phoneNumber: '+34620936400', password: '…' });
// submits phone_number=+34620936400
```

`phone_number` rides along on every path that carries a number. That is deliberate: `normalizeTypedBody` returns early without setting `body.phone_number` for `strategy === 'sms'` and for non-string typed fields.

## Country codes

`countryCodes.available` is `null` unless the screen's rendering configuration asks for it: `{ "context_configuration": ["country_codes"] }`. `code` is not unique across the list, since a country with several dial codes contributes one entry per code, so rendered lists key on `code` and `dialCode` together.

## Testing

- New `typed-identifier` suite at 100% coverage: the contract per type, `identifier`/`username` precedence, blank country code, country code with a non-phone type, unrecognized type degrading, no payload mutation.
- New `login` and `login-id` cases asserting the exact wire payload per type, and that an unchanged call still submits `username` alone.
- `phone-identifier` at 100% coverage, extended for the composite submission and for a blank phone submitting neither spelling.
- Cases covering an explicitly passed `phone_number` reaching the wire unchanged.
- Full suite green. `tsc --noEmit` and TypeDoc clean, 0 warnings, down from 4.
