### PR TITLE
feat: add tryAnotherMethod to MfaWebAuthnPlatformEnrollment

### DIFF
--- a/packages/auth0-acul-js/examples/mfa-webauthn-platform-enrollment.md
+++ b/packages/auth0-acul-js/examples/mfa-webauthn-platform-enrollment.md
@@ -12,6 +12,7 @@ Available actions:
 -   **Report Browser Error**: Sends details of a browser-side WebAuthn error to Auth0.
 -   **Snooze Enrollment**: Allows the user to postpone enrollment.
 -   **Refuse Enrollment on This Device**: Allows the user to decline enrollment on the current device.
+-   **Try Another Method**: Navigates the user to the MFA factor picker screen.
 
 ## React Component Example with TailwindCSS
 
@@ -37,6 +38,10 @@ const MfaWebAuthnPlatformEnrollmentScreen: React.FC = () => {
 
   const handleRefuse = () => {
     sdk.refuseEnrollmentOnThisDevice();
+  };
+
+  const handleTryAnotherMethod = () => {
+    sdk.tryAnotherMethod();
   };
   
   return (
@@ -81,6 +86,13 @@ const MfaWebAuthnPlatformEnrollmentScreen: React.FC = () => {
             className="w-full flex justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
           >
             {texts.refuseEnrollmentButtonText ?? 'Not on This Device'}
+          </button>
+
+          <button
+            onClick={handleTryAnotherMethod}
+            className="w-full flex justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+          >
+            {texts.pickAuthenticatorText ?? 'Try Another Method'}
           </button>
         </div>
       </div>
@@ -187,4 +199,10 @@ await sdk.snoozeEnrollment();
 ```typescript
 // ... (sdk initialization)
 await sdk.refuseEnrollmentOnThisDevice();
+```
+
+### Try Another Method
+```typescript
+// ... (sdk initialization)
+await sdk.tryAnotherMethod();
 ```

--- a/packages/auth0-acul-js/interfaces/export/options.ts
+++ b/packages/auth0-acul-js/interfaces/export/options.ts
@@ -58,7 +58,7 @@ export type {
 export type { ContinueOptions as MfaRecoveryCodeChallengeNewCodeContinueOptions } from '../screens/mfa-recovery-code-challenge-new-code';
 export type { ConfirmLogoutOptions } from '../screens/logout';
 export type { ContinueWithCodeOptions as ContinueWithCodeOptionPayload, ResendCodeOptions as ResendCodeOptionsPayload } from '../screens/login-email-verification';
-export type { SubmitPasskeyCredentialOptions, ReportBrowserErrorOptions } from '../screens/mfa-webauthn-platform-enrollment';
+export type { SubmitPasskeyCredentialOptions, ReportBrowserErrorOptions, TryAnotherMethodOptions as MfaWebAuthnPlatformEnrollmentTryAnotherMethodOptions } from '../screens/mfa-webauthn-platform-enrollment';
 export type { ShowErrorOptions, TryAnotherMethodOptions as MfaWebAuthnRoamingEnrollmentTryAnotherMethodOptions } from '../screens/mfa-webauthn-roaming-enrollment';
 export type { VerifySecurityKeyOptions, ReportWebAuthnErrorOptions as MfaWebAuthnRoamingChallengeReportErrorOptions, TryAnotherMethodOptions as MfaWebAuthnRoamingChallengeTryAnotherMethodOptions } from '../screens/mfa-webauthn-roaming-challenge';
 export type { VerifyPlatformAuthenticatorOptions, ReportBrowserErrorOptions as MfaWebAuthnPlatformChallengeReportErrorOptions, TryAnotherMethodOptions as MfaWebAuthnPlatformChallengeTryAnotherMethodOptions } from '../screens/mfa-webauthn-platform-challenge';

--- a/packages/auth0-acul-js/interfaces/screens/mfa-webauthn-platform-enrollment.ts
+++ b/packages/auth0-acul-js/interfaces/screens/mfa-webauthn-platform-enrollment.ts
@@ -47,6 +47,15 @@ export interface ReportBrowserErrorOptions {
 }
 
 /**
+ * @interface TryAnotherMethodOptions
+ * @extends CustomOptions
+ * description Defines the options for the `tryAnotherMethod` method.
+ * Currently, it only supports `CustomOptions` for extensibility if any custom parameters
+ * need to be sent with the 'pick-authenticator' action.
+ */
+export interface TryAnotherMethodOptions extends CustomOptions { }
+
+/**
  * @interface MfaWebAuthnPlatformEnrollmentMembers
  * @extends BaseMembers
  * description Defines the members (properties and methods) for interacting with the MFA WebAuthn Platform Enrollment screen.
@@ -138,4 +147,20 @@ export interface MfaWebAuthnPlatformEnrollmentMembers extends BaseMembers {
    * ```
    */
   refuseEnrollmentOnThisDevice(payload?: CustomOptions): Promise<void>;
+
+  /**
+   * Allows the user to opt-out of the WebAuthn platform enrollment and select a different MFA method.
+   * This action submits `action: "pick-authenticator"` to Auth0, which should navigate
+   * the user to an MFA factor selection screen.
+   *
+   * @param {TryAnotherMethodOptions} [payload] - Optional custom parameters to be sent with the request.
+   * @returns {Promise<void>} A promise that resolves when the 'pick-authenticator' action is submitted.
+   * @throws {Error} Throws an error if the submission fails.
+   * @example
+   * ```typescript
+   * // Assuming 'sdk' is an instance of MfaWebAuthnPlatformEnrollment
+   * await sdk.tryAnotherMethod();
+   * ```
+   */
+  tryAnotherMethod(payload?: TryAnotherMethodOptions): Promise<void>;
 }

--- a/packages/auth0-acul-js/src/screens/mfa-webauthn-platform-enrollment/index.ts
+++ b/packages/auth0-acul-js/src/screens/mfa-webauthn-platform-enrollment/index.ts
@@ -12,6 +12,7 @@ import type {
   ScreenMembersOnMfaWebAuthnPlatformEnrollment as ScreenOptions,
   SubmitPasskeyCredentialOptions, // Though this interface will now be just CustomOptions effectively
   ReportBrowserErrorOptions,
+  TryAnotherMethodOptions,
 } from '../../../interfaces/screens/mfa-webauthn-platform-enrollment';
 import type { FormOptions as SDKFormOptions } from '../../../interfaces/utils/form-handler';
 
@@ -147,6 +148,26 @@ export default class MfaWebAuthnPlatformEnrollment extends BaseContext implement
       action: FormActions.REFUSE_ADD_DEVICE,
     });
   }
