### PR TITLE
feat: add skip-password on signup-password screen

### DIFF
--- a/packages/auth0-acul-js/examples/signup-password.md
+++ b/packages/auth0-acul-js/examples/signup-password.md
@@ -27,15 +27,32 @@
 ```
 
 ## skipPassword
-   Skips password creation during signup when the connection allows it.
-   `screen.data.showSkipPassword` is `true` only when the connection has **Password on signup → Allow**,
-   **Support users without a password → ON**, and the user has already verified their email or phone via OTP.
+   Skips password creation during signup and completes the account with OTP as the primary
+   authentication method.
+
+   ### When the skip is available
+
+   `screen.data.showSkipPassword` is `true` only when **all** of the following are true.
+   Otherwise it is `false`/`undefined` and the skip control must not be rendered:
+
+   | Requirement | Where it is configured |
+   | --- | --- |
+   | Flexible Identifiers enabled on the connection | Connection settings |
+   | Signups allowed on the connection | Password on signup → **Allow** (`signup_behavior = allow`) |
+   | An OTP method enabled on the connection | Email OTP or Phone (SMS) OTP |
+   | Password is optional for the connection | Support users without a password → **ON** (`api_behavior = optional`) |
+   | User completed OTP verification earlier in this signup | Decided at runtime, per session |
+
+   On skip, the account is created with no password credential; the verified identifier stays
+   `email_verified` / `phone_verified`, standard signup Actions still fire, and the user can add
+   a password later from My Account.
 
 ```typescript
     import SignupPassword from "@auth0/auth0-acul-js/signup-password";
 
     const signupPasswordManager = new SignupPassword();
 
+    // Only render your "Skip" control when the SDK reports it is available.
     if (signupPasswordManager.screen.data?.showSkipPassword) {
       await signupPasswordManager.skipPassword();
     }

--- a/packages/auth0-acul-js/examples/signup-password.md
+++ b/packages/auth0-acul-js/examples/signup-password.md
@@ -26,6 +26,21 @@
     signupPasswordManager.signup(signupParams);
 ```
 
+## skipPassword
+   Skips password creation during signup when the connection allows it.
+   `screen.data.showSkipPassword` is `true` only when the connection has **Password on signup → Allow**,
+   **Support users without a password → ON**, and the user has already verified their email or phone via OTP.
+
+```typescript
+    import SignupPassword from "@auth0/auth0-acul-js/signup-password";
+
+    const signupPasswordManager = new SignupPassword();
+
+    if (signupPasswordManager.screen.data?.showSkipPassword) {
+      await signupPasswordManager.skipPassword();
+    }
+```
+
 ## signupPassword Example using validatePassword 
 
 ```typescript

--- a/packages/auth0-acul-js/examples/signup-password.md
+++ b/packages/auth0-acul-js/examples/signup-password.md
@@ -28,7 +28,8 @@
 
 ## skipPassword
    Skips password creation during signup and completes the account with OTP as the primary
-   authentication method.
+   authentication method. This is for database connections that support passwordless signup
+   (where a password is optional) — not the standalone email/SMS Passwordless connection type.
 
    ### When the skip is available
 

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -7,7 +7,7 @@ export type { EmailChallengeOptions } from '../screens/email-identifier-challeng
 export type { PhoneChallengeOptions } from '../screens/phone-identifier-challenge';
 export type { PhoneEnrollmentOptions } from '../screens/phone-identifier-enrollment';
 export type { SignupOptions, FederatedSignupOptions } from '../screens/signup-id';
-export type { SignupPasswordOptions, FederatedSignupOptions as FederatedSignupPasswordPayloadOptions, SwitchConnectionOptions as SwitchConnectionOptionsSignupPassword } from '../screens/signup-password';
+export type { SignupPasswordOptions, FederatedSignupOptions as FederatedSignupPasswordPayloadOptions, SwitchConnectionOptions as SwitchConnectionOptionsSignupPassword, SkipPasswordOptions } from '../screens/signup-password';
 export type { LoginOptions as LoginPayloadOptions, FederatedLoginOptions as FederatedLoginPayloadOptions } from '../screens/login';
 export type { SignupOptions as SignupPayloadOptions, FederatedSignupOptions as FederatedSignupPayloadOptions } from '../screens/signup';
 export type { ResetPasswordEmailOptions } from '../screens/reset-password-email';

