### PR TITLE
fix branding context data

### DIFF
--- a/packages/auth0-acul-js/src/models/organization.ts
+++ b/packages/auth0-acul-js/src/models/organization.ts
@@ -1,3 +1,5 @@
+import { toCamelCased } from '../utils/to-camel-cased';
+
 import type { OrganizationContext, OrganizationMembers } from '../../interfaces/models/organization';
 
 /**
@@ -33,7 +35,7 @@ export class Organization implements OrganizationMembers {
     this.name = organization?.name ?? null;
     this.usage = organization?.usage ?? null;
     this.displayName = organization?.display_name ?? null;
-    this.branding = organization?.branding ?? null;
+    this.branding = organization?.branding ? toCamelCased(organization.branding) : null;
     this.metadata = organization?.metadata ?? null;
   }
 }

--- a/packages/auth0-acul-js/src/utils/to-camel-cased.ts
+++ b/packages/auth0-acul-js/src/utils/to-camel-cased.ts
@@ -1,0 +1,14 @@
+type GenericObject = Record<string, unknown>;
+
+function isKeyedObject(value: unknown): value is GenericObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function toCamelCased(obj: GenericObject): GenericObject {
+  const result: GenericObject = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const newKey = key.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+    result[newKey] = isKeyedObject(value) ? toCamelCased(value) : value;
+  }
+  return result;
+}

--- a/packages/auth0-acul-js/tests/unit/utils/to-camel-cased.test.ts
+++ b/packages/auth0-acul-js/tests/unit/utils/to-camel-cased.test.ts
@@ -1,0 +1,21 @@
+import { toCamelCased } from '../../../src/utils/to-camel-cased';
+
+describe('toCamelCased', () => {
+  it('should convert snake_case keys to camelCase', () => {
+    const input = {
+      first_name: 'John',
+      last_name: 'Doe',
+      nested_object: {
+        inner_key: 'value'
+      }
+    };
+    const expected = {
+      firstName: 'John',
+      lastName: 'Doe',
+      nestedObject: {
+        innerKey: 'value'
+      }
+    };
+    expect(toCamelCased(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
### Description

The `organization.branding` context wasn't being converted to camel-casing, as the typing suggests.

### References

https://github.com/auth0/universal-login/issues/392

### Testing

Access any of the screens and reference `organization.branding` to see that it's camel-cased.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
