### PR TITLE
fix: populate `textCode` on the `device-code-confirmation` screen

### DIFF
--- a/packages/auth0-acul-js/interfaces/screens/device-code-confirmation.ts
+++ b/packages/auth0-acul-js/interfaces/screens/device-code-confirmation.ts
@@ -7,7 +7,18 @@ import type { ScreenMembers } from '../models/screen';
  */
 export interface ScreenMembersOnDeviceCodeConfirmation extends ScreenMembers {
   data: {
+    /**
+     * The code the user must confirm on the device.
+     */
     textCode: string;
+    /**
+     * The same value as {@link textCode}, under the raw key used by the Universal Login context.
+     *
+     * @deprecated Use `textCode`. This key is retained only because `textCode` was
+     * unpopulated in versions up to 1.6.0, so existing integrations read the raw
+     * `text_code` instead. It will be removed in the next major version.
+     */
+    text_code: string;
   } | null;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/device-code-confirmation.ts
+++ b/packages/auth0-acul-js/interfaces/screens/device-code-confirmation.ts
@@ -15,8 +15,8 @@ export interface ScreenMembersOnDeviceCodeConfirmation extends ScreenMembers {
      * The same value as {@link textCode}, under the raw key used by the Universal Login context.
      *
      * @deprecated Use `textCode`. This key is retained only because `textCode` was
-     * unpopulated in versions up to 1.6.0, so existing integrations read the raw
-     * `text_code` instead. It will be removed in the next major version.
+     * unpopulated in versions up to and including 1.7.0, so existing integrations read
+     * the raw `text_code` instead. It will be removed in the next major version.
      */
     text_code: string;
   } | null;

--- a/packages/auth0-acul-js/interfaces/screens/device-code-confirmation.ts
+++ b/packages/auth0-acul-js/interfaces/screens/device-code-confirmation.ts
@@ -12,7 +12,7 @@ export interface ScreenMembersOnDeviceCodeConfirmation extends ScreenMembers {
      */
     textCode: string;
     /**
-     * The same value as {@link textCode}, under the raw key used by the Universal Login context.
+     * The same value as `textCode`, under the raw key used by the Universal Login context.
      *
      * @deprecated Use `textCode`. This key is retained only because `textCode` was
      * unpopulated in versions up to and including 1.7.0, so existing integrations read

--- a/packages/auth0-acul-js/src/screens/device-code-confirmation/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/device-code-confirmation/screen-override.ts
@@ -8,20 +8,24 @@ export class ScreenOverride extends Screen implements OverrideOptions {
 
   constructor(screenContext: ScreenContext) {
     super(screenContext);
-    this.data = Screen.getScreenData(screenContext) as OverrideOptions['data'];
+    this.data = ScreenOverride.getScreenData(screenContext);
   }
 
   /**
    * Extracts and transforms the screen data from the context
    * @param screenContext The screen context containing the data
-   * @returns The transformed screen data
+   * @returns The transformed screen data, exposing the code as `textCode` and, for
+   *          backward compatibility, under the raw `text_code` key as well
    */
   static getScreenData = (screenContext: ScreenContext): OverrideOptions['data'] => {
     const data = screenContext.data;
     if (!data) return null;
 
+    const textCode = typeof data.text_code === 'string' ? data.text_code : '';
+
     return {
-      textCode: typeof data.text_code === 'string' ? data.text_code : '',
+      textCode,
+      text_code: textCode,
     };
   };
 }

--- a/packages/auth0-acul-js/tests/unit/screens/device-code-confirmation/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/device-code-confirmation/index.test.ts
@@ -12,6 +12,7 @@ describe('DeviceCodeConfirmation', () => {
   beforeEach(() => {
     global.window = Object.create(window);
     baseContextData.screen.name = ScreenIds.DEVICE_CODE_CONFIRMATION;
+    baseContextData.screen.data = { text_code: 'ABC123' } as unknown as typeof baseContextData.screen.data;
     window.universal_login_context = baseContextData;
 
     mockFormHandler = {
@@ -29,6 +30,14 @@ describe('DeviceCodeConfirmation', () => {
 
   it('should create an instance of DeviceCodeConfirmation', () => {
     expect(deviceCodeConfirmation).toBeInstanceOf(DeviceCodeConfirmation);
+  });
+
+  it('should expose the screen data through the ScreenOverride', () => {
+    expect(deviceCodeConfirmation.screen.data?.textCode).toBe('ABC123');
+  });
+
+  it('should keep exposing the code under the deprecated text_code key', () => {
+    expect(deviceCodeConfirmation.screen.data?.text_code).toBe('ABC123');
   });
 
   describe('confirm', () => {

--- a/packages/auth0-acul-js/tests/unit/screens/device-code-confirmation/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/device-code-confirmation/screen-override.test.ts
@@ -1,5 +1,6 @@
-import { ScreenOverride } from '../../../../src/screens/device-code-confirmation/screen-override';
 import { Screen } from '../../../../src/models/screen';
+import { ScreenOverride } from '../../../../src/screens/device-code-confirmation/screen-override';
+
 import type { ScreenContext } from '../../../../interfaces/models/screen';
 
 describe('ScreenOverride', () => {
@@ -13,6 +14,7 @@ describe('ScreenOverride', () => {
     const screenOverride = new ScreenOverride(screenContext);
     expect(screenOverride.data).toEqual({
       textCode: "123456",
+      text_code: "123456",
     });
   });
 
@@ -33,7 +35,8 @@ describe('ScreenOverride', () => {
     } as ScreenContext;
     const screenOverride = new ScreenOverride(screenContext);
     expect(screenOverride.data).toEqual({
-      textCode: null,
+      textCode: '',
+      text_code: '',
     });
   });
 


### PR DESCRIPTION
## Description

`screen.data.textCode` now returns the code the user has to confirm. It has returned `undefined` since `0.1.0-beta.4`, leaving nothing to render on a screen whose only purpose is displaying that code.

The screen's data was read through the generic base implementation, which returns the Universal Login context untouched, so the transform mapping `text_code` onto `textCode` never ran. `confirm()` and `cancel()` are unaffected.

Fixes #383.

## Behaviour

```ts
// Universal Login context: screen.data = { text_code: 'ABC123' }

screenManager.screen.data?.textCode;
// before: undefined
// after:  'ABC123'

screenManager.screen.data?.text_code;
// before: 'ABC123'  (raw context shape)
// after:  'ABC123'  (unchanged)
```

`data` absent or `null` yields `null`; a missing or non-string `text_code` yields `''` for both keys.

## Compatibility

No breaking change. Because `textCode` was never populated, every working integration of this screen reads the raw `text_code`, so that key keeps returning the code and is now declared on `ScreenMembersOnDeviceCodeConfirmation` as `@deprecated`. Consumers should migrate to `textCode`; `text_code` will be removed in the next major.