--- a/packages/auth0-acul-js/interfaces/screens/signup-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-password.ts
@@ -61,6 +61,7 @@ export interface SwitchConnectionOptions {
 }
 
 export interface SkipPasswordOptions {
+  captcha?: string;
   [key: string]: string | number | boolean | undefined;
 }
 

--- a/packages/auth0-acul-js/interfaces/screens/signup-password.ts
+++ b/packages/auth0-acul-js/interfaces/screens/signup-password.ts
@@ -14,6 +14,7 @@ export interface ScreenContextOnSignupPassword extends ScreenContext {
     email?: string;
     phone_number?: string;
     username?: string;
+    show_skip_password?: boolean;
   };
 }
 
@@ -33,6 +34,7 @@ export interface ScreenMembersOnSignupPassword extends ScreenMembers {
     email?: string;
     phoneNumber?: string;
     username?: string;
+    showSkipPassword?: boolean;
   } | null;
 }
 
@@ -58,11 +60,16 @@ export interface SwitchConnectionOptions {
   [key: string]: string | number | boolean;
 }
 
+export interface SkipPasswordOptions {
+  [key: string]: string | number | boolean | undefined;
+}
+
 export interface SignupPasswordMembers extends BaseMembers {
   screen: ScreenMembersOnSignupPassword;
   transaction: TransactionMembersOnSignupPassword;
   signup(payload: SignupPasswordOptions): Promise<void>;
   federatedSignup(payload: FederatedSignupOptions): Promise<void>;
   switchConnection(payload: SwitchConnectionOptions): Promise<void>;
+  skipPassword(payload?: SkipPasswordOptions): Promise<void>;
   validatePassword(password: string): PasswordValidationResult;
 }

--- a/packages/auth0-acul-js/src/constants/form-actions.ts
+++ b/packages/auth0-acul-js/src/constants/form-actions.ts
@@ -34,4 +34,5 @@ export const FormActions = {
   SWITCH_TO_PASSWORD_AUTH: 'switch-to-password-auth' as const,
   GOOGLE_ONE_TAP: 'google-one-tap' as const,
   PROCEED_TO_SIGNUP: 'proceed-to-signup' as const,
+  SKIP_PASSWORD: 'skip-password' as const,
 } as const;

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -1,4 +1,4 @@
-import { ScreenIds } from '../../constants';
+import { FormActions, ScreenIds } from '../../constants';
 import { BaseContext } from '../../models/base-context';
 import { FormHandler } from '../../utils/form-handler';
 import { validatePassword as _validatePassword, validateWithComplexityPolicy as _validateFlexiblePassword } from '../../utils/validate-password';
@@ -158,7 +158,7 @@ export default class SignupPassword extends BaseContext implements SignupPasswor
 
     await new FormHandler(options).submitData<SkipPasswordOptions>({
       ...payload,
-      action: 'skip-password',
+      action: FormActions.SKIP_PASSWORD,
     });
   }
 

--- a/packages/auth0-acul-js/src/screens/signup-password/index.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/index.ts
@@ -16,6 +16,7 @@ import type {
   SignupPasswordOptions,
   FederatedSignupOptions,
   SwitchConnectionOptions,
+  SkipPasswordOptions,
 } from '../../../interfaces/screens/signup-password';
 import type { FormOptions } from '../../../interfaces/utils/form-handler';
 import type { PasswordValidationResult } from '../../../interfaces/utils/validate-password';
