### PR TITLE
feat: add skipOrganizationSelection to organization-selection screen

### DIFF
--- a/packages/auth0-acul-js/examples/organization-selection.md
+++ b/packages/auth0-acul-js/examples/organization-selection.md
@@ -16,8 +16,13 @@ organizationSelection.continueWithOrganizationName({
   organizationName: 'testOrganizationName',
 });
 
-// Example of skipping the organization selection and continuing with the personal account
-organizationSelection.skipOrganizationSelection();
+// Only rendered when organization is optional (organization_usage: allow).
+// The server rejects this call if the organization is required for the transaction.
+try {
+  await organizationSelection.skipOrganizationSelection();
+} catch (error) {
+  console.error('Failed to skip organization selection:', error);
+}
 
 ## React Component Example with TailwindCSS
 

--- a/packages/auth0-acul-js/examples/organization-selection.md
+++ b/packages/auth0-acul-js/examples/organization-selection.md
@@ -16,6 +16,9 @@ organizationSelection.continueWithOrganizationName({
   organizationName: 'testOrganizationName',
 });
 
+// Example of skipping the organization selection and continuing with the personal account
+organizationSelection.skipOrganizationSelection();
+
 ## React Component Example with TailwindCSS
 
 ```jsx
@@ -36,6 +39,14 @@ const OrganizationSelectionScreen = () => {
       });
     } catch (error) {
       console.error('Organization Selection failed:', error);
+    }
+  };
+
+  const handleSkipOrganizationSelection = async () => {
+    try {
+      await organizationSelectionManager.skipOrganizationSelection();
+    } catch (error) {
+      console.error('Failed to skip organization selection:', error);
     }
   };
 
@@ -78,6 +89,17 @@ const OrganizationSelectionScreen = () => {
               </button>
             </div>
           </form>
+
+          {/* Rendered only when the organization is optional for this transaction */}
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={handleSkipOrganizationSelection}
+              className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              { `${ screen?.texts?.skipOrganizationSelectionButtonText ?? 'Continue with my personal account' }` }
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/auth0-acul-js/interfaces/screens/organization-selection.ts
+++ b/packages/auth0-acul-js/interfaces/screens/organization-selection.ts
@@ -1,3 +1,4 @@
+import type { CustomOptions } from '../common';
 import type { BaseMembers } from '../models/base-context';
 import type { ClientMembers } from '../models/client';
 import type { OrganizationMembers } from '../models/organization';
@@ -45,4 +46,9 @@ export interface OrganizationSelectionMembers extends BaseMembers {
    * @param payload The options containing the organization name.
    */
   continueWithOrganizationName(payload: ContinueWithOrganizationNameOptions): Promise<void>;
+  /**
+   * Skips the organization selection, proceeding with the user's personal account.
+   * @param payload Optional custom options to include with the request.
+   */
+  skipOrganizationSelection(payload?: CustomOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/organization-selection/index.ts
+++ b/packages/auth0-acul-js/src/screens/organization-selection/index.ts
@@ -57,6 +57,8 @@ export default class OrganizationSelection extends BaseContext implements Organi
 
   /**
    * Skips the organization selection, proceeding with the user's personal account.
+   * Only available when the client is configured with `organization_usage: allow` (B2C login enabled).
+   * The server will reject this with an error if the organization is required for the transaction.
    * @param payload Optional custom options to include with the request.
    * @example
    * ```typescript

--- a/packages/auth0-acul-js/src/screens/organization-selection/index.ts
+++ b/packages/auth0-acul-js/src/screens/organization-selection/index.ts
@@ -2,6 +2,7 @@ import { FormActions, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 
+import type { CustomOptions } from '../../../interfaces/common';
 import type { ScreenContext } from '../../../interfaces/models/screen';
 import type {
   OrganizationSelectionMembers,
@@ -50,6 +51,29 @@ export default class OrganizationSelection extends BaseContext implements Organi
     };
     await new FormHandler(options).submitData<ContinueWithOrganizationNameOptions>({
       ...payload,
+      action: FormActions.DEFAULT,
+    });
+  }
+
+  /**
+   * Skips the organization selection, proceeding with the user's personal account.
+   * @param payload Optional custom options to include with the request.
+   * @example
+   * ```typescript
+   * import OrganizationSelection from '@auth0/auth0-acul-js/organization-selection';
+   *
+   * const organizationSelection = new OrganizationSelection();
+   * await organizationSelection.skipOrganizationSelection();
+   * ```
+   */
+  async skipOrganizationSelection(payload?: CustomOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [OrganizationSelection.screenIdentifier, 'skipOrganizationSelection'],
+    };
+    await new FormHandler(options).submitData({
+      ...payload,
+      organizationSkipped: true,
       action: FormActions.DEFAULT,
     });
   }