+
+  /**
+   * Allows the user to opt-out of the WebAuthn platform enrollment and select a different MFA method.
+   * This action submits `action: "pick-authenticator"` to Auth0, which should navigate
+   * the user to an MFA factor selection screen.
+   *
+   * @param {TryAnotherMethodOptions} [payload] - Optional custom parameters to be sent with the request.
+   * @returns {Promise<void>} A promise that resolves when the 'pick-authenticator' action is submitted.
+   * @throws {Error} Throws an error if the form submission fails (e.g., network error, invalid state).
+   */
+  async tryAnotherMethod(payload?: TryAnotherMethodOptions): Promise<void> {
+    const formOptions: SDKFormOptions = {
+      state: this.transaction.state,
+      telemetry: [MfaWebAuthnPlatformEnrollment.screenIdentifier, 'tryAnotherMethod'],
+    };
+    await new FormHandler(formOptions).submitData({
+      ...(payload || {}),
+      action: FormActions.PICK_AUTHENTICATOR,
+    });
+  }
 }
 
 export {
@@ -154,6 +175,7 @@ export {
   ScreenOptions as ScreenMembersOnMfaWebAuthnPlatformEnrollment,
   SubmitPasskeyCredentialOptions,
   ReportBrowserErrorOptions,
+  TryAnotherMethodOptions,
 };
 export * from '../../../interfaces/export/common';
 export * from '../../../interfaces/export/base-properties';

--- a/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-platform-enrollment/index.test.ts
+++ b/packages/auth0-acul-js/tests/unit/screens/mfa-webauthn-platform-enrollment/index.test.ts
@@ -7,7 +7,7 @@ import { baseContextData } from '../../../data/test-data';
 
 import type { CustomOptions } from '../../../../interfaces/common';
 import type { PasskeyCreate } from '../../../../interfaces/models/screen';
-import type { ReportBrowserErrorOptions } from '../../../../interfaces/screens/mfa-webauthn-platform-enrollment';
+import type { ReportBrowserErrorOptions, TryAnotherMethodOptions } from '../../../../interfaces/screens/mfa-webauthn-platform-enrollment';
 import type { PasskeyCreateResponse } from '../../../../interfaces/utils/passkeys';
 
 
@@ -171,6 +171,43 @@ describe('MfaWebAuthnPlatformEnrollment', () => {
       expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
         action: FormActions.REFUSE_ADD_DEVICE,
       });
+    });
+  });
+
+  describe('tryAnotherMethod', () => {
+    it('should call FormHandler with pick-authenticator action', async () => {
+      const options: TryAnotherMethodOptions = {};
+      await sdk.tryAnotherMethod(options);
+      expect(FormHandler).toHaveBeenCalledWith({
+        state: mockTransactionState,
+        telemetry: [ScreenIds.MFA_WEBAUTHN_PLATFORM_ENROLLMENT, 'tryAnotherMethod'],
+      });
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        action: FormActions.PICK_AUTHENTICATOR,
+      });
+    });
+
+    it('should include custom options in the payload', async () => {
+      const options: TryAnotherMethodOptions = { customField: 'anotherValue' };
+      await sdk.tryAnotherMethod(options);
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customField: 'anotherValue',
+          action: FormActions.PICK_AUTHENTICATOR,
+        }),
+      );
+    });
+
+    it('should call FormHandler with pick-authenticator action without payload', async () => {
+      await sdk.tryAnotherMethod();
+      expect(mockFormHandlerInstance.submitData).toHaveBeenCalledWith({
+        action: FormActions.PICK_AUTHENTICATOR,
+      });
+    });
+
+    it('should propagate errors from FormHandler', async () => {
+      mockFormHandlerInstance.submitData.mockRejectedValue(new Error('Mocked reject'));
+      await expect(sdk.tryAnotherMethod()).rejects.toThrow('Mocked reject');
     });
   });
 });