@@ -136,6 +137,32 @@ export default class SignupPassword extends BaseContext implements SignupPasswor
   }
 
   /**
+   * @remarks
+   * Skips password creation during signup when the connection allows it.
+   * Only available when `screen.data.showSkipPassword` is `true`.
+   *
+   * @example
+   * import SignupPassword from "@auth0/auth0-acul-js/signup-password";
+   *
+   * const signupPasswordManager = new SignupPassword();
+   *
+   * if (signupPasswordManager.screen.data?.showSkipPassword) {
+   *   await signupPasswordManager.skipPassword();
+   * }
+   */
+  async skipPassword(payload?: SkipPasswordOptions): Promise<void> {
+    const options: FormOptions = {
+      state: this.transaction.state,
+      telemetry: [SignupPassword.screenIdentifier, 'skipPassword'],
+    };
+
+    await new FormHandler(options).submitData<SkipPasswordOptions>({
+      ...payload,
+      action: 'skip-password',
+    });
+  }
+
+  /**
   * Validates a password string against the current transaction's password policy.
   *
   * This method retrieves the password policy from the current transaction context
@@ -175,6 +202,7 @@ export {
   SignupPasswordOptions,
   FederatedSignupOptions,
   SwitchConnectionOptions,
+  SkipPasswordOptions,
   ScreenOptions as ScreenMembersOnSignupPassword,
   TransactionOptions as TransactionMembersOnSignupPassword,
 };

--- a/packages/auth0-acul-js/src/screens/signup-password/screen-override.ts
+++ b/packages/auth0-acul-js/src/screens/signup-password/screen-override.ts
@@ -22,6 +22,7 @@ export class ScreenOverride extends Screen implements OverrideOptions {
       email: data.email,
       phoneNumber: data.phone_number,
       username: data.username,
+      showSkipPassword: typeof data.show_skip_password === 'boolean' ? data.show_skip_password : undefined,
     } as OverrideOptions['data'];
   };
 }

--- a/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
@@ -3,7 +3,7 @@ import SignupPassword from '../../../../src/screens/signup-password';
 import { FormHandler } from '../../../../src/utils/form-handler';
 import { baseContextData } from '../../../data/test-data';
 
-import type { SignupPasswordOptions, FederatedSignupOptions } from 'interfaces/screens/signup-password';
+import type { SignupPasswordOptions, FederatedSignupOptions, SkipPasswordOptions } from 'interfaces/screens/signup-password';
 
 jest.mock('../../../../src/utils/form-handler');
 
@@ -118,6 +118,42 @@ describe('SignupPassword', () => {
       await expect(signupPassword.signup(payload)).rejects.toThrow(
         'Invalid phone number format'
       );
+    });
+  });
+
+  describe('skipPassword method', () => {
+    it('should submit action=skip-password', async () => {
+      await signupPassword.skipPassword();
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'skip-password' })
+      );
+    });
+
+    it('should merge extra payload with action=skip-password', async () => {
+      const payload: SkipPasswordOptions = { captcha: 'token' };
+      await signupPassword.skipPassword(payload);
+
+      expect(mockFormHandler.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'skip-password', captcha: 'token' })
+      );
+    });
+
+    it('should use correct telemetry', async () => {
+      await signupPassword.skipPassword();
+
+      expect(FormHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          telemetry: [ScreenIds.SIGNUP_PASSWORD, 'skipPassword'],
+        })
+      );
+    });
+
+    it('should throw when FormHandler rejects', async () => {
+      mockFormHandler.submitData.mockRejectedValue(new Error('skip failed'));
+
+      await expect(signupPassword.skipPassword()).rejects.toThrow('skip failed');
     });
   });
 

--- a/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-password/index.test.ts
@@ -1,4 +1,4 @@
-import { ScreenIds } from '../../../../src/constants';
+import { FormActions, ScreenIds } from '../../../../src/constants';
 import SignupPassword from '../../../../src/screens/signup-password';
 import { FormHandler } from '../../../../src/utils/form-handler';
 import { baseContextData } from '../../../data/test-data';
@@ -127,7 +127,7 @@ describe('SignupPassword', () => {
 
       expect(mockFormHandler.submitData).toHaveBeenCalledTimes(1);
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'skip-password' })
+        expect.objectContaining({ action: FormActions.SKIP_PASSWORD })
       );
     });
 
@@ -136,7 +136,7 @@ describe('SignupPassword', () => {
       await signupPassword.skipPassword(payload);
 
       expect(mockFormHandler.submitData).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'skip-password', captcha: 'token' })
+        expect.objectContaining({ action: FormActions.SKIP_PASSWORD, captcha: 'token' })
       );
     });
 

--- a/packages/auth0-acul-js/tests/unit/screens/signup-password/screen-override.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/signup-password/screen-override.test.ts
@@ -40,7 +40,8 @@ describe('ScreenOverride', () => {
     expect(screenOverride.data).toEqual({
       email: 'test@example.com',
       phoneNumber: '+1234567890',
-      username: 'testuser'
+      username: 'testuser',
+      showSkipPassword: undefined,
     });
   });
 
@@ -58,7 +59,8 @@ describe('ScreenOverride', () => {
       expect(result).toEqual({
         email: 'test@example.com',
         phoneNumber: '+1234567890',
-        username: 'testuser'
+        username: 'testuser',
+        showSkipPassword: undefined,
       });
     });
 
@@ -80,13 +82,44 @@ describe('ScreenOverride', () => {
           username: 'testuser'
         }
       } as ScreenContextOnSignupPassword;
-      
+
       const result = ScreenOverride.getScreenData(contextWithoutPhone);
       expect(result).toEqual({
         email: 'test@example.com',
         phoneNumber: undefined,
-        username: 'testuser'
+        username: 'testuser',
+        showSkipPassword: undefined,
       });
+    });
+
+    it('should set showSkipPassword to true when show_skip_password is true', () => {
+      const context = {
+        ...screenContext,
+        data: { email: 'test@example.com', show_skip_password: true },
+      } as ScreenContextOnSignupPassword;
+
+      const result = ScreenOverride.getScreenData(context);
+      expect(result?.showSkipPassword).toBe(true);
+    });
+
+    it('should set showSkipPassword to false when show_skip_password is false', () => {
+      const context = {
+        ...screenContext,
+        data: { email: 'test@example.com', show_skip_password: false },
+      } as ScreenContextOnSignupPassword;
+
+      const result = ScreenOverride.getScreenData(context);
+      expect(result?.showSkipPassword).toBe(false);
+    });
+
+    it('should set showSkipPassword to undefined when show_skip_password is absent', () => {
+      const context = {
+        ...screenContext,
+        data: { email: 'test@example.com' },
+      } as ScreenContextOnSignupPassword;
+
+      const result = ScreenOverride.getScreenData(context);
+      expect(result?.showSkipPassword).toBeUndefined();
     });
   });
 

--- a/packages/auth0-acul-react/examples/signup-password.md
+++ b/packages/auth0-acul-react/examples/signup-password.md
@@ -275,6 +275,8 @@ export default SignupPasswordScreen;
     *   The core SDK will handle the API request and subsequent redirection on success.
     *   Errors are caught and can be displayed to the user.
 5.  **Skip password** (`skipPassword` + `screen.data?.showSkipPassword`):
+    *   For database connections that support passwordless signup (where a password is
+        optional) — not the standalone email/SMS Passwordless connection type.
     *   `showSkipPassword` is `true` only when the connection has Flexible Identifiers enabled,
         Password on signup → **Allow** (`signup_behavior = allow`), an OTP method enabled
         (Email or Phone/SMS OTP), Support users without a password → **ON**

--- a/packages/auth0-acul-react/examples/signup-password.md
+++ b/packages/auth0-acul-react/examples/signup-password.md
@@ -274,6 +274,14 @@ export default SignupPasswordScreen;
     *   You must replace the empty `payload` object with the actual data from your form inputs.
     *   The core SDK will handle the API request and subsequent redirection on success.
     *   Errors are caught and can be displayed to the user.
+5.  **Skip password** (`skipPassword` + `screen.data?.showSkipPassword`):
+    *   `showSkipPassword` is `true` only when the connection has Flexible Identifiers enabled,
+        Password on signup → **Allow** (`signup_behavior = allow`), an OTP method enabled
+        (Email or Phone/SMS OTP), Support users without a password → **ON**
+        (`api_behavior = optional`), and the user completed OTP verification earlier in this
+        signup. Only render the Skip control when it is `true`.
+    *   Calling `skipPassword()` creates the account with OTP as the primary method and no
+        password credential; the user can add one later from My Account.
 
 
 ### Examaple using utility hooks - usePasswordValidation, useErrors

--- a/packages/auth0-acul-react/examples/signup-password.md
+++ b/packages/auth0-acul-react/examples/signup-password.md
@@ -286,7 +286,7 @@ export default SignupPasswordScreen;
         password credential; the user can add one later from My Account.
 
 
-### Examaple using utility hooks - usePasswordValidation, useErrors
+### Example using utility hooks - usePasswordValidation, useErrors
 
 ``` tsx
 import React, { useState } from 'react';

--- a/packages/auth0-acul-react/examples/signup-password.md
+++ b/packages/auth0-acul-react/examples/signup-password.md
@@ -19,6 +19,7 @@ import {
     useTransaction,
     // Submit functions
     signup as signupMethod,
+    skipPassword as skipPasswordMethod,
     usePasswordValidation,
     // Common hooks
     useErrors
@@ -221,6 +222,17 @@ const SignupPasswordScreen: React.FC = () => {
                     >
                         Sign Up
                     </button>
+
+                    {/* Skip password — only rendered when the connection allows it and OTP is verified */}
+                    {screen.data?.showSkipPassword && (
+                        <button
+                            type="button"
+                            onClick={() => skipPasswordMethod()}
+                            className="w-full flex justify-center py-2 px-4 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+                        >
+                            Skip for now
+                        </button>
+                    )}
                 </form>
 
                 {/* Server-side / global errors */}