--- a/packages/auth0-acul-js/tests/unit/screens/organization-selection/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/organization-selection/index.test.ts
@@ -1,0 +1,87 @@
+import { FormActions, ScreenIds } from '../../../../src/constants';
+import OrganizationSelection from '../../../../src/screens/organization-selection';
+import { FormHandler } from '../../../../src/utils/form-handler';
+import { baseContextData } from '../../../data/test-data';
+
+import type { CustomOptions } from 'interfaces/common';
+
+jest.mock('../../../../src/utils/form-handler');
+
+describe('OrganizationSelection', () => {
+  let organizationSelection: OrganizationSelection;
+  let mockFormHandler: { submitData: jest.Mock };
+
+  beforeEach(() => {
+    global.window = Object.create(window);
+    window.universal_login_context = {
+      ...baseContextData,
+      screen: {
+        ...baseContextData.screen,
+        name: 'organization-selection',
+      }
+    };
+    organizationSelection = new OrganizationSelection();
+    mockFormHandler = {
+      submitData: jest.fn(),
+    };
+    (FormHandler as jest.Mock).mockImplementation(() => mockFormHandler);
+  });
+
+  it('should have the correct screenIdentifier', () => {
+    expect(OrganizationSelection.screenIdentifier).toBe(ScreenIds.ORGANIZATION_SELECTION);
+  });
+
+  describe('continueWithOrganizationName method', () => {
+    it('should handle continueWithOrganizationName with valid payload correctly', async () => {
+      const payload = {
+        organizationName: 'testOrganizationName',
+      };
+      await organizationSelection.continueWithOrganizationName(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        ...payload,
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
+      const payload = {
+        organizationName: 'testOrganizationName',
+      };
+      await expect(organizationSelection.continueWithOrganizationName(payload)).rejects.toThrow('Mocked reject');
+    });
+  });
+
+  describe('skipOrganizationSelection method', () => {
+    it('should handle skipOrganizationSelection with valid payload correctly', async () => {
+      const payload: CustomOptions = {
+        someOption: 'value',
+      };
+      await organizationSelection.skipOrganizationSelection(payload);
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        ...payload,
+        organizationSkipped: true,
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should handle skipOrganizationSelection without payload correctly', async () => {
+      await organizationSelection.skipOrganizationSelection();
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith({
+        organizationSkipped: true,
+        action: FormActions.DEFAULT,
+      });
+    });
+
+    it('should throw error when promise is rejected', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('Mocked reject'));
+      const payload: CustomOptions = {
+        someOption: 'value',
+      };
+      await expect(organizationSelection.skipOrganizationSelection(payload)).rejects.toThrow('Mocked reject');
+    });
+  });
+});

--- a/packages/auth0-acul-react/src/screens/organization-selection.tsx
+++ b/packages/auth0-acul-react/src/screens/organization-selection.tsx
@@ -8,6 +8,7 @@ import { registerScreen } from '../state/instance-store';
 import type {
   OrganizationSelectionMembers,
   ContinueWithOrganizationNameOptions,
+  CustomOptions,
 } from '@auth0/auth0-acul-js/organization-selection';
 
 // Register the singleton instance of OrganizationSelection
@@ -33,6 +34,8 @@ export const {
 // Submit functions
 export const continueWithOrganizationName = (payload: ContinueWithOrganizationNameOptions) =>
   withError(instance.continueWithOrganizationName(payload));
+export const skipOrganizationSelection = (payload?: CustomOptions) =>
+  withError(instance.skipOrganizationSelection(payload));
 
 // Common hooks
 export { useCurrentScreen, useErrors, useAuth0Themes, useChangeLanguage } from '../hooks';


### PR DESCRIPTION
## Description

Adds a `skipOrganizationSelection` method to the `organization-selection` screen so users can continue with their personal account when the organization is optional for the transaction.

The method submits `organizationSkipped: true` with `action: default`, and `state` is injected by `FormHandler`. It accepts optional `CustomOptions` for any additional fields.

```ts

const organizationSelection = new OrganizationSelection();
await organizationSelection.skipOrganizationSelection();

```

```tsx
import { skipOrganizationSelection } from '@auth0/auth0-acul-react/organization-selection';

<button type="button" onClick={() => skipOrganizationSelection()}>
  Continue with my personal account
</button>
```