--- a/packages/auth0-acul-react/examples/mfa-webauthn-platform-enrollment.md
+++ b/packages/auth0-acul-react/examples/mfa-webauthn-platform-enrollment.md
@@ -18,6 +18,7 @@ import {
   submitPasskeyCredential,
   snoozeEnrollment,
   refuseEnrollmentOnThisDevice,
+  tryAnotherMethod,
   useErrors
 } from '@auth0/auth0-acul-react/mfa-webauthn-platform-enrollment';
 import { Logo } from '../../components/Logo';
@@ -41,6 +42,10 @@ const MfaWebAuthnPlatformEnrollmentScreen: React.FC = () => {
 
   const handleRefuse = () => {
     refuseEnrollmentOnThisDevice();
+  };
+
+  const handleTryAnotherMethod = () => {
+    tryAnotherMethod();
   };
 
   return (
@@ -85,6 +90,13 @@ const MfaWebAuthnPlatformEnrollmentScreen: React.FC = () => {
             className="w-full py-2 px-4 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
           >
             {texts.refuseEnrollmentButtonText ?? 'Not on This Device'}
+          </button>
+
+          <button
+            onClick={handleTryAnotherMethod}
+            className="w-full py-2 px-4 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            {texts.pickAuthenticatorText ?? 'Try Another Method'}
           </button>
         </div>
 

--- a/packages/auth0-acul-react/src/screens/mfa-webauthn-platform-enrollment.tsx
+++ b/packages/auth0-acul-react/src/screens/mfa-webauthn-platform-enrollment.tsx
@@ -10,6 +10,7 @@ import type {
   SubmitPasskeyCredentialOptions,
   ReportBrowserErrorOptions,
   CustomOptions,
+  TryAnotherMethodOptions,
 } from '@auth0/auth0-acul-js/mfa-webauthn-platform-enrollment';
 
 // Register the singleton instance of MfaWebAuthnPlatformEnrollment
@@ -43,6 +44,8 @@ export const snoozeEnrollment = (payload?: CustomOptions) =>
   withError(instance.snoozeEnrollment(payload));
 export const refuseEnrollmentOnThisDevice = (payload?: CustomOptions) =>
   withError(instance.refuseEnrollmentOnThisDevice(payload));
+export const tryAnotherMethod = (payload?: TryAnotherMethodOptions) =>
+  withError(instance.tryAnotherMethod(payload));
 
 // Common hooks
 export { useCurrentScreen, useErrors, useAuth0Themes, useChangeLanguage } from '../hooks';


### PR DESCRIPTION
## Description

Adds the missing `tryAnotherMethod` action to the `MfaWebAuthnPlatformEnrollment` screen, allowing users to navigate to the MFA factor picker from the platform enrollment screen.

The method submits `action: "pick-authenticator"` via `FormHandler` with the transaction `state` field automatically included.

Fixes #361

```ts
const sdk = new MfaWebAuthnPlatformEnrollment();

// navigate user to the factor selection screen
await sdk.tryAnotherMethod();
```

```tsx
import { tryAnotherMethod } from '@auth0/auth0-acul-react/mfa-webauthn-platform-enrollment';

<button type="button" onClick={() => tryAnotherMethod()}>
  Try another method
</button>
```


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