@@ -275,6 +287,7 @@ import {
     useTransaction,
     // Submit functions
     signup as signupMethod,
+    skipPassword as skipPasswordMethod,
     usePasswordValidation,
     // Common hooks
     useErrors
@@ -477,6 +490,17 @@ const SignupPasswordScreen: React.FC = () => {
                     >
                         Sign Up
                     </button>
+
+                    {/* Skip password — only rendered when the connection allows it and OTP is verified */}
+                    {screen.data?.showSkipPassword && (
+                        <button
+                            type="button"
+                            onClick={() => skipPasswordMethod()}
+                            className="w-full flex justify-center py-2 px-4 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+                        >
+                            Skip for now
+                        </button>
+                    )}
                 </form>
 
                 {/* Server-side / global errors */}

--- a/packages/auth0-acul-react/src/screens/signup-password.tsx
+++ b/packages/auth0-acul-react/src/screens/signup-password.tsx
@@ -10,6 +10,7 @@ import type {
   SignupPasswordOptions,
   FederatedSignupOptions,
   SwitchConnectionOptions,
+  SkipPasswordOptions,
 } from '@auth0/auth0-acul-js/signup-password';
 
 // Register the singleton instance of SignupPassword
@@ -38,6 +39,8 @@ export const federatedSignup = (payload: FederatedSignupOptions) =>
   withError(instance.federatedSignup(payload));
 export const switchConnection = (payload: SwitchConnectionOptions) =>
   withError(instance.switchConnection(payload));
+export const skipPassword = (payload?: SkipPasswordOptions) =>
+  withError(instance.skipPassword(payload));
 
 // Utility Hooks
 export { usePasswordValidation } from '../hooks/utility/validate-password';

--- a/packages/auth0-acul-react/tests/screens/signup-password.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/signup-password.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import SignupPassword from '@auth0/auth0-acul-js/signup-password';
 import * as SignupPasswordScreen from '../../src/screens/signup-password';
 import { categorizeScreenExports } from './test-helpers';
 
@@ -14,6 +15,9 @@ jest.mock('@auth0/auth0-acul-js', () => ({
 // Mock the core SDK class
 jest.mock('@auth0/auth0-acul-js/signup-password', () => {
   return jest.fn().mockImplementation(() => ({
+    signup: jest.fn(() => Promise.resolve()),
+    federatedSignup: jest.fn(() => Promise.resolve()),
+    switchConnection: jest.fn(() => Promise.resolve()),
     skipPassword: jest.fn(() => Promise.resolve()),
   }));
 }, { virtual: true });
@@ -49,6 +53,8 @@ jest.mock('../../src/hooks/utility/validate-password', () => ({
 }));
 
 describe('SignupPassword Screen', () => {
+  const instance = (SignupPassword as any).mock.results[0].value;
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -157,14 +163,18 @@ describe('SignupPassword Screen', () => {
     });
 
     it('should call instance.skipPassword with no payload', () => {
-      const result = SignupPasswordScreen.skipPassword();
-      expect(result).toBeDefined();
+      SignupPasswordScreen.skipPassword();
+
+      expect(instance.skipPassword).toHaveBeenCalledTimes(1);
+      expect(instance.skipPassword).toHaveBeenCalledWith(undefined);
     });
 
     it('should call instance.skipPassword with the provided payload', () => {
       const payload = { captcha: 'token' };
-      const result = SignupPasswordScreen.skipPassword(payload);
-      expect(result).toBeDefined();
+      SignupPasswordScreen.skipPassword(payload);
+
+      expect(instance.skipPassword).toHaveBeenCalledTimes(1);
+      expect(instance.skipPassword).toHaveBeenCalledWith(payload);
     });
   });
 });

--- a/packages/auth0-acul-react/tests/screens/signup-password.test.tsx
+++ b/packages/auth0-acul-react/tests/screens/signup-password.test.tsx
@@ -13,7 +13,9 @@ jest.mock('@auth0/auth0-acul-js', () => ({
 
 // Mock the core SDK class
 jest.mock('@auth0/auth0-acul-js/signup-password', () => {
-  return jest.fn().mockImplementation(() => {});
+  return jest.fn().mockImplementation(() => ({
+    skipPassword: jest.fn(() => Promise.resolve()),
+  }));
 }, { virtual: true });
 
 // Mock the instance store
@@ -146,6 +148,23 @@ describe('SignupPassword Screen', () => {
           // Function may require specific parameters
         }
       });
+    });
+  });
+
+  describe('skipPassword', () => {
+    it('should export skipPassword as a function', () => {
+      expect(typeof SignupPasswordScreen.skipPassword).toBe('function');
+    });
+
+    it('should call instance.skipPassword with no payload', () => {
+      const result = SignupPasswordScreen.skipPassword();
+      expect(result).toBeDefined();
+    });
+
+    it('should call instance.skipPassword with the provided payload', () => {
+      const payload = { captcha: 'token' };
+      const result = SignupPasswordScreen.skipPassword(payload);
+      expect(result).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds `showSkipPassword` data field and `skipPassword()` action to the `signup-password` screen, allowing custom UIs to let users complete signup without setting a password when the connection permits it.

`screen.data.showSkipPassword` is `true` only when the connection has **Password on signup → Allow**, **Support users without a password → ON**, and the user has already verified their email or phone via OTP earlier in the signup flow. Otherwise it is `false` and the skip button should not be shown.

---

## Manual Testing

### Prerequisites

1. Database connection: **Password on signup → Allow**, **Support users without a password → ON**, and Email or Phone OTP method enabled
2. Signup flow is configured to verify the identifier via OTP **before** reaching the signup-password screen

---

### JS SDK

```js
import SignupPassword from '@auth0/auth0-acul-js/signup-password';

const signupPasswordManager = new SignupPassword();

console.log(signupPasswordManager.screen.data?.showSkipPassword);
// → true  (connection allows skip + OTP verified)
// → false (skip not allowed)

if (signupPasswordManager.screen.data?.showSkipPassword) {
  await signupPasswordManager.skipPassword();
}

// Normal signup is unchanged
await signupPasswordManager.signup({ email: 'user@example.com', password: 'S3cur3!' });
```

**Verify:**
- [ ] `showSkipPassword` is `true` when connection allows skip and OTP is verified
- [ ] `showSkipPassword` is `false` when skip is not allowed
- [ ] `skipPassword()` advances the flow without requiring a password
- [ ] `signup()` still works with no regression

---

### React

```tsx
import {
  useScreen,
  skipPassword,
} from '@auth0/auth0-acul-react/signup-password';

function SignupPasswordScreen() {
  const screen = useScreen();

  return (
    <form onSubmit={/* normal signup */}>
      {/* ... existing fields ... */}

      <button type="submit">Sign Up</button>

      {screen.data?.showSkipPassword && (
        <button type="button" onClick={() => skipPassword()}>
          Skip for now
        </button>
      )}
    </form>
  );
}
```

**Verify:**
- [ ] Skip button is **not visible** when `showSkipPassword` is `false` or `undefined`
- [ ] Skip button **is visible** when `showSkipPassword` is `true`
- [ ] Clicking Skip advances the user through the flow without a password being set
- [ ] Normal Sign Up submit is unaffected
